### PR TITLE
Add kwargs to AutoMLRegressor init

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1057,6 +1057,9 @@ class AutoMLClassifier(BaseAutoML):
 
 
 class AutoMLRegressor(BaseAutoML):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
     def fit(
         self,
         X: np.ndarray,


### PR DESCRIPTION
`AutoMLRegressor` is currently lacking an `__init___()` method to be able to override default args to `AutoML` base class. This pull requests adds this functionality based on the existing code for `AutoMLClassifier`.

For example, if you would like to specify a new value for `ml_memory_limit` this is not currently possible.