### PR TITLE
resolving #683

### DIFF
--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -398,8 +398,13 @@ class AutoSklearnEstimator(BaseEstimator):
                 kwargs=kwargs,
                 load_models=True,
             )
-            for p in processes:
-                p.join()
+
+            try:
+                for p in processes:
+                    p.join()
+            except KeyboardInterrupt:
+                # To handle the process for _fit_automl is keyboardInterrupted
+                p.terminate()
 
         return self
 


### PR DESCRIPTION
resolving #683

When n_jobs > 1,
The process for function _fit_automl should be terminated
if the process is keyboardInterrupted