### PR TITLE
Fix broken link in documentation

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -84,7 +84,7 @@ This can be turned off by setting
 Resampling strategies
 =====================
 
-Examples for using holdout and cross-validation can be found in `auto-sklearn/examples/ <https://github.com/automl/auto-sklearn/tree/master/example>`_
+Examples for using holdout and cross-validation can be found in `auto-sklearn/examples/ <https://github.com/automl/auto-sklearn/tree/master/examples>`_
 
 Inspecting the results
 ======================


### PR DESCRIPTION
Small change to fix broken link.

Previous link pointed to `example` directory. Changed to point
to `examples`.