### PR TITLE
add method to get list of evaluated models (#336)

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -764,12 +764,23 @@ class AutoML(BaseEstimator):
                   'limit: %d\n' % num_memout)
         return sio.getvalue()
 
-    def show_models(self):
+    def get_models_with_weights(self):
         if self.models_ is None or len(self.models_) == 0 or \
                 self.ensemble_ is None:
             self._load_models()
 
-        return self.ensemble_.pprint_ensemble_string(self.models_)
+        return self.ensemble_.get_models_with_weights(self.models_)
+
+    def show_models(self):
+        models_with_weights = self.get_models_with_weights()
+
+        with io.StringIO() as sio:
+            sio.write("[")
+            for weight, model in models_with_weights:
+                sio.write("(%f, %s),\n" % (weight, model))
+            sio.write("]")
+
+            return sio.getvalue()
 
     def _create_search_space(self, tmp_dir, backend, datamanager,
                              include_estimators=None,

--- a/autosklearn/ensembles/abstract_ensemble.py
+++ b/autosklearn/ensembles/abstract_ensemble.py
@@ -42,8 +42,8 @@ class AbstractEnsemble(object):
         self
 
     @abstractmethod
-    def pprint_ensemble_string(self, models):
-        """Return a nicely-readable representation of the ensmble.
+    def get_models_with_weights(self, models):
+        """Return a list of (wight, model) pairs
 
         Parameters
         ----------
@@ -53,8 +53,9 @@ class AbstractEnsemble(object):
 
         Returns
         -------
-        str
+        array : [(weight_1, model_1), ..., (weight_n, model_n)]
         """
+
 
     @abstractmethod
     def get_model_identifiers(self):

--- a/autosklearn/ensembles/abstract_ensemble.py
+++ b/autosklearn/ensembles/abstract_ensemble.py
@@ -43,7 +43,7 @@ class AbstractEnsemble(object):
 
     @abstractmethod
     def get_models_with_weights(self, models):
-        """Return a list of (wight, model) pairs
+        """Return a list of (weight, model) pairs
 
         Parameters
         ----------

--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -2,7 +2,6 @@ from collections import Counter
 import random
 
 import numpy as np
-import six
 
 from autosklearn.constants import *
 from autosklearn.ensembles.abstract_ensemble import AbstractEnsemble
@@ -204,9 +203,9 @@ class EnsembleSelection(AbstractEnsemble):
                           enumerate(self.identifiers_)
                           if self.weights_[idx] > 0]))
 
-    def pprint_ensemble_string(self, models):
+    def get_models_with_weights(self, models):
         output = []
-        sio = six.StringIO()
+
         for i, weight in enumerate(self.weights_):
             identifier = self.identifiers_[i]
             model = models[identifier]
@@ -215,12 +214,7 @@ class EnsembleSelection(AbstractEnsemble):
 
         output.sort(reverse=True, key=lambda t: t[0])
 
-        sio.write("[")
-        for weight, model in output:
-            sio.write("(%f, %s),\n" % (weight, model))
-        sio.write("]")
-
-        return sio.getvalue()
+        return output
 
     def get_model_identifiers(self):
         return self.identifiers_

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -73,6 +73,16 @@ class AutoMLDecorator(object):
         """
         return self._automl.show_models()
 
+    def get_models_with_weights(self):
+        """Return a list of the final ensemble found by auto-sklearn.
+
+        Returns
+        -------
+        [(weight_1, model_1), ..., (weight_n, model_n)]
+
+        """
+        return self._automl.get_models_with_weights()
+
     @property
     def cv_results_(self):
         return self._automl.cv_results_


### PR DESCRIPTION
I added `EnsembleSelection.get_models_with_weights` as a general version of the previous `EnsembleSelection.pprint_ensemble_string` while refactoring the latter to the level of `AutoML.show_models` now using the newly introduced `get_models_with_weights` method.