### PR TITLE
fix for n_jobs=-1, resolves #692

### DIFF
--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Dict
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.utils.multiclass import type_of_target
+import joblib
 
 from autosklearn.automl import AutoMLClassifier, AutoMLRegressor, BaseAutoML
 from autosklearn.util.backend import create, get_randomized_directory_names
@@ -343,7 +344,7 @@ class AutoSklearnEstimator(BaseEstimator):
             )
 
             if self.n_jobs == -1:
-                self._n_jobs = get_number_of_available_cores()
+                self._n_jobs = joblib.cpu_count()
             else:
                 self._n_jobs = self.n_jobs
 
@@ -828,18 +829,3 @@ class AutoSklearnRegressor(AutoSklearnEstimator):
         return AutoMLRegressor
 
 
-def get_number_of_available_cores():
-    """
-    Returns the number of available logical cores on the system
-    First tries to use os.sched_getaffinity, if it is not available use os.cpu_count
-    :return: Number of cores, int
-    """
-
-    try:
-        n = len(os.sched_getaffinity(0))
-    except AttributeError:
-        n = os.cpu_count()
-
-    if n is None:
-        return 1
-    return n

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+import os
 import copy
 import multiprocessing
 from typing import Optional, List, Dict
@@ -341,7 +342,11 @@ class AutoSklearnEstimator(BaseEstimator):
                 output_directory=self.output_folder,
             )
 
-            self._n_jobs = self.n_jobs
+            if self.n_jobs == -1:
+                self._n_jobs = get_number_of_available_cores()
+            else:
+                self._n_jobs = self.n_jobs
+
             shared_mode = True
             seeds = set()
             for i in range(self._n_jobs):
@@ -821,3 +826,20 @@ class AutoSklearnRegressor(AutoSklearnEstimator):
 
     def _get_automl_class(self):
         return AutoMLRegressor
+
+
+def get_number_of_available_cores():
+    """
+    Returns the number of available logical cores on the system
+    First tries to use os.sched_getaffinity, if it is not available use os.cpu_count
+    :return: Number of cores, int
+    """
+
+    try:
+        n = len(os.sched_getaffinity(0))
+    except AttributeError:
+        n = os.cpu_count()
+
+    if n is None:
+        return 1
+    return n

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-import os
 import copy
 import multiprocessing
 from typing import Optional, List, Dict
@@ -514,7 +513,6 @@ class AutoSklearnEstimator(BaseEstimator):
         self._automl[0].refit(X, y)
         return self
 
-
     def predict(self, X, batch_size=None, n_jobs=1):
         return self._automl[0].predict(X, batch_size=batch_size, n_jobs=n_jobs)
 
@@ -827,5 +825,3 @@ class AutoSklearnRegressor(AutoSklearnEstimator):
 
     def _get_automl_class(self):
         return AutoMLRegressor
-
-

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -11,7 +11,7 @@ import numpy.ma as npma
 
 import autosklearn.pipeline.util as putil
 import autosklearn.estimators
-from autosklearn.estimators import AutoSklearnEstimator, get_number_of_available_cores
+from autosklearn.estimators import AutoSklearnEstimator
 from autosklearn.classification import AutoSklearnClassifier
 from autosklearn.regression import AutoSklearnRegressor
 from autosklearn.metrics import accuracy, f1_macro, mean_squared_error
@@ -20,7 +20,7 @@ from autosklearn.util.backend import Backend, BackendContext
 from autosklearn.constants import BINARY_CLASSIFICATION
 sys.path.append(os.path.dirname(__file__))
 from base import Base
-
+from joblib import cpu_count
 
 class ArrayReturningDummyPredictor(object):
     def __init__(self, test):
@@ -482,33 +482,14 @@ class EstimatorTest(Base, unittest.TestCase):
 
     @unittest.mock.patch('autosklearn.estimators.AutoSklearnEstimator.build_automl')
     def test_fit_n_jobs_negative(self, build_automl_patch):
-        n_cores = get_number_of_available_cores()
+        n_cores = cpu_count()
         cls = AutoSklearnEstimator(n_jobs=-1)
         cls.fit()
         self.assertEqual(len(cls._automl), n_cores)
 
     def test_get_number_of_available_cores(self):
-        n_cores = get_number_of_available_cores()
+        n_cores = cpu_count()
         self.assertGreaterEqual(n_cores, 1)
-
-    @unittest.mock.patch('autosklearn.estimators.os.sched_getaffinity')
-    def test_get_number_of_available_cores_overwrite_function(self, mocked):
-        mocked.return_value = {1, 2, 3, 4}
-        self.assertEqual(get_number_of_available_cores(), 4)
-
-    @unittest.mock.patch('autosklearn.estimators.os')
-    def test_get_number_of_available_cores_no_linux(self, mocked_os):
-        delattr(mocked_os, 'sched_getaffinity')
-        mocked_os.cpu_count.return_value = -1
-        self.assertEqual(autosklearn.estimators.os.cpu_count(), -1)
-        self.assertEqual(get_number_of_available_cores(), -1)
-
-    @unittest.mock.patch('autosklearn.estimators.os')
-    def test_get_number_of_available_cores_undefined(self, mocked_os):
-        delattr(mocked_os, 'sched_getaffinity')
-        mocked_os.cpu_count.return_value = None
-        self.assertEqual(autosklearn.estimators.os.cpu_count(), None)
-        self.assertEqual(get_number_of_available_cores(), 1)
 
 
 class AutoMLClassifierTest(Base, unittest.TestCase):

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -9,6 +9,8 @@ import sklearn
 import numpy as np
 import numpy.ma as npma
 
+from joblib import cpu_count
+
 import autosklearn.pipeline.util as putil
 import autosklearn.estimators
 from autosklearn.estimators import AutoSklearnEstimator
@@ -18,9 +20,9 @@ from autosklearn.metrics import accuracy, f1_macro, mean_squared_error
 from autosklearn.automl import AutoMLClassifier, AutoML
 from autosklearn.util.backend import Backend, BackendContext
 from autosklearn.constants import BINARY_CLASSIFICATION
-sys.path.append(os.path.dirname(__file__))
 from base import Base
-from joblib import cpu_count
+
+sys.path.append(os.path.dirname(__file__))
 
 class ArrayReturningDummyPredictor(object):
     def __init__(self, test):

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -12,7 +12,7 @@ import numpy.ma as npma
 from joblib import cpu_count
 
 import autosklearn.pipeline.util as putil
-import autosklearn.estimators
+import autosklearn.estimators  # noqa F401
 from autosklearn.estimators import AutoSklearnEstimator
 from autosklearn.classification import AutoSklearnClassifier
 from autosklearn.regression import AutoSklearnRegressor


### PR DESCRIPTION
* Setting `n_jobs=-1` as described in the documentation throws an `IndexError` (see #692)
* The PR addresses this issue, `n_jobs` will be determined based on the number of logical cores available for the process
* Tried to make the changes as gentle as possible and future proof (works with OS other than Linux hopefully)
* Unittests were addded for possible flows