### PR TITLE
Fixed capitalization inconsistencies and misspelled words

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -16,7 +16,7 @@ auto-sklearn has the following system requirements:
 * C++ compiler (with C++11 supports) and SWIG (version 3.0 or later) 
 
 For an explanation of missing Microsoft Windows and MAC OSX support please
-check the Section `Windows/OSX compability`_.
+check the Section `Windows/OSX compatibility`_.
 
 Installing auto-sklearn
 =======================
@@ -56,7 +56,7 @@ Anaconda does not ship *auto-sklearn*, and there are no conda packages for
 the Section `Installing auto-sklearn`_.
 
 A common installation problem under recent Linux distribution is the
-incompability of the compiler version used to compile the Python binary
+incompatibility of the compiler version used to compile the Python binary
 shipped by AnaConda and the compiler installed by the distribution. This can
 be solved by installing the *gcc* compiler shipped with AnaConda (as well as
 *swig*):
@@ -66,8 +66,8 @@ be solved by installing the *gcc* compiler shipped with AnaConda (as well as
     conda install gxx_linux-64 gcc_linux-64 swig
 
 
-Windows/OSX compability
-=======================
+Windows/OSX compatibility
+=========================
 
 Windows
 ~~~~~~~

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -20,8 +20,8 @@ aspects of its usage:
 * `Parallel usage <https://github.com/automl/auto-sklearn/blob/master/example/example_parallel.py>`_
 * `Sequential usage <https://github.com/automl/auto-sklearn/blob/master/example/example_sequential.py>`_
 * `Regression <https://github.com/automl/auto-sklearn/blob/master/example/example_regression.py>`_
-* `Continuous and Categorical Data <https://github.com/automl/auto-sklearn/blob/master/example/example_feature_types.py>`_
-* `Using Custom metrics <https://github.com/automl/auto-sklearn/blob/master/example/example_metrics.py>`_
+* `Continuous and categorical data <https://github.com/automl/auto-sklearn/blob/master/example/example_feature_types.py>`_
+* `Using custom metrics <https://github.com/automl/auto-sklearn/blob/master/example/example_metrics.py>`_
 
 
 Time and memory limits
@@ -44,7 +44,7 @@ time limit of one day, and a time limit of 30 minutes for a single run.
 Further guidelines can be found in
 `auto-sklearn/issues/142 <https://github.com/automl/auto-sklearn/issues/142>`_.
 
-Restricting the Searchspace
+Restricting the searchspace
 ===========================
 
 Instead of using all available estimators, it is possible to restrict


### PR DESCRIPTION
doc/installation.rst
1. fixed all words 'incompability' to 'incompatibility'

doc/manual.rst
1. fixed capitalization issues:
'Continuous and Categorical Data' -> 'Continuous and categorical data'
'Using Custom metrics' -> 'Using custom metrics'
'Restricting the Searchspace' -> Restricting the searchspace'