### PR TITLE
Add instructions for Docker

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -105,3 +105,18 @@ Possible other solutions (not tested):
 
 * virtual machine
 * docker image
+
+
+Docker image
+============
+To pull the Docker image for *auto-sklearn* from `Docker hub<https://hub.docker.com/r/mfeurer/auto-sklearn/>`_:
+
+.. code:: bash
+
+    docker pull mfeurer/auto-sklearn
+
+To start a Jupyter notebook, you could run e.g.:
+
+.. code:: bash
+
+    docker run -it -v $PWD:/opt/nb -p 8888:8888 mfeurer/auto-sklearn /bin/bash -c "mkdir -p /opt/nb && jupyter notebook --notebook-dir=/opt/nb --ip='0.0.0.0' --port=8888 --no-browser --allow-root"


### PR DESCRIPTION
Instructions for pulling the Docker image and running auto-sklearn are now added.

I tried to follow the format of `doc/installation.rst` as best I can, but feel free to make any edits as you see fit.

#320 