### PR TITLE
Fix the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 doc:
-    cd ./doc
-    make html
-    cd ..
+	cd ./doc
+	make html
+	cd ..
 
 test-code: in
-    $(NOSETESTS) -s -v tests
+	$(NOSETESTS) -s -v tests
 test-doc:
 	$(NOSETESTS) -s -v doc/*.rst
 

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ doc:
 	cd ..
 
 test-code: in
-	$(NOSETESTS) -s -v tests
+	$(NOSETESTS) -s -v test
 test-doc:
 	$(NOSETESTS) -s -v doc/*.rst
 
 test-coverage:
 	rm -rf coverage .coverage
-	$(NOSETESTS) -s -v --with-coverage tests
+	$(NOSETESTS) -s -v --with-coverage test
 
 test: test-code test-sphinxext test-doc


### PR DESCRIPTION
Doing a 
```bash
$ make all
````
raises a missing separator error in lines 19 and 24. Then, doing

```bash
$ cat -etv Makefile
```
reveals that those lines have spaces, not tabs. (http://stackoverflow.com/questions/16931770/makefile4-missing-separator-stop)

This PR fixes that by introducing literal tabs.