### PR TITLE
set sklearn dependency to GTEQ 0.18.1

### DIFF
--- a/autosklearn/__init__.py
+++ b/autosklearn/__init__.py
@@ -5,7 +5,7 @@ from autosklearn.__version__ import __version__
 
 __MANDATORY_PACKAGES__ = '''
 numpy>=1.9
-scikit-learn==0.18.1
+scikit-learn>=0.18.1
 smac==0.5.0
 lockfile>=0.10
 ConfigSpace>=0.3.3,<0.4


### PR DESCRIPTION
## Motivation
Currently, sklearn version 0.18.1 is required for auto-sklearn, sklearns most recent version is 0.18.2. (see http://scikit-learn.org/stable/whats_new.html#version-0-18-2)

## Changes
I have changed the dependency to `>=0.18.1` instead of `==0.18.1`.

## Results
The following code works as expected:
```
import autosklearn.classification
classifier = autosklearn.classification.AutoSklearnClassifier()
classifier.fit(features_train, targets_train)
classifier.score(features_test, targets_test)
```

## Todos
- [ ] Further testing