### PR TITLE
Fix#266

### DIFF
--- a/autosklearn/pipeline/components/classification/qda.py
+++ b/autosklearn/pipeline/components/classification/qda.py
@@ -18,7 +18,8 @@ class QDA(AutoSklearnClassificationAlgorithm):
     def fit(self, X, Y):
         import sklearn.discriminant_analysis
 
-        estimator = sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis(self.reg_param)
+        estimator = sklearn.discriminant_analysis.\
+            QuadraticDiscriminantAnalysis(reg_param=self.reg_param)
 
         if len(Y.shape) == 2 and Y.shape[1] > 1:
             self.estimator = sklearn.multiclass.OneVsRestClassifier(estimator, n_jobs=1)
@@ -68,8 +69,8 @@ class QDA(AutoSklearnClassificationAlgorithm):
 
     @staticmethod
     def get_hyperparameter_search_space(dataset_properties=None):
-        reg_param = UniformFloatHyperparameter('reg_param', 0.0, 10.0,
-                                               default=0.5)
+        reg_param = UniformFloatHyperparameter('reg_param', 0.0, 1.0,
+                                               default=0.0)
         cs = ConfigurationSpace()
         cs.add_hyperparameter(reg_param)
         return cs

--- a/test/test_metalearning/pyMetaLearn/test_metalearner.py
+++ b/test/test_metalearning/pyMetaLearn/test_metalearner.py
@@ -35,7 +35,8 @@ class MetaLearnerTest(unittest.TestCase):
 
     def test_metalearning_suggest_all(self):
         ret = self.meta_optimizer.metalearning_suggest_all()
-        self.assertEqual(18, len(ret))
+        self.assertEqual(17, len(ret))
+        # Reduced to 17 as we changed QDA searchspace
         self.assertEqual('gradient_boosting', ret[0]['classifier:__choice__'])
         self.assertEqual('random_forest', ret[1]['classifier:__choice__'])
         # There is no test for exclude_double_configuration as it's not present
@@ -45,7 +46,8 @@ class MetaLearnerTest(unittest.TestCase):
         self.meta_optimizer.meta_base.metafeatures.loc["38_acc"].iloc[:10] = \
             np.NaN
         ret = self.meta_optimizer.metalearning_suggest_all()
-        self.assertEqual(18, len(ret))
+        self.assertEqual(17, len(ret))
+        # Reduced to 17 as we changed QDA searchspace
         self.assertEqual('gradient_boosting', ret[0]['classifier:__choice__'])
         self.assertEqual('random_forest', ret[1]['classifier:__choice__'])
 

--- a/test/test_pipeline/components/classification/test_adaboost.py
+++ b/test/test_pipeline/components/classification/test_adaboost.py
@@ -1,51 +1,20 @@
-import unittest
+import sklearn.ensemble
 
 from autosklearn.pipeline.components.classification.adaboost import \
     AdaboostClassifier
-from autosklearn.pipeline.util import _test_classifier, _test_classifier_predict_proba
-
-import sklearn.metrics
-import sklearn.ensemble
-import numpy as np
+from .test_base import BaseClassificationComponentTest
 
 
-class AdaBoostComponentTest(unittest.TestCase):
-    def test_default_configuration_iris(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(AdaboostClassifier)
-            self.assertAlmostEqual(0.93999999999999995,
-                                   sklearn.metrics.accuracy_score(targets,
-                                                                  predictions))
+class AdaBoostComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_iris_predict_proba(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(AdaboostClassifier)
-            self.assertAlmostEqual(0.22452300738472031,
-                                   sklearn.metrics.log_loss(targets, predictions))
+    __test__ = True
 
-    def test_default_configuration_iris_sparse(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(AdaboostClassifier, sparse=True)
-            self.assertAlmostEqual(0.85999999999999999,
-                                   sklearn.metrics.accuracy_score(targets,
-                                                                  predictions))
+    res = dict()
+    res["default_on_iris"] = 0.93999999999999995
+    res["default_on_iris_proba"] = 0.22452300738472031
+    res["default_on_iris_sparse"] = 0.85999999999999999
+    res["default_binary"] = 0.93564055859137829
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(classifier=AdaboostClassifier,
-                                 dataset='digits', sparse=True,
-                                 make_binary=True)
-            self.assertAlmostEqual(0.93564055859137829,
-                                   sklearn.metrics.accuracy_score(
-                                       targets, predictions))
+    sk_mod = sklearn.ensemble.AdaBoostClassifier
 
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.ensemble.AdaBoostClassifier()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    module = AdaboostClassifier

--- a/test/test_pipeline/components/classification/test_adaboost.py
+++ b/test/test_pipeline/components/classification/test_adaboost.py
@@ -10,10 +10,15 @@ class AdaBoostComponentTest(BaseClassificationComponentTest):
     __test__ = True
 
     res = dict()
-    res["default_on_iris"] = 0.93999999999999995
-    res["default_on_iris_proba"] = 0.22452300738472031
-    res["default_on_iris_sparse"] = 0.85999999999999999
-    res["default_binary"] = 0.93564055859137829
+    res["default_iris"] = 0.93999999999999995
+    res["default_iris_iterative"] = -1
+    res["default_iris_proba"] = 0.22452300738472031
+    res["default_iris_sparse"] = 0.85999999999999999
+    res["default_digits"] = 0.6879174256223437
+    res["default_digits_iterative"] = -1
+    res["default_digits_binary"] = 0.98299939283545845
+    res["default_digits_multilabel"] = -1
+    res["default_digits_multilabel_proba"] = -1
 
     sk_mod = sklearn.ensemble.AdaBoostClassifier
 

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -11,6 +11,7 @@ import numpy as np
 class BaseClassificationComponentTest(unittest.TestCase):
 
     res = None
+
     module = None
     sk_module = None
 
@@ -24,7 +25,9 @@ class BaseClassificationComponentTest(unittest.TestCase):
                                  classifier=self.module)
             self.assertAlmostEqual(self.res["default_iris"],
                                    sklearn.metrics.accuracy_score(targets,
-                                                                  predictions))
+                                                                  predictions),
+                                   places=self.res.get(
+                                           "default_iris_places", 7))
 
     def test_default_iris_iterative_fit(self):
         if not hasattr(self.module, 'iterative_fit'):
@@ -35,8 +38,10 @@ class BaseClassificationComponentTest(unittest.TestCase):
                 _test_classifier_iterative_fit(dataset="iris",
                                                classifier=self.module)
             self.assertAlmostEqual(self.res["default_iris_iterative"],
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+                                   sklearn.metrics.accuracy_score(targets,
+                                                                  predictions),
+                                   places=self.res.get(
+                                           "default_iris_iterative_places", 7))
 
     def test_default_iris_predict_proba(self):
         for i in range(2):
@@ -44,7 +49,9 @@ class BaseClassificationComponentTest(unittest.TestCase):
                 _test_classifier_predict_proba(dataset="iris",
                                                classifier=self.module)
             self.assertAlmostEqual(self.res["default_iris_proba"],
-                                   sklearn.metrics.log_loss(targets, predictions))
+                                   sklearn.metrics.log_loss(targets, predictions),
+                                   places=self.res.get(
+                                           "default_iris_proba_places", 7))
 
     def test_default_iris_sparse(self):
         if SPARSE not in self.module.get_properties()["input"]:
@@ -57,7 +64,9 @@ class BaseClassificationComponentTest(unittest.TestCase):
                                  sparse=True)
             self.assertAlmostEqual(self.res["default_iris_sparse"],
                                    sklearn.metrics.accuracy_score(targets,
-                                                                  predictions))
+                                                                  predictions),
+                                   places=self.res.get(
+                                           "default_iris_sparse_places", 7))
 
     def test_default_digits_binary(self):
         for i in range(2):
@@ -67,7 +76,9 @@ class BaseClassificationComponentTest(unittest.TestCase):
                                  make_binary=True)
             self.assertAlmostEqual(self.res["default_digits_binary"],
                                    sklearn.metrics.accuracy_score(
-                                       targets, predictions))
+                                       targets, predictions),
+                                   places=self.res.get(
+                                           "default_digits_binary_places", 7))
 
     def test_default_digits(self):
         for i in range(2):
@@ -76,7 +87,9 @@ class BaseClassificationComponentTest(unittest.TestCase):
                                  classifier=self.module)
             self.assertAlmostEqual(self.res["default_digits"],
                                    sklearn.metrics.accuracy_score(targets,
-                                                                  predictions))
+                                                                  predictions),
+                                   places=self.res.get(
+                                           "default_digits_places", 7))
 
     def test_default_digits_iterative_fit(self):
         if not hasattr(self.module, 'iterative_fit'):
@@ -88,7 +101,9 @@ class BaseClassificationComponentTest(unittest.TestCase):
                                                classifier=self.module)
             self.assertAlmostEqual(self.res["default_digits_iterative"],
                                    sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+                                                                  targets),
+                                   places=self.res.get(
+                                           "default_digits_iterative_places", 7))
 
     def test_default_digits_multilabel(self):
         if not self.module.get_properties()["handles_multilabel"]:
@@ -101,7 +116,9 @@ class BaseClassificationComponentTest(unittest.TestCase):
                                  make_multilabel=True)
             self.assertAlmostEqual(self.res["default_digits_multilabel"],
                                    sklearn.metrics.average_precision_score(
-                                       targets, predictions))
+                                       targets, predictions),
+                                   places=self.res.get(
+                                           "default_digits_multilabel_places", 7))
 
     def test_default_digits_multilabel_predict_proba(self):
         if not self.module.get_properties()["handles_multilabel"]:
@@ -114,7 +131,9 @@ class BaseClassificationComponentTest(unittest.TestCase):
             self.assertEqual(predictions.shape, ((50, 3)))
             self.assertAlmostEqual(self.res["default_digits_multilabel_proba"],
                                    sklearn.metrics.average_precision_score(
-                                       targets, predictions))
+                                       targets, predictions),
+                                   places=self.res.get(
+                                           "default_digits_multilabel_proba_places", 7))
 
     def test_target_algorithm_multioutput_multiclass_support(self):
         if not self.module.get_properties()["handles_multiclass"]:

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -1,0 +1,59 @@
+import unittest
+
+from autosklearn.pipeline.util import _test_classifier, _test_classifier_predict_proba
+
+import sklearn.metrics
+import numpy as np
+
+
+class BaseClassificationComponentTest(unittest.TestCase):
+
+    res_dict = None
+    module = None
+    sk_module = None
+
+    # Magic command to not run tests on base class
+    __test__ = False
+
+    def test_default_configuration_iris(self):
+        for i in range(2):
+            predictions, targets = \
+                _test_classifier(self.module)
+            self.assertAlmostEqual(self.res["default_on_iris"],
+                                   sklearn.metrics.accuracy_score(targets,
+                                                                  predictions))
+
+    def test_default_configuration_iris_predict_proba(self):
+        for i in range(2):
+            predictions, targets = \
+                _test_classifier_predict_proba(self.module)
+            self.assertAlmostEqual(self.res["default_on_iris_proba"],
+                                   sklearn.metrics.log_loss(targets, predictions))
+
+    def test_default_configuration_iris_sparse(self):
+        for i in range(2):
+            predictions, targets = \
+                _test_classifier(self.module, sparse=True)
+            self.assertAlmostEqual(self.res["default_on_iris_sparse"],
+                                   sklearn.metrics.accuracy_score(targets,
+                                                                  predictions))
+
+    def test_default_configuration_binary(self):
+        for i in range(2):
+            predictions, targets = \
+                _test_classifier(classifier=self.module,
+                                 dataset='digits', sparse=True,
+                                 make_binary=True)
+            self.assertAlmostEqual(self.res["default_binary"],
+                                   sklearn.metrics.accuracy_score(
+                                       targets, predictions))
+
+    def test_target_algorithm_multioutput_multiclass_support(self):
+        if self.sk_module is not None:
+            cls = self.sk_module
+            X = np.random.random((10, 10))
+            y = np.random.randint(0, 1, size=(10, 10))
+            self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
+                                    cls.fit, X, y)
+        else:
+            return 

--- a/test/test_pipeline/components/classification/test_bernoulli_nb.py
+++ b/test/test_pipeline/components/classification/test_bernoulli_nb.py
@@ -1,63 +1,25 @@
-import unittest
+import sklearn.naive_bayes
 
 from autosklearn.pipeline.components.classification.bernoulli_nb import \
     BernoulliNB
-from autosklearn.pipeline.util import _test_classifier, \
-    _test_classifier_iterative_fit, _test_classifier_predict_proba
 
-import numpy as np
-import sklearn.metrics
-import sklearn.naive_bayes
+from .test_base import BaseClassificationComponentTest
 
 
-class BernoulliNBComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(BernoulliNB)
-            self.assertAlmostEqual(0.26000000000000001,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+class BernoulliNBComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_iterative_fit(BernoulliNB)
-            self.assertAlmostEqual(0.26000000000000001,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    __test__ = True
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(BernoulliNB, make_binary=True)
-            self.assertAlmostEqual(0.73999999999999999,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
+    res = dict()
+    res["default_iris"] = 0.26
+    res["default_iris_iterative"] = 0.26
+    res["default_iris_proba"] = 1.1157508543538652
+    res["default_iris_sparse"] = 0.38
+    res["default_digits"] = 0.81238615664845171
+    res["default_digits_iterative"] = 0.81238615664845171
+    res["default_digits_binary"] = 0.99392835458409234
+    res["default_digits_multilabel"] = 0.73112394623587451
+    res["default_digits_multilabel_proba"] = 0.66666666666666663
 
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(classifier=BernoulliNB,
-                                 dataset='digits',
-                                 make_multilabel=True)
-            self.assertAlmostEqual(0.73112394623587451,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_default_configuration_multilabel_predict_proba(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(classifier=BernoulliNB,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.66666666666666663,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.naive_bayes.BernoulliNB()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    sk_mod = sklearn.naive_bayes.BernoulliNB
+    module = BernoulliNB

--- a/test/test_pipeline/components/classification/test_decision_tree.py
+++ b/test/test_pipeline/components/classification/test_decision_tree.py
@@ -1,63 +1,25 @@
-import unittest
-
-from autosklearn.pipeline.components.classification.decision_tree import DecisionTree
-from autosklearn.pipeline.util import _test_classifier, _test_classifier_predict_proba
-
-import numpy as np
-import sklearn.metrics
 import sklearn.tree
 
+from autosklearn.pipeline.components.classification.decision_tree import \
+    DecisionTree
 
-class DecisionTreetComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(DecisionTree)
-            self.assertAlmostEqual(0.62,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+from .test_base import BaseClassificationComponentTest
 
-    def test_default_configuration_sparse(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(DecisionTree, sparse=True)
-            self.assertAlmostEqual(0.41999999999999998,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                              targets))
 
-    def test_default_configuration_predict_proba(self):
-        for i in range(2):
-            predictions, targets = _test_classifier_predict_proba(
-                DecisionTree)
-            self.assertAlmostEqual(0.51333963481747835,
-                sklearn.metrics.log_loss(targets, predictions))
+class DecisionTreetComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(
-                DecisionTree, make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(
-                                       targets, predictions))
+    __test__ = True
 
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(
-                DecisionTree, make_multilabel=True)
-            self.assertAlmostEqual(0.81108108108108112,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
+    res = dict()
+    res["default_iris"] = 0.62
+    res["default_iris_iterative"] = -1
+    res["default_iris_proba"] = 0.51333963481747835
+    res["default_iris_sparse"] = 0.41999999999999998
+    res["default_digits"] = 0.15057680631451123
+    res["default_digits_iterative"] = -1
+    res["default_digits_binary"] = 0.92167577413479052
+    res["default_digits_multilabel"] = 0.56326230155706081
+    res["default_digits_multilabel_proba"] = 0.83333333333333337
 
-    def test_default_configuration_multilabel_predict_proba(self):
-        for i in range(2):
-            predictions, targets = _test_classifier_predict_proba(
-                DecisionTree, make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.83333333333333337,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.tree.DecisionTreeClassifier()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        # Running this without an exception is the purpose of this test!
-        cls.fit(X, y)
+    sk_mod = sklearn.tree.DecisionTreeClassifier
+    module = DecisionTree

--- a/test/test_pipeline/components/classification/test_extra_trees.py
+++ b/test/test_pipeline/components/classification/test_extra_trees.py
@@ -1,76 +1,25 @@
-import unittest
+import sklearn.ensemble
 
 from autosklearn.pipeline.components.classification.extra_trees import \
     ExtraTreesClassifier
-from autosklearn.pipeline.util import _test_classifier, \
-    _test_classifier_iterative_fit, _test_classifier_predict_proba
 
-import numpy as np
-import sklearn.metrics
-import sklearn.ensemble
+from .test_base import BaseClassificationComponentTest
 
 
-class ExtraTreesComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(ExtraTreesClassifier)
-            self.assertAlmostEqual(0.95999999999999996,
-                sklearn.metrics.accuracy_score(targets, predictions))
+class ExtraTreesComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_predict_proba(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(ExtraTreesClassifier)
-            self.assertAlmostEqual(0.1086791056721286,
-                                   sklearn.metrics.log_loss(
-                                       targets, predictions))
+    __test__ = True
 
-    def test_default_configuration_sparse(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(ExtraTreesClassifier, sparse=True)
-            self.assertAlmostEqual(0.71999999999999997,
-                                   sklearn.metrics.accuracy_score(targets,
-                                                                  predictions))
+    res = dict()
+    res["default_iris"] = 0.95999999999999996
+    res["default_iris_iterative"] = 0.93999999999999995
+    res["default_iris_proba"] = 0.1086791056721286
+    res["default_iris_sparse"] = 0.71999999999999997
+    res["default_digits"] = 0.8986035215543412
+    res["default_digits_iterative"] = 0.81785063752276865
+    res["default_digits_binary"] = 0.99392835458409234
+    res["default_digits_multilabel"] = 0.82229416703109792
+    res["default_digits_multilabel_proba"] = 0.99401797442008899
 
-    def test_default_configuration_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_iterative_fit(ExtraTreesClassifier)
-            self.assertAlmostEqual(0.93999999999999995,
-                                   sklearn.metrics.accuracy_score(targets,
-                                                                  predictions))
-
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(ExtraTreesClassifier, make_binary=True)
-            self.assertAlmostEqual(1,
-                                   sklearn.metrics.accuracy_score(targets,
-                                                                  predictions))
-
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(ExtraTreesClassifier, make_multilabel=True)
-            self.assertAlmostEqual(0.97060428849902536,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_default_configuration_predict_proba_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(ExtraTreesClassifier,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.99401797442008899,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.ensemble.ExtraTreesClassifier()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        # Running this without an exception is the purpose of this test!
-        cls.fit(X, y)
+    sk_mod = sklearn.ensemble.ExtraTreesClassifier
+    module = ExtraTreesClassifier

--- a/test/test_pipeline/components/classification/test_gaussian_nb.py
+++ b/test/test_pipeline/components/classification/test_gaussian_nb.py
@@ -1,63 +1,25 @@
-import unittest
+import sklearn.naive_bayes
 
 from autosklearn.pipeline.components.classification.gaussian_nb import \
     GaussianNB
-from autosklearn.pipeline.util import _test_classifier, \
-    _test_classifier_iterative_fit, _test_classifier_predict_proba
 
-import numpy as np
-import sklearn.metrics
-import sklearn.naive_bayes
+from .test_base import BaseClassificationComponentTest
 
 
-class GaussianNBComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(GaussianNB)
-            self.assertAlmostEqual(0.95999999999999996,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+class GaussianNBComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_iterative_fit(GaussianNB)
-            self.assertAlmostEqual(0.95999999999999996,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    __test__ = True
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(GaussianNB,
-                                                    make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.average_precision_score(
-                                       predictions, targets))
+    res = dict()
+    res["default_iris"] = 0.95999999999999996
+    res["default_iris_iterative"] = 0.95999999999999996
+    res["default_iris_proba"] = 0.11199001987342033
+    res["default_iris_sparse"] = -1
+    res["default_digits"] = 0.80692167577413476
+    res["default_digits_iterative"] = 0.80692167577413476
+    res["default_digits_binary"] = 0.98664238008500305
+    res["default_digits_multilabel"] = 0.71507312748717466
+    res["default_digits_multilabel_proba"] = 0.98533237262174234
 
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(classifier=GaussianNB,
-                                 dataset='digits',
-                                 make_multilabel=True)
-            self.assertAlmostEqual(0.71507312748717466,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_default_configuration_multilabel_predict_proba(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(classifier=GaussianNB,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.98533237262174234,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.naive_bayes.GaussianNB()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    sk_mod = sklearn.naive_bayes.GaussianNB
+    module = GaussianNB

--- a/test/test_pipeline/components/classification/test_gradient_boosting.py
+++ b/test/test_pipeline/components/classification/test_gradient_boosting.py
@@ -1,42 +1,25 @@
-import unittest
+import sklearn.ensemble
 
 from autosklearn.pipeline.components.classification.gradient_boosting import \
     GradientBoostingClassifier
-from autosklearn.pipeline.util import _test_classifier, \
-    _test_classifier_iterative_fit, _test_classifier_predict_proba
 
-import sklearn.metrics
-import sklearn.ensemble
-import numpy as np
+from .test_base import BaseClassificationComponentTest
 
 
-class GradientBoostingComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(GradientBoostingClassifier)
-            self.assertAlmostEqual(0.93999999999999995,
-                sklearn.metrics.accuracy_score(predictions, targets))
+class GradientBoostingComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_iterative_fit(GradientBoostingClassifier)
-            self.assertAlmostEqual(0.95999999999999996,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    __test__ = True
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(
-                GradientBoostingClassifier, make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    res = dict()
+    res["default_iris"] = 0.93999999999999995
+    res["default_iris_iterative"] = 0.95999999999999996
+    res["default_iris_proba"] = 0.36351844058108812
+    res["default_iris_sparse"] = -1
+    res["default_digits"] = 0.87795992714025506
+    res["default_digits_iterative"] = 0.78324225865209474
+    res["default_digits_binary"] = 0.99089253187613846
+    res["default_digits_multilabel"] = -1
+    res["default_digits_multilabel_proba"] = -1
 
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.ensemble.GradientBoostingClassifier()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    sk_mod = sklearn.ensemble.ExtraTreesClassifier
+    module = GradientBoostingClassifier

--- a/test/test_pipeline/components/classification/test_k_nearest_neighbor.py
+++ b/test/test_pipeline/components/classification/test_k_nearest_neighbor.py
@@ -1,67 +1,25 @@
-import unittest
+import sklearn.neighbors
 
 from autosklearn.pipeline.components.classification.k_nearest_neighbors import \
     KNearestNeighborsClassifier
-from autosklearn.pipeline.util import _test_classifier, _test_classifier_predict_proba
 
-import numpy as np
-import sklearn.metrics
-import sklearn.neighbors
+from .test_base import BaseClassificationComponentTest
 
 
-class KNearestNeighborsComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(KNearestNeighborsClassifier)
-            self.assertAlmostEqual(0.959999999999999,
-                sklearn.metrics.accuracy_score(predictions, targets))
+class KNearestNeighborsComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_sparse_data(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(KNearestNeighborsClassifier, sparse=True)
-            self.assertAlmostEqual(0.82,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    __test__ = True
 
-    def test_default_configuration_predict_proba(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(KNearestNeighborsClassifier)
-            self.assertAlmostEqual(1.381551055796429,
-                sklearn.metrics.log_loss(targets, predictions))
+    res = dict()
+    res["default_iris"] = 0.959999999999999
+    res["default_iris_iterative"] = -1
+    res["default_iris_proba"] = 1.381551055796429
+    res["default_iris_sparse"] = 0.82
+    res["default_digits"] = 0.93321190042501523
+    res["default_digits_iterative"] = -1
+    res["default_digits_binary"] = 0.99574984820886459
+    res["default_digits_multilabel"] = 0.93733794389823633
+    res["default_digits_multilabel_proba"] = 0.97060428849902536
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(KNearestNeighborsClassifier, make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
-
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(KNearestNeighborsClassifier,
-                                 make_multilabel=True)
-            self.assertAlmostEqual(0.959999999999999,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
-
-    def test_default_configuration_predict_proba_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(KNearestNeighborsClassifier,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.97060428849902536,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.neighbors.KNeighborsClassifier()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        # Running this without an exception is the purpose of this test!
-        cls.fit(X, y)
+    sk_mod = sklearn.neighbors.KNeighborsClassifier
+    module = KNearestNeighborsClassifier

--- a/test/test_pipeline/components/classification/test_lda.py
+++ b/test/test_pipeline/components/classification/test_lda.py
@@ -1,60 +1,24 @@
-import unittest
-
-from autosklearn.pipeline.components.classification.lda import LDA
-from autosklearn.pipeline.util import _test_classifier, _test_classifier_predict_proba
-
-import numpy as np
-import sklearn.metrics
 import sklearn.discriminant_analysis
 
+from autosklearn.pipeline.components.classification.lda import LDA
 
-class LDAComponentTest(unittest.TestCase):
-    def test_default_configuration_iris(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(LDA)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+from .test_base import BaseClassificationComponentTest
 
-    def test_default_configuration_digits(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(classifier=LDA, dataset='digits')
-            self.assertAlmostEqual(0.88585306618093507,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
 
-    def test_default_configuration_iris_binary(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(LDA, make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+class LDAComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_iris_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(LDA, make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.66,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    __test__ = True
 
-    def test_default_configuration_predict_proba_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(LDA,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.96639166748245653,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
+    res = dict()
+    res["default_iris"] = 1.0
+    res["default_iris_iterative"] = -1
+    res["default_iris_proba"] = 0.71825067760050065
+    res["default_iris_sparse"] = -1
+    res["default_digits"] = 0.88585306618093507
+    res["default_digits_iterative"] = -1
+    res["default_digits_binary"] = 0.9811778992106861
+    res["default_digits_multilabel"] = 0.83890327969812117
+    res["default_digits_multilabel_proba"] = 0.96639166748245653
 
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.discriminant_analysis.LinearDiscriminantAnalysis()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    sk_mod = sklearn.discriminant_analysis.LinearDiscriminantAnalysis
+    module = LDA

--- a/test/test_pipeline/components/classification/test_liblinear.py
+++ b/test/test_pipeline/components/classification/test_liblinear.py
@@ -15,7 +15,7 @@ class LibLinearComponentTest(BaseClassificationComponentTest):
     res["default_iris_iterative"] = -1
     res["default_iris_proba"] = 0.33728319465089696
     res["default_iris_sparse"] = 0.56
-    res["default_digits"] = 0.91560412871888286
+    res["default_digits"] = 0.91499696417729204
     res["default_digits_iterative"] = -1
     res["default_digits_binary"] = 0.98907103825136611
     res["default_digits_multilabel"] = 0.89539354612444322

--- a/test/test_pipeline/components/classification/test_liblinear.py
+++ b/test/test_pipeline/components/classification/test_liblinear.py
@@ -1,43 +1,25 @@
-import unittest
-
-import numpy as np
-import sklearn.metrics
 import sklearn.svm
 
-from autosklearn.pipeline.components.classification.liblinear_svc import LibLinear_SVC
-from autosklearn.pipeline.util import _test_classifier, _test_classifier_predict_proba
+from autosklearn.pipeline.components.classification.liblinear_svc import \
+    LibLinear_SVC
+
+from .test_base import BaseClassificationComponentTest
 
 
-class LibLinearComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(LibLinear_SVC)
-            self.assertTrue(all(targets == predictions))
+class LibLinearComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_sparse(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(LibLinear_SVC,
-                                                    sparse=True)
-            self.assertEquals(0.56, sklearn.metrics.accuracy_score(
-                targets, predictions))
+    __test__ = True
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(LibLinear_SVC,
-                                                    make_binary=True)
-            self.assertTrue(all(targets == predictions))
+    res = dict()
+    res["default_iris"] = 1
+    res["default_iris_iterative"] = -1
+    res["default_iris_proba"] = 0.33728319465089696
+    res["default_iris_sparse"] = 0.56
+    res["default_digits"] = 0.91560412871888286
+    res["default_digits_iterative"] = -1
+    res["default_digits_binary"] = 0.98907103825136611
+    res["default_digits_multilabel"] = 0.89539354612444322
+    res["default_digits_multilabel_proba"] = 0.99999999999999989
 
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(LibLinear_SVC,
-                                                    make_multilabel=True)
-            self.assertAlmostEquals(0.84479797979797977, sklearn.metrics.average_precision_score(
-                targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.svm.LinearSVC()
-
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    sk_mod = sklearn.svm.LinearSVC
+    module = LibLinear_SVC

--- a/test/test_pipeline/components/classification/test_libsvm_svc.py
+++ b/test/test_pipeline/components/classification/test_libsvm_svc.py
@@ -1,22 +1,33 @@
-import unittest
-
-from autosklearn.pipeline.components.classification.libsvm_svc import LibSVM_SVC
-from autosklearn.pipeline.util import _test_classifier, \
-    _test_classifier_predict_proba, get_dataset
-
-import numpy as np
 import sklearn.metrics
 import sklearn.svm
 
+from autosklearn.pipeline.components.classification.libsvm_svc import LibSVM_SVC
+from autosklearn.pipeline.util import get_dataset, \
+    _test_classifier_predict_proba
 
-class LibSVM_SVCComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(LibSVM_SVC, dataset='iris')
-            self.assertAlmostEqual(0.96,
-                sklearn.metrics.accuracy_score(predictions, targets))
+from .test_base import BaseClassificationComponentTest
 
-    def test_default_configuration_predict_proba(self):
+
+class LibSVM_SVCComponentTest(BaseClassificationComponentTest):
+
+    __test__ = True
+
+    res = dict()
+    res["default_iris"] = 0.96
+    res["default_iris_iterative"] = -1
+    res["default_iris_proba"] = 0.32243463915795706
+    res["default_iris_sparse"] = 0.64
+    res["default_digits"] = 0.096539162112932606
+    res["default_digits_iterative"] = -1
+    res["default_digits_binary"] = 0.90103217972070426
+    res["default_digits_multilabel"] = -1
+    res["default_digits_multilabel_proba"] = -1
+
+    sk_mod = sklearn.svm.SVC
+    module = LibSVM_SVC
+
+    def test_default_configuration_predict_proba_individual(self):
+        # Leave this additional test here
         for i in range(2):
             predictions, targets = _test_classifier_predict_proba(
                 LibSVM_SVC, sparse=True, dataset='digits',
@@ -54,19 +65,3 @@ class LibSVM_SVCComponentTest(unittest.TestCase):
             prediction = cls.predict_proba(X_test)
             self.assertAlmostEqual(sklearn.metrics.log_loss(Y_test, prediction),
                                    0.69323680119641773)
-
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(LibSVM_SVC,
-                                                    make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.svm.SVC()
-
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)

--- a/test/test_pipeline/components/classification/test_multinomial_nb.py
+++ b/test/test_pipeline/components/classification/test_multinomial_nb.py
@@ -1,31 +1,32 @@
-import unittest
+import numpy as np
+
+import sklearn.naive_bayes
+import sklearn.preprocessing
 
 from autosklearn.pipeline.components.classification.multinomial_nb import \
     MultinomialNB
-from autosklearn.pipeline.util import _test_classifier, _test_classifier_iterative_fit, \
-    get_dataset, _test_classifier_predict_proba
+from autosklearn.pipeline.util import get_dataset
 
-import numpy as np
-import sklearn.metrics
-import sklearn.naive_bayes
+from .test_base import BaseClassificationComponentTest
 
 
-class MultinomialNBComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(MultinomialNB)
-            self.assertAlmostEqual(0.97999999999999998,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+class MultinomialNBComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_iterative_fit(MultinomialNB)
-            self.assertAlmostEqual(0.97999999999999998,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    __test__ = True
+
+    res = dict()
+    res["default_iris"] = 0.97999999999999998
+    res["default_iris_iterative"] = 0.97999999999999998
+    res["default_iris_proba"] = 0.5879188799085624
+    res["default_iris_sparse"] = 0.54
+    res["default_digits"] = 0.89496053430479661
+    res["default_digits_iterative"] = 0.89496053430479661
+    res["default_digits_binary"] = 0.98967820279295693
+    res["default_digits_multilabel"] = 0.81239938943608647
+    res["default_digits_multilabel_proba"] = 0.76548981051208942
+
+    sk_mod = sklearn.naive_bayes.MultinomialNB
+    module = MultinomialNB
 
     def test_default_configuration_negative_values(self):
         # Custon preprocessing test to check if clipping to zero works
@@ -44,38 +45,3 @@ class MultinomialNBComponentTest(unittest.TestCase):
         prediction = cls.predict(X_test)
         self.assertAlmostEqual(np.nanmean(prediction == Y_test),
                                0.88888888888888884)
-
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(MultinomialNB, make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
-
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(classifier=MultinomialNB,
-                                 dataset='digits',
-                                 make_multilabel=True)
-            self.assertAlmostEqual(0.81239938943608647,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_default_configuration_multilabel_predict_proba(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(classifier=MultinomialNB,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.76548981051208942,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.naive_bayes.MultinomialNB()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)

--- a/test/test_pipeline/components/classification/test_passive_aggressive.py
+++ b/test/test_pipeline/components/classification/test_passive_aggressive.py
@@ -1,79 +1,25 @@
-import unittest
+import sklearn.linear_model
 
 from autosklearn.pipeline.components.classification.passive_aggressive import \
     PassiveAggressive
-from autosklearn.pipeline.util import _test_classifier, \
-    _test_classifier_iterative_fit, _test_classifier_predict_proba
 
-import numpy as np
-import sklearn.metrics
-import sklearn.linear_model
+from .test_base import BaseClassificationComponentTest
 
 
-class PassiveAggressiveComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(PassiveAggressive)
-            self.assertAlmostEqual(0.71999999999999997,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+class PassiveAggressiveComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = _test_classifier_iterative_fit(
-                PassiveAggressive)
-            self.assertAlmostEqual(0.81999999999999995,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
+    __test__ = True
 
-    def test_default_configuration_digits(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(classifier=PassiveAggressive, dataset='digits')
-            self.assertAlmostEqual(0.92046144505160898,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    res = dict()
+    res["default_iris"] = 0.71999999999999997
+    res["default_iris_iterative"] = 0.81999999999999995
+    res["default_iris_proba"] = 0.46713079533751622
+    res["default_iris_sparse"] = 0.4
+    res["default_digits"] = 0.92046144505160898
+    res["default_digits_iterative"] = 0.92349726775956287
+    res["default_digits_binary"] = 0.99574984820886459
+    res["default_digits_multilabel"] = 0.8975269956947447
+    res["default_digits_multilabel_proba"] = 0.99703892466326138
 
-    def test_default_configuration_digits_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = _test_classifier_iterative_fit(classifier=PassiveAggressive,
-                                                    dataset='digits')
-            self.assertAlmostEqual(0.92349726775956287,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
-
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(PassiveAggressive,
-                                                    make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
-
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(classifier=PassiveAggressive,
-                                 dataset='digits',
-                                 make_multilabel=True)
-            self.assertAlmostEqual(0.8975269956947447,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_default_configuration_multilabel_predict_proba(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(classifier=PassiveAggressive,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.99703892466326138,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.linear_model.PassiveAggressiveClassifier()
-
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    sk_mod = sklearn.linear_model.PassiveAggressiveClassifier
+    module = PassiveAggressive

--- a/test/test_pipeline/components/classification/test_qda.py
+++ b/test/test_pipeline/components/classification/test_qda.py
@@ -10,15 +10,16 @@ class QDAComponentTest(BaseClassificationComponentTest):
     __test__ = True
 
     res = dict()
-    res["default_iris"] = 1
+    res["default_iris"] = 1.0
     res["default_iris_iterative"] = -1
-    res["default_iris_proba"] = 0.56121944069862362
+    res["default_iris_proba"] = 0.56124476634783993
     res["default_iris_sparse"] = -1
     res["default_digits"] = 0.18882817243472982
     res["default_digits_iterative"] = -1
     res["default_digits_binary"] = 0.89071038251366119
-    res["default_digits_multilabel"] = 0.17238069061487776
-    res["default_digits_multilabel_proba"] = 1.0
+    res["default_digits_multilabel"] = 0.17011293429111091
+    res["default_digits_multilabel_places"] = 1
+    res["default_digits_multilabel_proba"] = 0.99999999999999989
 
     sk_mod = sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis
     module = QDA

--- a/test/test_pipeline/components/classification/test_qda.py
+++ b/test/test_pipeline/components/classification/test_qda.py
@@ -1,60 +1,24 @@
-import unittest
-
-from autosklearn.pipeline.components.classification.qda import QDA
-from autosklearn.pipeline.util import _test_classifier, _test_classifier_predict_proba
-
-import numpy as np
-import sklearn.metrics
 import sklearn.discriminant_analysis
 
+from autosklearn.pipeline.components.classification.qda import QDA
 
-class QDAComponentTest(unittest.TestCase):
-    def test_default_configuration_iris(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(QDA)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+from .test_base import BaseClassificationComponentTest
 
-    #@unittest.skip("QDA fails on this one")
-    def test_default_configuration_digits(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(classifier=QDA, dataset='digits')
-            self.assertAlmostEqual(0.18882817243472982,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(QDA, make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+class QDAComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(QDA, make_multilabel=True)
-            self.assertAlmostEqual(0.99456140350877187,
-                                   sklearn.metrics.average_precision_score(
-                                       predictions, targets))
+    __test__ = True
 
-    def test_default_configuration_predict_proba_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(QDA,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
+    res = dict()
+    res["default_iris"] = 1
+    res["default_iris_iterative"] = -1
+    res["default_iris_proba"] = 0.56121944069862362
+    res["default_iris_sparse"] = -1
+    res["default_digits"] = 0.18882817243472982
+    res["default_digits_iterative"] = -1
+    res["default_digits_binary"] = 0.89071038251366119
+    res["default_digits_multilabel"] = 0.17238069061487776
+    res["default_digits_multilabel_proba"] = 1.0
 
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    sk_mod = sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis
+    module = QDA

--- a/test/test_pipeline/components/classification/test_random_forest.py
+++ b/test/test_pipeline/components/classification/test_random_forest.py
@@ -1,66 +1,25 @@
-import unittest
-
-from autosklearn.pipeline.components.classification.random_forest import RandomForest
-from autosklearn.pipeline.util import _test_classifier, \
-    _test_classifier_iterative_fit, _test_classifier_predict_proba
-
-import numpy as np
 import sklearn.ensemble
-import sklearn.metrics
+
+from autosklearn.pipeline.components.classification.random_forest import \
+    RandomForest
+
+from .test_base import BaseClassificationComponentTest
 
 
-class RandomForestComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(RandomForest)
-            self.assertAlmostEqual(0.95999999999999996,
-                sklearn.metrics.accuracy_score(predictions, targets))
+class RandomForestComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_sparse(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(RandomForest, sparse=True)
-            self.assertAlmostEqual(0.85999999999999999,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    __test__ = True
 
-    def test_default_configuration_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_iterative_fit(RandomForest)
-            self.assertAlmostEqual(0.95999999999999996,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
+    res = dict()
+    res["default_iris"] = 0.95999999999999996
+    res["default_iris_iterative"] = 0.95999999999999996
+    res["default_iris_proba"] = 0.12735301219200268
+    res["default_iris_sparse"] = 0.85999999999999999
+    res["default_digits"] = 0.88585306618093507
+    res["default_digits_iterative"] = 0.78870673952641168
+    res["default_digits_binary"] = 0.98664238008500305
+    res["default_digits_multilabel"] = 0.79662039405484386
+    res["default_digits_multilabel_proba"] = 0.99252721833266977
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(RandomForest,
-                                                    make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
-
-    def test_default_configuration_multilabel(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(RandomForest,
-                                                    make_multilabel=True)
-            self.assertAlmostEqual(0.95999999999999996,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
-
-    def test_default_configuration_predict_proba_multilabel(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(RandomForest,
-                                               make_multilabel=True)
-            self.assertEqual(predictions.shape, ((50, 3)))
-            self.assertAlmostEqual(0.99252721833266977,
-                                   sklearn.metrics.average_precision_score(
-                                       targets, predictions))
-
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.ensemble.RandomForestClassifier()
-
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        # Running this without an exception is the purpose of this test!
-        cls.fit(X, y)
+    sk_mod = sklearn.ensemble.RandomForestClassifier
+    module = RandomForest

--- a/test/test_pipeline/components/classification/test_sgd.py
+++ b/test/test_pipeline/components/classification/test_sgd.py
@@ -1,57 +1,24 @@
-import unittest
-
-from autosklearn.pipeline.components.classification.sgd import SGD
-from autosklearn.pipeline.util import _test_classifier, \
-    _test_classifier_iterative_fit, _test_classifier_predict_proba
-
-import numpy as np
-import sklearn.metrics
 import sklearn.linear_model
 
+from autosklearn.pipeline.components.classification.sgd import SGD
 
-class SGDComponentTest(unittest.TestCase):
-    def test_default_configuration(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(SGD)
-            self.assertAlmostEqual(0.64000000000000001,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+from .test_base import BaseClassificationComponentTest
 
-    def test_default_configuration_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = _test_classifier_iterative_fit(
-                SGD)
-            self.assertAlmostEqual(0.76000000000000001,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
 
-    def test_default_configuration_digits(self):
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier(SGD, dataset='digits')
-            self.assertAlmostEqual(0.89981785063752273,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+class SGDComponentTest(BaseClassificationComponentTest):
 
-    def test_default_configuration_digits_iterative_fit(self):
-        for i in range(2):
-            predictions, targets = _test_classifier_iterative_fit(
-                SGD,
-                dataset='digits')
-            self.assertAlmostEqual(0.89981785063752273,
-                                   sklearn.metrics.accuracy_score(
-                                       predictions, targets))
+    __test__ = True
 
-    def test_default_configuration_binary(self):
-        for i in range(2):
-            predictions, targets = _test_classifier(SGD, make_binary=True)
-            self.assertAlmostEqual(1.0,
-                                   sklearn.metrics.accuracy_score(predictions,
-                                                                  targets))
+    res = dict()
+    res["default_iris"] = 0.64
+    res["default_iris_iterative"] = 0.76
+    res["default_iris_proba"] = 12.433959502167845
+    res["default_iris_sparse"] = 0.26
+    res["default_digits"] = 0.89981785063752273
+    res["default_digits_iterative"] = 0.89981785063752273
+    res["default_digits_binary"] = 0.9927140255009107
+    res["default_digits_multilabel"] = -1
+    res["default_digits_multilabel_proba"] = -1
 
-    def test_target_algorithm_multioutput_multiclass_support(self):
-        cls = sklearn.linear_model.SGDClassifier()
-        X = np.random.random((10, 10))
-        y = np.random.randint(0, 1, size=(10, 10))
-        self.assertRaisesRegexp(ValueError, 'bad input shape \(10, 10\)',
-                                cls.fit, X, y)
+    sk_mod = sklearn.linear_model.SGDClassifier
+    module = SGD


### PR DESCRIPTION
Rewrite all unittests. There is now a base class which provides test skeletons and each classifier test only provides results.

If this is fine, we can also change the tests for regression models.