### PR TITLE
Remove Cython and numpy build dependencies and implement work around …

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,7 @@ recursive-include autosklearn/metalearning/files *.csv
 recursive-include autosklearn/metalearning/files *.txt
 include autosklearn/util/logging.yaml
 recursive-include autosklearn *.pyx
+
+include setup.py
+include requirements.txt
+global-exclude __pycache__

--- a/autosklearn/__init__.py
+++ b/autosklearn/__init__.py
@@ -2,6 +2,10 @@
 import os
 import sys
 
+import warnings
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+
 from autosklearn.util import dependencies
 from autosklearn.__version__ import __version__
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-import logging
 import os
 import sys
 
@@ -31,9 +30,7 @@ class build_ext(_build_ext):
         self.include_dirs.append(numpy.get_include())
 
 extensions = [Extension('autosklearn.data.competition_c_functions',
-               sources=['autosklearn/data/competition_c_functions.pyx'],
-               language='c',)
-     ]
+              sources=['autosklearn/data/competition_c_functions.pyx'])]
 
 setup_requirements = [
     "Cython",
@@ -68,7 +65,7 @@ setuptools.setup(
     name='auto-sklearn',
     description='Automated machine learning.',
     version=version,
-    cmdclass={'build_ext':build_ext},
+    cmdclass={'build_ext': build_ext},
     setup_requires=setup_requirements,
     install_requires=requirements,
     ext_modules=extensions,

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 # -*- encoding: utf-8 -*-
-import setuptools
-from setuptools.extension import Extension
-import numpy as np
-from Cython.Build import cythonize
+import logging
 import os
 import sys
 
+import setuptools
+from setuptools.command.build_ext import build_ext as _build_ext
+from setuptools.extension import Extension
 
 # Check if Auto-sklearn *could* run on the given system
 if os.name != 'posix':
@@ -22,13 +22,23 @@ if sys.version_info < (3, 5):
         '3.5 or higher.' % sys.version_info
     )
 
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
-extensions = cythonize(
-    [Extension('autosklearn.data.competition_c_functions',
+extensions = [Extension('autosklearn.data.competition_c_functions',
                sources=['autosklearn/data/competition_c_functions.pyx'],
-               language='c',
-               include_dirs=[np.get_include()])
-     ])
+               language='c',)
+     ]
+
+setup_requirements = [
+    "Cython",
+    "numpy"
+]
 
 requirements = [
     "setuptools",
@@ -58,9 +68,11 @@ setuptools.setup(
     name='auto-sklearn',
     description='Automated machine learning.',
     version=version,
+    cmdclass={'build_ext':build_ext},
+    setup_requires=setup_requirements,
+    install_requires=requirements,
     ext_modules=extensions,
     packages=setuptools.find_packages(exclude=['test']),
-    install_requires=requirements,
     test_suite='nose.collector',
     include_package_data=True,
     author='Matthias Feurer',


### PR DESCRIPTION
…suggested in:

https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
https://github.com/numpy/numpy/issues/2434
https://github.com/numpy/numpy/pull/432

In order to allow autosklearn to be installed using requirements file. An incremental release to pypi based on this change would be greatly appreciated to clean up dependant project dependencies.