### PR TITLE
Drop sort in get_selected_model_identifiers()

### DIFF
--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -258,8 +258,6 @@ class EnsembleSelection(AbstractEnsemble):
             if weight > 0.0:
                 output.append(identifier)
 
-        output.sort(reverse=True, key=lambda t: t[0])
-
         return output
 
     def get_validation_performance(self):


### PR DESCRIPTION
Remove sorting of identifiers as it seems to have no purpose and messes with ensemble prediction.