### PR TITLE
update SimpleClassificationPipeline docstring to match class parameters

### DIFF
--- a/autosklearn/pipeline/classification.py
+++ b/autosklearn/pipeline/classification.py
@@ -41,7 +41,7 @@ class SimpleClassificationPipeline(ClassifierMixin, BasePipeline):
 
     Parameters
     ----------
-    configuration : ConfigSpace.configuration_space.Configuration
+    config : ConfigSpace.configuration_space.Configuration
         The configuration to evaluate.
 
     random_state : int, RandomState instance or None, optional (default=None)


### PR DESCRIPTION
pretty straightforward change: replace `configuration` with `config` in the docstring of `SimpleClassificationPipeline`

I was also thinking of adding a short section in the docs hosted `https://automl.github.io/auto-sklearn/master/` about how to use this class given the results of `AutoSklearnClassifier`. any pointers as to where that should live in the hierarchy of docs? **Examples** or **Manual**? 