### PR TITLE
Remove duplicated word in a print statement

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ replacement for a scikit-learn estimator:
     >>> import autosklearn.classification
     >>> cls = autosklearn.classification.AutoSklearnClassifier()
     >>> cls.fit(X_train, y_train)
-    >>> predictions = cls.predict(X_test, y_test)
+    >>> predictions = cls.predict(X_test)
 
 *auto-sklearn* frees a machine learning user from algorithm selection and
 hyperparameter tuning. It leverages recent advantages in *Bayesian

--- a/example/example_metrics.py
+++ b/example/example_metrics.py
@@ -49,7 +49,7 @@ def main():
 
     # Second example: Use own accuracy metric
     print("#"*80)
-    print("Use self defined accuracy accuracy metric")
+    print("Use self defined accuracy metric")
     accuracy_scorer = autosklearn.metrics.make_scorer(name="accu",
                                                       score_func=accuracy,
                                                       greater_is_better=True,


### PR DESCRIPTION
This is a minor change, just removing a duplicated word in a print statement