### PR TITLE
Replace the use of the now-removed time.clock.

### DIFF
--- a/autosklearn/util/stopwatch.py
+++ b/autosklearn/util/stopwatch.py
@@ -21,12 +21,12 @@ class TimingTask(object):
 
     def __init__(self, name):
         self._name = name
-        self._cpu_tic = time.clock()
+        self._cpu_tic = time.process_time()
         self._wall_tic = time.time()
 
     def stop(self):
         if not self._cpu_tac:
-            self._cpu_tac = time.clock()
+            self._cpu_tac = time.process_time()
             self._wall_tac = time.time()
             self._cpu_dur = self._cpu_tac - self._cpu_tic
             self._wall_dur = self._wall_tac - self._wall_tic
@@ -96,7 +96,7 @@ class StopWatch:
                 return self._tasks[name].wall_dur
 
     def cpu_elapsed(self, name):
-        tmp = time.clock()
+        tmp = time.process_time()
         if name in self._tasks:
             if not self._tasks[name].cpu_dur:
                 tsk_start = self._tasks[name].cpu_tic

--- a/test/test_util/test_StopWatch.py
+++ b/test/test_util/test_StopWatch.py
@@ -19,12 +19,12 @@ class Test(unittest.TestCase):
 
         # Wall Overhead
         start = time.time()
-        cpu_start = time.clock()
+        cpu_start = time.process_time()
         watch = StopWatch()
         for i in range(1, 1000):
             watch.start_task('task_%d' % i)
             watch.stop_task('task_%d' % i)
-        cpu_stop = time.clock()
+        cpu_stop = time.process_time()
         stop = time.time()
         dur = stop - start
         cpu_dur = cpu_stop - cpu_start


### PR DESCRIPTION
It no longer exists on 3.8, and has been deprecated
since 3.3.

See e.g. https://docs.python.org/3.5/library/time.html#time.clock

It was replaced by `time.process_time` and `time.perf_counter` (basically because `time.clock` was always platform-specific behavior anyhow) -- empirically it *seems* like the one that was intended was `time.process_time` here, so that's what I replaced it with, but in case the other was intended obviously can change.