### PR TITLE
Raise error and exit if dummy prediction fails

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -310,8 +310,7 @@ class AutoML(BaseEstimator):
             self._logger.error('Error creating dummy predictions: %s ',
                                str(additional_info))
             # Fail if dummy prediction fails.
-            # Should we provide more details?
-            raise ValueError("Dummy prediction failed!")
+            raise ValueError("Dummy prediction failed: %s " % str(additional_info))
 
         return ta.num_run
 

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -309,6 +309,9 @@ class AutoML(BaseEstimator):
         else:
             self._logger.error('Error creating dummy predictions: %s ',
                                str(additional_info))
+            # Fail if dummy prediction fails.
+            # Should we provide more details?
+            raise ValueError("Dummy prediction failed!")
 
         return ta.num_run
 

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -296,7 +296,7 @@ class AutoMLTest(Base, unittest.TestCase):
         raised = False
         try:
             auto._do_dummy_prediction(D, 1)
-        except:
+        except ValueError:
             raised = True
         self.assertFalse(raised, 'Exception raised')
 

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -19,6 +19,7 @@ import autosklearn.pipeline.util as putil
 from autosklearn.util import setup_logger, get_logger, backend
 from autosklearn.constants import *
 from autosklearn.smbo import load_data
+from smac.tae.execute_ta_run import StatusType
 
 sys.path.append(os.path.dirname(__file__))
 from base import Base
@@ -265,8 +266,72 @@ class AutoMLTest(Base, unittest.TestCase):
             self._tearDown(backend_api.temporary_directory)
             self._tearDown(backend_api.output_directory)
 
-    def test_fail_if_dummy_prediction_fails(self):
-        pass
+    @unittest.mock.patch('autosklearn.evaluation.ExecuteTaFuncWithQueue.run')
+    def test_fail_if_dummy_prediction_fails(self, ta_run_mock):
+        backend_api = self._create_backend('test_fail_if_dummy_prediction_fails')
+
+        dataset = os.path.join(self.test_dir, '..', '.data', '401_bac')
+
+        auto = autosklearn.automl.AutoML(
+            backend_api, 20, 5,
+            initial_configurations_via_metalearning=25)
+        setup_logger()
+        auto._logger = get_logger('test_fail_if_dummy_prediction_fails')
+        auto._backend._make_internals_directory()
+        D = load_data(dataset, backend_api)
+        auto._backend.save_datamanager(D)
+
+        # First of all, check that ta.run() is actually called.
+        ta_run_mock.return_value = StatusType.SUCCESS, None, None, "test"
+        auto._do_dummy_prediction(D, 1)
+        ta_run_mock.assert_called_once()
+
+        # Case 1. Check that function raises no error when statustype == success.
+        # ta.run() returns status, cost, runtime, and additional info.
+        ta_run_mock.return_value = StatusType.SUCCESS, None, None, "test"
+        raised = False
+        try:
+            auto._do_dummy_prediction(D, 1)
+        except:
+            raised = True
+        self.assertFalse(raised, 'Exception raised')
+
+        # Case 2. Check that if statustype returned by ta.run() != success,
+        # the function raises error.
+        ta_run_mock.return_value = StatusType.CRASHED, None, None, "test"
+        self.assertRaisesRegexp(ValueError,
+                                'Dummy prediction failed: test',
+                                auto._do_dummy_prediction,
+                                D, 1,
+                                )
+        ta_run_mock.return_value = StatusType.ABORT, None, None, "test"
+        self.assertRaisesRegexp(ValueError,
+                                'Dummy prediction failed: test',
+                                auto._do_dummy_prediction,
+                                D, 1,
+                                )
+        ta_run_mock.return_value = StatusType.TIMEOUT, None, None, "test"
+        self.assertRaisesRegexp(ValueError,
+                                'Dummy prediction failed: test',
+                                auto._do_dummy_prediction,
+                                D, 1,
+                                )
+        ta_run_mock.return_value = StatusType.MEMOUT, None, None, "test"
+        self.assertRaisesRegexp(ValueError,
+                                'Dummy prediction failed: test',
+                                auto._do_dummy_prediction,
+                                D, 1,
+                                )
+        ta_run_mock.return_value = StatusType.CAPPED, None, None, "test"
+        self.assertRaisesRegexp(ValueError,
+                                'Dummy prediction failed: test',
+                                auto._do_dummy_prediction,
+                                D, 1,
+                                )
+
+        self._tearDown(backend_api.temporary_directory)
+        self._tearDown(backend_api.output_directory)
+
 
 if __name__=="__main__":
     unittest.main()

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -299,35 +299,35 @@ class AutoMLTest(Base, unittest.TestCase):
         # Case 2. Check that if statustype returned by ta.run() != success,
         # the function raises error.
         ta_run_mock.return_value = StatusType.CRASHED, None, None, "test"
-        self.assertRaisesRegexp(ValueError,
-                                'Dummy prediction failed: test',
-                                auto._do_dummy_prediction,
-                                D, 1,
-                                )
+        self.assertRaisesRegex(ValueError,
+                               'Dummy prediction failed: test',
+                               auto._do_dummy_prediction,
+                               D, 1,
+                               )
         ta_run_mock.return_value = StatusType.ABORT, None, None, "test"
-        self.assertRaisesRegexp(ValueError,
-                                'Dummy prediction failed: test',
-                                auto._do_dummy_prediction,
-                                D, 1,
-                                )
+        self.assertRaisesRegex(ValueError,
+                               'Dummy prediction failed: test',
+                               auto._do_dummy_prediction,
+                               D, 1,
+                               )
         ta_run_mock.return_value = StatusType.TIMEOUT, None, None, "test"
-        self.assertRaisesRegexp(ValueError,
-                                'Dummy prediction failed: test',
-                                auto._do_dummy_prediction,
-                                D, 1,
-                                )
+        self.assertRaisesRegex(ValueError,
+                               'Dummy prediction failed: test',
+                               auto._do_dummy_prediction,
+                               D, 1,
+                               )
         ta_run_mock.return_value = StatusType.MEMOUT, None, None, "test"
-        self.assertRaisesRegexp(ValueError,
-                                'Dummy prediction failed: test',
-                                auto._do_dummy_prediction,
-                                D, 1,
-                                )
+        self.assertRaisesRegex(ValueError,
+                               'Dummy prediction failed: test',
+                               auto._do_dummy_prediction,
+                               D, 1,
+                               )
         ta_run_mock.return_value = StatusType.CAPPED, None, None, "test"
-        self.assertRaisesRegexp(ValueError,
-                                'Dummy prediction failed: test',
-                                auto._do_dummy_prediction,
-                                D, 1,
-                                )
+        self.assertRaisesRegex(ValueError,
+                               'Dummy prediction failed: test',
+                               auto._do_dummy_prediction,
+                               D, 1,
+                               )
 
         self._tearDown(backend_api.temporary_directory)
         self._tearDown(backend_api.output_directory)

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -272,9 +272,13 @@ class AutoMLTest(Base, unittest.TestCase):
 
         dataset = os.path.join(self.test_dir, '..', '.data', '401_bac')
 
-        auto = autosklearn.automl.AutoML(
-            backend_api, 20, 5,
-            initial_configurations_via_metalearning=25)
+        time_for_this_task = 30
+        per_run_time = 10
+        auto = autosklearn.automl.AutoML(backend_api,
+                                         time_for_this_task,
+                                         per_run_time,
+                                         initial_configurations_via_metalearning=25,
+                                         )
         setup_logger()
         auto._logger = get_logger('test_fail_if_dummy_prediction_fails')
         auto._backend._make_internals_directory()
@@ -284,7 +288,7 @@ class AutoMLTest(Base, unittest.TestCase):
         # First of all, check that ta.run() is actually called.
         ta_run_mock.return_value = StatusType.SUCCESS, None, None, "test"
         auto._do_dummy_prediction(D, 1)
-        ta_run_mock.assert_called_once()
+        ta_run_mock.assert_called_once_with(1, cutoff=time_for_this_task)
 
         # Case 1. Check that function raises no error when statustype == success.
         # ta.run() returns status, cost, runtime, and additional info.

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -251,7 +251,7 @@ class AutoMLTest(Base, unittest.TestCase):
             auto._backend._make_internals_directory()
             D = load_data(dataset, backend_api)
             auto._backend.save_datamanager(D)
-            auto._do_dummy_prediction(D, 1)
+            a = auto._do_dummy_prediction(D, 1)
 
             # Ensure that the dummy predictions are not in the current working
             # directory, but in the temporary directory.
@@ -265,6 +265,8 @@ class AutoMLTest(Base, unittest.TestCase):
             self._tearDown(backend_api.temporary_directory)
             self._tearDown(backend_api.output_directory)
 
+    def test_fail_if_dummy_prediction_fails(self):
+        pass
 
 if __name__=="__main__":
     unittest.main()

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -252,7 +252,7 @@ class AutoMLTest(Base, unittest.TestCase):
             auto._backend._make_internals_directory()
             D = load_data(dataset, backend_api)
             auto._backend.save_datamanager(D)
-            a = auto._do_dummy_prediction(D, 1)
+            auto._do_dummy_prediction(D, 1)
 
             # Ensure that the dummy predictions are not in the current working
             # directory, but in the temporary directory.


### PR DESCRIPTION
If dummy prediction fails, something is not working right so fail and exit auto-sklearn immediately. Specifically, fail and exit if status != StatusType.SUCCESS in _do_dummy_prediction(), automl.py.