### PR TITLE
Add size check before trying to split for GMeans

### DIFF
--- a/autosklearn/metalearning/metalearning/clustering/gmeans.py
+++ b/autosklearn/metalearning/metalearning/clustering/gmeans.py
@@ -36,7 +36,7 @@ class GMeans(object):
 
                     if np.sum(indices) < self.minimum_samples_per_cluster*2:
                         cluster_centers.append(cluster_center)
-                        continue 
+                        continue
 
                     for i in range(10):
                         KMeans_ = sklearn.cluster.KMeans(n_clusters=2,

--- a/autosklearn/metalearning/metalearning/clustering/gmeans.py
+++ b/autosklearn/metalearning/metalearning/clustering/gmeans.py
@@ -34,6 +34,10 @@ class GMeans(object):
                     indices = KMeans.labels_ == i
                     X_ = X[indices]
 
+                    if np.sum(indices) < self.minimum_samples_per_cluster*2:
+                        cluster_centers.append(cluster_center)
+                        continue 
+
                     for i in range(10):
                         KMeans_ = sklearn.cluster.KMeans(n_clusters=2,
                                                          n_init=self.n_init,


### PR DESCRIPTION
This adds a simple check before trying to split the current cluster into two. Since we have the `minimum_samples_per_cluster` parameter, there is no point in trying to split a cluster with less than `self.minimum_samples_per_cluster*2` samples.

This also prevents the algorithm from running into the state where it is trying to split a cluster with just one sample, which could happen if there are some outliers in your data.

You can recreate this problem using the [sample data from HDBSCAN](https://github.com/scikit-learn-contrib/hdbscan/blob/master/notebooks/clusterable_data.npy)

```python
from autosklearn.metalearning.metalearning.clustering.gmeans import GMeans
import numpy as np

data = np.load('clusterable_data.npy')
# Add outliers
data[0][0] = -1
data[0][1] = -1

gmeans = GMeans()
clusters = gmeans.fit_predict(data)
```

And this may result to the following error:
```
ValueError                                Traceback (most recent call last)
<ipython-input-10-e61faf5588d4> in <module>
      1 gmeans = GMeans()
----> 2 clusters = gmeans.fit_predict(data)
      3 clusters

<ipython-input-9-5b649f70193c> in fit_predict(self, X)
     82 
     83     def fit_predict(self, X):
---> 84         self.fit(X)
     85         predictions = self.KMeans.predict(X)
     86         return predictions

<ipython-input-9-5b649f70193c> in fit(self, X)
     37                                                          n_init=self.n_init,
     38                                                          random_state=self.random_state)
---> 39                         predictions = KMeans_.fit_predict(X_)
     40                         bins = np.bincount(predictions)
     41                         minimum = np.min(bins)

~/anaconda3/envs/tm/lib/python3.7/site-packages/sklearn/cluster/k_means_.py in fit_predict(self, X, y, sample_weight)
    996             Index of the cluster each sample belongs to.
    997         """
--> 998         return self.fit(X, sample_weight=sample_weight).labels_
    999 
   1000     def fit_transform(self, X, y=None, sample_weight=None):

~/anaconda3/envs/tm/lib/python3.7/site-packages/sklearn/cluster/k_means_.py in fit(self, X, y, sample_weight)
    970                 tol=self.tol, random_state=random_state, copy_x=self.copy_x,
    971                 n_jobs=self.n_jobs, algorithm=self.algorithm,
--> 972                 return_n_iter=True)
    973         return self
    974 

~/anaconda3/envs/tm/lib/python3.7/site-packages/sklearn/cluster/k_means_.py in k_means(X, n_clusters, sample_weight, init, precompute_distances, n_init, max_iter, verbose, tol, random_state, copy_x, n_jobs, algorithm, return_n_iter)
    314     if _num_samples(X) < n_clusters:
    315         raise ValueError("n_samples=%d should be >= n_clusters=%d" % (
--> 316             _num_samples(X), n_clusters))
    317 
    318     tol = _tolerance(X, tol)

ValueError: n_samples=1 should be >= n_clusters=2
```
