### PR TITLE
Freeze xgboost requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ConfigArgParse
 liac-arff
 pandas
 Cython
-xgboost
+xgboost==0.4a30
 
 ConfigSpace
 pynisher>=0.4


### PR DESCRIPTION
Without this, pip would fail to choose version during installation. I guess xgboost doesn't use semantic versioning atm.