### PR TITLE
Using install_requirements like requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,14 +22,16 @@ lib
 lib64
 __pycache__
 
-# Installer logs
+# Installer trash
 pip-log.txt
+autosklearn/data/competition_c_functions.c
 
 # Unit test / coverage reports
 htmlcov
 .coverage
 .tox
 nosetests.xml
+autosklearn.log
 
 # pycharm
 .idea

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # simple makefile to simplify repetitive build env management tasks under posix
 
 PYTHON ?= python
+PIP ?= pip
 CYTHON ?= cython
 NOSETESTS ?= nosetests
 CTAGS ?= ctags
@@ -29,4 +30,7 @@ test-coverage:
 	rm -rf coverage .coverage
 	$(NOSETESTS) -s -v --with-coverage test
 
-test: test-code test-sphinxext test-doc
+test-install:
+	$(PIP) install -r requirements_test.txt
+
+test: test-install test-code test-sphinxext test-doc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,8 @@
-setuptools
-nose
+numpy>=1.9.0
+scipy>=0.14.1
 
 six
 Cython
-
-numpy>=1.9.0
-scipy>=0.14.1
 
 scikit-learn>=0.19,<0.20
 xgboost==0.80

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ six
 Cython
 
 scikit-learn>=0.19,<0.20
-xgboost==0.80
+xgboost==0.7.post3
 
 lockfile
 joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy>=1.9.0
 scipy>=0.14.1
 
 scikit-learn>=0.19,<0.20
-xgboost==0.7.post3
+xgboost==0.80
 
 lockfile
 joblib

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+setuptools
+nose

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extensions = cythonize(
      ])
 
 with open("requirements.txt") as reqs:
-    requirements = reqs.read().replace("\r").split("\n")
+    requirements = reqs.read().replace("\r", "").split("\n")
 
 with open("autosklearn/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")

--- a/setup.py
+++ b/setup.py
@@ -30,26 +30,8 @@ extensions = cythonize(
                include_dirs=[np.get_include()])
      ])
 
-requirements = [
-    "setuptools",
-    "nose",
-    "six",
-    "Cython",
-    "numpy>=1.9.0",
-    "scipy>=0.14.1",
-    "scikit-learn>=0.19,<0.20",
-    "lockfile",
-    "joblib",
-    "psutil",
-    "pyyaml",
-    "liac-arff",
-    "pandas",
-    "ConfigSpace>=0.4.0,<0.5",
-    "pynisher>=0.4,<0.5",
-    "pyrfr>=0.6.1,<0.8",
-    "smac>=0.8,<0.9",
-    "xgboost==0.7.post3",
-]
+with open("requirements.txt") as reqs:
+    requirements = reqs.read().replace("\r").split("\n")
 
 with open("autosklearn/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")


### PR DESCRIPTION
With this change I don't need this hack anymore: 

curl https://raw.githubusercontent.com/automl/auto-sklearn/master/requirements.txt | xargs -n 1 -L 1 pip install

As follow: https://automl.github.io/auto-sklearn/stable/installation.html