### PR TITLE
Add Dockerfiles for current Github versions

### DIFF
--- a/Dockerfile_devel
+++ b/Dockerfile_devel
@@ -1,0 +1,18 @@
+FROM ubuntu
+
+# System requirements
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  curl \
+  python3-pip \
+  swig \
+  && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip then install dependencies
+RUN pip3 install --upgrade pip
+RUN pip3 install git+https://github.com/automl/auto-sklearn@development
+
+# Install
+RUN pip3 install \
+  auto-sklearn \
+  jupyter

--- a/Dockerfile_devel
+++ b/Dockerfile_devel
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y \
 
 # Upgrade pip then install dependencies
 RUN pip3 install --upgrade pip
-RUN pip3 install git+https://github.com/automl/auto-sklearn@development
+RUN curl https://raw.githubusercontent.com/automl/auto-sklearn/development/requirements.txt \
+  | xargs -n 1 -L 1 pip3 install
 
 # Install
-RUN pip3 install \
-  auto-sklearn \
-  jupyter
+RUN pip3 install git+https://github.com/automl/auto-sklearn@development
+RUN pip3 install jupyter

--- a/Dockerfile_devel
+++ b/Dockerfile_devel
@@ -4,6 +4,7 @@ FROM ubuntu
 RUN apt-get update && apt-get install -y \
   build-essential \
   curl \
+  git \
   python3-pip \
   swig \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile_github
+++ b/Dockerfile_github
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y \
 
 # Upgrade pip then install dependencies
 RUN pip3 install --upgrade pip
-RUN pip3 install git+https://github.com/automl/auto-sklearn
+RUN curl https://raw.githubusercontent.com/automl/auto-sklearn/master/requirements.txt \
+  | xargs -n 1 -L 1 pip3 install
 
 # Install
-RUN pip3 install \
-  auto-sklearn \
-  jupyter
+RUN pip3 install git+https://github.com/automl/auto-sklearn
+RUN pip3 install jupyter

--- a/Dockerfile_github
+++ b/Dockerfile_github
@@ -1,0 +1,18 @@
+FROM ubuntu
+
+# System requirements
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  curl \
+  python3-pip \
+  swig \
+  && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip then install dependencies
+RUN pip3 install --upgrade pip
+RUN pip3 install git+https://github.com/automl/auto-sklearn
+
+# Install
+RUN pip3 install \
+  auto-sklearn \
+  jupyter

--- a/Dockerfile_github
+++ b/Dockerfile_github
@@ -4,6 +4,7 @@ FROM ubuntu
 RUN apt-get update && apt-get install -y \
   build-essential \
   curl \
+  git \
   python3-pip \
   swig \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
Each of the two added Dockerfiles would build a Docker image with the current version of auto-sklearn from Github: one from the master branch, and the other from the development branch.

Specifically, the file 'Dockerfile_github' will install with:
```
pip install git+https://github.com/automl/auto-sklearn
```
and the file 'Dockerfile_devel' will install with:
```
pip install git+https://github.com/automl/auto-sklearn@development
```
(See https://github.com/automl/auto-sklearn/pull/285#issuecomment-304041041.)
The Docker images were all [built successfully](https://hub.docker.com/r/felixleung/auto-sklearn/builds/).

## Other notes
The resulting Docker images could then be pulled with e.g.:
```
$ docker pull automl/auto-sklearn:github     # To install from master
$ docker pull automl/auto-sklearn:devel      # To install from development
```
The default, i.e. `docker pull automl/auto-sklearn`, would pull the image with the 'latest' tag, which is built with the file 'Dockerfile', added by #285.

FYI, the three Dockerfiles have the following settings (on my Docker Hub):
![docker_build_settings](https://cloud.githubusercontent.com/assets/5020729/26482361/5e2feb86-422a-11e7-982d-4e5791b87956.png)

## Suggestions needed
Would you like to change the file name of any of the Dockerfiles, to match the Docker tag names you may have in mind? Of course, the tags could always be changed on Docker Hub.
