### PR TITLE
Change `cat` to `curl` in installation directions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -56,7 +56,7 @@ Please install all dependencies manually with:
 
 .. code:: bash
 
-    cat https://raw.githubusercontent.com/automl/auto-sklearn/master/requirements.txt | xargs -n 1 -L 1 pip install
+    curl https://raw.githubusercontent.com/automl/auto-sklearn/master/requirements.txt | xargs -n 1 -L 1 pip install
 
 Then install *auto-sklearn*
 


### PR DESCRIPTION
`cat` isn't the appropriate command for this step, `curl` works great though