### PR TITLE
Origin/py 3 8 warns rebase changes

### DIFF
--- a/autosklearn/evaluation/train_evaluator.py
+++ b/autosklearn/evaluation/train_evaluator.py
@@ -1010,9 +1010,10 @@ class TrainEvaluator(AbstractEvaluator):
             elif self.resampling_strategy in ['cv', 'partial-cv',
                                               'partial-cv-iterative-fit']:
                 random_state = 1 if shuffle else None
-                cv = KFold(n_splits=self.resampling_strategy_args['folds'],
-                           shuffle=shuffle,
-                           random_state=random_state,
+                cv = KFold(
+                    n_splits=self.resampling_strategy_args['folds'],
+                    shuffle=shuffle,
+                    random_state=random_state,
                 )
             else:
                 raise ValueError(self.resampling_strategy)

--- a/autosklearn/evaluation/train_evaluator.py
+++ b/autosklearn/evaluation/train_evaluator.py
@@ -991,7 +991,7 @@ class TrainEvaluator(AbstractEvaluator):
                         shuffle=shuffle, random_state=1)
                 else:
                     cv = KFold(n_splits=self.resampling_strategy_args['folds'],
-                               shuffle=shuffle, random_state=1)
+                               shuffle=shuffle)
             else:
                 raise ValueError(self.resampling_strategy)
         else:
@@ -1009,8 +1009,11 @@ class TrainEvaluator(AbstractEvaluator):
                     cv.n_splits = 1  # As sklearn is inconsistent here
             elif self.resampling_strategy in ['cv', 'partial-cv',
                                               'partial-cv-iterative-fit']:
+                random_state = 1 if shuffle else None
                 cv = KFold(n_splits=self.resampling_strategy_args['folds'],
-                           shuffle=shuffle, random_state=1)
+                           shuffle=shuffle,
+                           random_state=random_state,
+                )
             else:
                 raise ValueError(self.resampling_strategy)
         return cv

--- a/autosklearn/pipeline/components/regression/sgd.py
+++ b/autosklearn/pipeline/components/regression/sgd.py
@@ -40,7 +40,7 @@ class SGD(
         return 1024
 
     def iterative_fit(self, X, y, n_iter=2, refit=False):
-        from sklearn.linear_model.stochastic_gradient import SGDRegressor
+        from sklearn.linear_model import SGDRegressor
         import sklearn.preprocessing
 
         # Need to fit at least two iterations, otherwise early stopping will not

--- a/scripts/2015_nips_paper/run/score_ensemble.py
+++ b/scripts/2015_nips_paper/run/score_ensemble.py
@@ -4,8 +4,8 @@ import glob
 import os
 import time
 
+import joblib
 import numpy as np
-import sklearn.externals.joblib as joblib
 
 from autosklearn.ensembles.ensemble_selection import EnsembleSelection
 from autosklearn.metrics import balanced_accuracy

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -58,7 +58,7 @@ class EstimatorTest(Base, unittest.TestCase):
     def test_pSMAC_wrong_arguments(self):
         X = np.zeros((100, 100))
         y = np.zeros((100, ))
-        self.assertRaisesRegexp(ValueError,
+        self.assertRaisesRegex(ValueError,
                                 "If shared_mode == True tmp_folder must not "
                                 "be None.",
                                 lambda shared_mode:
@@ -67,7 +67,7 @@ class EstimatorTest(Base, unittest.TestCase):
                                 ).fit(X, y),
                                 shared_mode=True)
 
-        self.assertRaisesRegexp(ValueError,
+        self.assertRaisesRegex(ValueError,
                                 "If shared_mode == True output_folder must not "
                                 "be None.",
                                 lambda shared_mode, tmp_folder:
@@ -82,18 +82,18 @@ class EstimatorTest(Base, unittest.TestCase):
         cls = AutoSklearnClassifier()
         X = np.zeros((100, 100))
         y = np.zeros((100, ))
-        self.assertRaisesRegexp(ValueError,
+        self.assertRaisesRegex(ValueError,
                                 'Array feat_type does not have same number of '
                                 'variables as X has features. 1 vs 100.',
                                 cls.fit,
                                 X=X, y=y, feat_type=[True])
 
-        self.assertRaisesRegexp(ValueError,
+        self.assertRaisesRegex(ValueError,
                                 'Array feat_type must only contain strings.',
                                 cls.fit,
                                 X=X, y=y, feat_type=[True]*100)
 
-        self.assertRaisesRegexp(ValueError,
+        self.assertRaisesRegex(ValueError,
                                 'Only `Categorical` and `Numerical` are '
                                 'valid feature types, you passed `Car`',
                                 cls.fit,

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -58,46 +58,56 @@ class EstimatorTest(Base, unittest.TestCase):
     def test_pSMAC_wrong_arguments(self):
         X = np.zeros((100, 100))
         y = np.zeros((100, ))
-        self.assertRaisesRegex(ValueError,
-                                "If shared_mode == True tmp_folder must not "
-                                "be None.",
-                                lambda shared_mode:
-                                AutoSklearnClassifier(
-                                    shared_mode=shared_mode,
-                                ).fit(X, y),
-                                shared_mode=True)
+        self.assertRaisesRegex(
+            ValueError,
+            "If shared_mode == True tmp_folder must not "
+            "be None.",
+            lambda shared_mode:
+            AutoSklearnClassifier(
+                shared_mode=shared_mode,
+            ).fit(X, y),
+            shared_mode=True
+        )
 
-        self.assertRaisesRegex(ValueError,
-                                "If shared_mode == True output_folder must not "
-                                "be None.",
-                                lambda shared_mode, tmp_folder:
-                                AutoSklearnClassifier(
-                                    shared_mode=shared_mode,
-                                    tmp_folder=tmp_folder,
-                                ).fit(X, y),
-                                shared_mode=True,
-                                tmp_folder='/tmp/duitaredxtvbedb')
+        self.assertRaisesRegex(
+            ValueError,
+            "If shared_mode == True output_folder must not "
+            "be None.",
+            lambda shared_mode, tmp_folder:
+            AutoSklearnClassifier(
+                shared_mode=shared_mode,
+                tmp_folder=tmp_folder,
+            ).fit(X, y),
+            shared_mode=True,
+            tmp_folder='/tmp/duitaredxtvbedb'
+        )
 
     def test_feat_type_wrong_arguments(self):
         cls = AutoSklearnClassifier()
         X = np.zeros((100, 100))
         y = np.zeros((100, ))
-        self.assertRaisesRegex(ValueError,
-                                'Array feat_type does not have same number of '
-                                'variables as X has features. 1 vs 100.',
-                                cls.fit,
-                                X=X, y=y, feat_type=[True])
+        self.assertRaisesRegex(
+            ValueError,
+            'Array feat_type does not have same number of '
+            'variables as X has features. 1 vs 100.',
+            cls.fit,
+            X=X, y=y, feat_type=[True]
+        )
 
-        self.assertRaisesRegex(ValueError,
-                                'Array feat_type must only contain strings.',
-                                cls.fit,
-                                X=X, y=y, feat_type=[True]*100)
+        self.assertRaisesRegex(
+            ValueError,
+            'Array feat_type must only contain strings.',
+            cls.fit,
+            X=X, y=y, feat_type=[True]*100
+        )
 
-        self.assertRaisesRegex(ValueError,
-                                'Only `Categorical` and `Numerical` are '
-                                'valid feature types, you passed `Car`',
-                                cls.fit,
-                                X=X, y=y, feat_type=['Car']*100)
+        self.assertRaisesRegex(
+            ValueError,
+            'Only `Categorical` and `Numerical` are '
+            'valid feature types, you passed `Car`',
+            cls.fit,
+            X=X, y=y, feat_type=['Car']*100
+        )
 
     # Mock AutoSklearnEstimator.fit so the test doesn't actually run fit().
     @unittest.mock.patch('autosklearn.estimators.AutoSklearnEstimator.fit')
@@ -179,29 +189,32 @@ class EstimatorTest(Base, unittest.TestCase):
         reg = AutoSklearnRegressor()
         # Illegal target types for regression: multiclass-multioutput,
         # multilabel-indicator, continuous-multioutput.
-        self.assertRaisesRegex(ValueError,
-                               "regression with data of type"
-                               " multiclass-multioutput is not supported",
-                               reg.fit,
-                               X=X,
-                               y=y_multiclass_multioutput,
-                               )
+        self.assertRaisesRegex(
+            ValueError,
+            "regression with data of type"
+            " multiclass-multioutput is not supported",
+            reg.fit,
+            X=X,
+            y=y_multiclass_multioutput,
+        )
 
-        self.assertRaisesRegex(ValueError,
-                               "regression with data of type"
-                               " multilabel-indicator is not supported",
-                               reg.fit,
-                               X=X,
-                               y=y_multilabel,
-                               )
+        self.assertRaisesRegex(
+            ValueError,
+            "regression with data of type"
+            " multilabel-indicator is not supported",
+            reg.fit,
+            X=X,
+            y=y_multilabel,
+        )
 
-        self.assertRaisesRegex(ValueError,
-                               "regression with data of type"
-                               " continuous-multioutput is not supported",
-                               reg.fit,
-                               X=X,
-                               y=y_continuous_multioutput,
-                               )
+        self.assertRaisesRegex(
+            ValueError,
+            "regression with data of type"
+            " continuous-multioutput is not supported",
+            reg.fit,
+            X=X,
+            y=y_continuous_multioutput,
+        )
         # Legal target types: continuous, binary, multiclass
         try:
             reg.fit(X, y_continuous)

--- a/test/test_data/test_data_manager.py
+++ b/test/test_data/test_data_manager.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy as np
-from sklearn.utils.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 
 from autosklearn.data.abstract_data_manager import AbstractDataManager
 

--- a/test/test_data/test_data_manager.py
+++ b/test/test_data/test_data_manager.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 from autosklearn.data.abstract_data_manager import AbstractDataManager
 
@@ -44,9 +43,9 @@ class CompetitionDataManagerTest(unittest.TestCase):
         self.D._info = {'is_sparse': 0, 'has_missing': 0}
         self.D.perform1HotEncoding()
 
-        assert_array_almost_equal(dataset_train, self.D.data['X_train'])
-        assert_array_almost_equal(dataset_valid, self.D.data['X_valid'])
-        assert_array_almost_equal(dataset_test, self.D.data['X_test'])
+        np.testing.assert_array_almost_equal(dataset_train, self.D.data['X_train'])
+        np.testing.assert_array_almost_equal(dataset_valid, self.D.data['X_valid'])
+        np.testing.assert_array_almost_equal(dataset_test, self.D.data['X_test'])
         self.assertIsInstance(self.D.data['X_train'], np.ndarray)
         self.assertIsInstance(self.D.data['X_valid'], np.ndarray)
         self.assertIsInstance(self.D.data['X_test'], np.ndarray)
@@ -57,9 +56,9 @@ class CompetitionDataManagerTest(unittest.TestCase):
         self.D.perform1HotEncoding()
 
         # Nothing should have happened to the array...
-        assert_array_almost_equal(dataset_train, self.D.data['X_train'])
-        assert_array_almost_equal(dataset_valid, self.D.data['X_valid'])
-        assert_array_almost_equal(dataset_test, self.D.data['X_test'])
+        np.testing.assert_array_almost_equal(dataset_train, self.D.data['X_train'])
+        np.testing.assert_array_almost_equal(dataset_valid, self.D.data['X_valid'])
+        np.testing.assert_array_almost_equal(dataset_test, self.D.data['X_test'])
         self.assertIsInstance(self.D.data['X_train'], np.ndarray)
         self.assertIsInstance(self.D.data['X_valid'], np.ndarray)
         self.assertIsInstance(self.D.data['X_test'], np.ndarray)

--- a/test/test_metalearning/pyMetaLearn/metalearning/test_kND.py
+++ b/test/test_metalearning/pyMetaLearn/metalearning/test_kND.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 from autosklearn.metalearning.metalearning.kNearestDatasets.kND import KNearestDatasets
 from autosklearn.metalearning.metalearning.metrics.misc import get_random_metric
-from sklearn.utils.testing import assert_array_almost_equal
 
 
 class kNDTest(unittest.TestCase):
@@ -43,21 +42,21 @@ class kNDTest(unittest.TestCase):
         neighbor, distance = kND.kNearestDatasets(self.anneal, 1,
                                                   return_distance=True)
         self.assertEqual([233], neighbor)
-        assert_array_almost_equal([1.82298937], distance)
+        np.testing.assert_array_almost_equal([1.82298937], distance)
 
         neighbors = kND.kNearestDatasets(self.anneal, 2)
         self.assertEqual([233, 234], neighbors)
         neighbors, distance = kND.kNearestDatasets(self.anneal, 2,
                                                    return_distance=True)
         self.assertEqual([233, 234], neighbors)
-        assert_array_almost_equal([1.822989, 2.267919], distance)
+        np.testing.assert_array_almost_equal([1.822989, 2.267919], distance)
 
         neighbors = kND.kNearestDatasets(self.anneal, -1)
         self.assertEqual([233, 234], neighbors)
         neighbors, distance = kND.kNearestDatasets(self.anneal, -1,
                                                    return_distance=True)
         self.assertEqual([233, 234], neighbors)
-        assert_array_almost_equal([1.822989, 2.267919], distance)
+        np.testing.assert_array_almost_equal([1.822989, 2.267919], distance)
 
         self.assertRaises(ValueError, kND.kNearestDatasets, self.anneal, 0)
         self.assertRaises(ValueError, kND.kNearestDatasets, self.anneal, -2)

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -210,7 +210,13 @@ class BaseClassificationComponentTest(unittest.TestCase):
             cls = self.sk_module
             X = np.random.random((10, 10))
             y = np.random.randint(0, 1, size=(10, 10))
-            self.assertRaisesRegexp(ValueError, r'bad input shape \(10, 10\)', cls.fit, X, y)
+            self.assertRaisesRegex(
+                ValueError,
+                'bad input shape \\(10, 10\\)',
+                cls.fit,
+                X,
+                y
+            )
         else:
             return
 

--- a/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_numerical.py
+++ b/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_numerical.py
@@ -1,8 +1,8 @@
 import unittest
 import numpy as np
-from scipy import sparse
+from numpy.testing import assert_array_almost_equal
 
-from sklearn.utils.testing import assert_array_almost_equal
+from scipy import sparse
 
 from autosklearn.pipeline.components.data_preprocessing.data_preprocessing_numerical \
     import NumericalPreprocessingPipeline

--- a/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_numerical.py
+++ b/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_numerical.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 from scipy import sparse
 
@@ -36,7 +35,7 @@ class NumericalPreprocessingPipelineTest(unittest.TestCase):
             [ 1/sdev,  1/sdev]])  # noqa : matrix legibility
         # dense input
         Yt = NumericalPreprocessingPipeline().fit_transform(X)
-        assert_array_almost_equal(Yt, Y1)
+        np.testing.assert_array_almost_equal(Yt, Y1)
         # sparse input (uses with_mean=False)
         Y2 = np.array([
             [1., 1.],
@@ -44,7 +43,7 @@ class NumericalPreprocessingPipelineTest(unittest.TestCase):
             [3., 3.]]) / sdev
         X_sparse = sparse.csc_matrix(X)
         Yt = NumericalPreprocessingPipeline().fit_transform(X_sparse)
-        assert_array_almost_equal(Yt.todense(), Y2)
+        np.testing.assert_array_almost_equal(Yt.todense(), Y2)
 
     def test_transform(self):
         X1 = np.array([
@@ -67,4 +66,4 @@ class NumericalPreprocessingPipelineTest(unittest.TestCase):
             [3/sdev, 6/sdev],
             [4/sdev, 7/sdev],
             [5/sdev,     0.]])  # noqa : matrix legibility
-        assert_array_almost_equal(Yt, Y2)
+        np.testing.assert_array_almost_equal(Yt, Y2)

--- a/test/test_pipeline/components/data_preprocessing/test_minority_coalescence.py
+++ b/test/test_pipeline/components/data_preprocessing/test_minority_coalescence.py
@@ -1,7 +1,8 @@
 import unittest
 import numpy as np
+from numpy.testing import assert_array_almost_equal
+
 import scipy.sparse
-from sklearn.utils.testing import assert_array_almost_equal
 
 from autosklearn.pipeline.components.data_preprocessing.minority_coalescense\
     .minority_coalescer import MinorityCoalescer

--- a/test/test_pipeline/components/data_preprocessing/test_minority_coalescence.py
+++ b/test/test_pipeline/components/data_preprocessing/test_minority_coalescence.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 import scipy.sparse
 
@@ -25,6 +24,6 @@ class MinorityCoalescerTest(unittest.TestCase):
     def test_no_coalescence(self):
         X = np.random.randint(0, 255, (3, 4))
         Y = NoCoalescence().fit_transform(X)
-        assert_array_almost_equal(Y, X)
+        np.testing.assert_array_almost_equal(Y, X)
         # Assert no copies were made
         self.assertEqual(id(X), id(Y))

--- a/test/test_pipeline/implementations/test_MinorityCoalescer.py
+++ b/test/test_pipeline/implementations/test_MinorityCoalescer.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 import scipy.sparse
 
@@ -43,7 +42,7 @@ class MinorityCoalescerTest(unittest.TestCase):
         X = self.X1
         X_copy = np.copy(X)
         Y = MinorityCoalescer().fit_transform(X)
-        assert_array_almost_equal(Y, X_copy)
+        np.testing.assert_array_almost_equal(Y, X_copy)
         # Assert no copies were made
         self.assertEqual(id(X), id(Y))
 
@@ -52,7 +51,7 @@ class MinorityCoalescerTest(unittest.TestCase):
         Y = MinorityCoalescer(minimum_fraction=.1).fit_transform(X)
         for col in range(Y.shape[1]):
             hist = np.histogram(Y[:, col], bins=np.arange(1, 7))
-            assert_array_almost_equal(hist[0], [10, 0, 30, 30, 30])
+            np.testing.assert_array_almost_equal(hist[0], [10, 0, 30, 30, 30])
         # Assert no copies were made
         self.assertEqual(id(X), id(Y))
 
@@ -64,7 +63,7 @@ class MinorityCoalescerTest(unittest.TestCase):
         Y = Y.todense()
         for col in range(Y.shape[1]):
             hist = np.histogram(Y[:, col], bins=np.arange(1, 7))
-            assert_array_almost_equal(hist[0], [10, 0, 30, 30, 30])
+            np.testing.assert_array_almost_equal(hist[0], [10, 0, 30, 30, 30])
 
     def test_invalid_X(self):
         X = self.X1 - 2
@@ -83,4 +82,4 @@ class MinorityCoalescerTest(unittest.TestCase):
         Y = mc.transform(X_transf)
         for col in range(Y.shape[1]):
             hist = np.histogram(Y[:, col], bins=np.arange(1, 7))
-            assert_array_almost_equal(hist[0], [85, 0, 5, 5, 5])
+            np.testing.assert_array_almost_equal(hist[0], [85, 0, 5, 5, 5])

--- a/test/test_pipeline/implementations/test_MinorityCoalescer.py
+++ b/test/test_pipeline/implementations/test_MinorityCoalescer.py
@@ -1,7 +1,8 @@
 import unittest
 import numpy as np
+from numpy.testing import assert_array_almost_equal
+
 import scipy.sparse
-from sklearn.utils.testing import assert_array_almost_equal
 
 from autosklearn.pipeline.implementations.MinorityCoalescer import MinorityCoalescer
 

--- a/test/test_pipeline/implementations/test_SparseOneHotEncoder.py
+++ b/test/test_pipeline/implementations/test_SparseOneHotEncoder.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 import scipy.sparse
 import openml
@@ -53,7 +52,7 @@ class TestSparseOneHotEncoder(unittest.TestCase):
         ohe = SparseOneHotEncoder()
         transformation = ohe.fit_transform(input)
         self.assertIsInstance(transformation, scipy.sparse.csr_matrix)
-        assert_array_almost_equal(expected.astype(float),
+        np.testing.assert_array_almost_equal(expected.astype(float),
                                   transformation.todense())
         self._check_arrays_equal(input, input_copy)
 
@@ -62,7 +61,7 @@ class TestSparseOneHotEncoder(unittest.TestCase):
         ohe2.fit(input)
         transformation = ohe2.transform(input)
         self.assertIsInstance(transformation, scipy.sparse.csr_matrix)
-        assert_array_almost_equal(expected, transformation.todense())
+        np.testing.assert_array_almost_equal(expected, transformation.todense())
         self._check_arrays_equal(input, input_copy)
 
     def _check_arrays_equal(self, a1, a2):
@@ -70,7 +69,7 @@ class TestSparseOneHotEncoder(unittest.TestCase):
             a1 = a1.toarray()
         if scipy.sparse.issparse(a2):
             a2 = a2.toarray()
-        assert_array_almost_equal(a1, a2)
+        np.testing.assert_array_almost_equal(a1, a2)
 
     def test_transform_with_unknown_value(self):
         # fit_data: this is going to be used to fit.

--- a/test/test_pipeline/implementations/test_SparseOneHotEncoder.py
+++ b/test/test_pipeline/implementations/test_SparseOneHotEncoder.py
@@ -1,6 +1,8 @@
 import unittest
 
 import numpy as np
+from numpy.testing import assert_array_almost_equal
+
 import scipy.sparse
 import openml
 import sklearn.tree
@@ -9,7 +11,6 @@ import sklearn.model_selection
 import sklearn.pipeline
 from sklearn.impute import SimpleImputer
 from sklearn.tree import DecisionTreeClassifier
-from sklearn.utils.testing import assert_array_almost_equal
 
 from autosklearn.pipeline.implementations.SparseOneHotEncoder import SparseOneHotEncoder
 from autosklearn.pipeline.implementations.CategoryShift import CategoryShift

--- a/test/test_pipeline/implementations/test_SparseOneHotEncoder.py
+++ b/test/test_pipeline/implementations/test_SparseOneHotEncoder.py
@@ -52,8 +52,10 @@ class TestSparseOneHotEncoder(unittest.TestCase):
         ohe = SparseOneHotEncoder()
         transformation = ohe.fit_transform(input)
         self.assertIsInstance(transformation, scipy.sparse.csr_matrix)
-        np.testing.assert_array_almost_equal(expected.astype(float),
-                                  transformation.todense())
+        np.testing.assert_array_almost_equal(
+            expected.astype(float),
+            transformation.todense()
+        )
         self._check_arrays_equal(input, input_copy)
 
         # Test fit, and afterwards transform

--- a/test/test_pipeline/implementations/test_util.py
+++ b/test/test_pipeline/implementations/test_util.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy as np
-from sklearn.utils.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 
 from autosklearn.pipeline.implementations.util import softmax
 

--- a/test/test_pipeline/implementations/test_util.py
+++ b/test/test_pipeline/implementations/test_util.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 from autosklearn.pipeline.implementations.util import softmax
 
@@ -16,7 +15,7 @@ class UtilTest(unittest.TestCase):
                        -33.10196906, 26.84144377, -36.8569686])
         probas = softmax(df)
         expected = [[1., 0.] if d < 0. else [0., 1.] for d in df]
-        assert_array_almost_equal(expected, probas)
+        np.testing.assert_array_almost_equal(expected, probas)
 
     def test_softmax(self):
         df = np.array([[2.75021367e+10, -8.83772371e-01, -2.20516715e+27],
@@ -33,4 +32,4 @@ class UtilTest(unittest.TestCase):
         probas = softmax(df)
         expected = np.array([[0.25838965, 0.42601251, 0.31559783],
                              [0.28943311, 0.31987306, 0.39069383]])
-        assert_array_almost_equal(expected, probas)
+        np.testing.assert_array_almost_equal(expected, probas)

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -6,14 +6,15 @@ import traceback
 import unittest
 import unittest.mock
 
+from joblib import Memory
 import numpy as np
+from numpy.testing import assert_array_almost_equal
+
 import sklearn.datasets
 import sklearn.decomposition
 import sklearn.model_selection
 import sklearn.ensemble
 import sklearn.svm
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.externals.joblib import Memory
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
@@ -426,7 +427,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         )
 
     def test_get_hyperparameter_search_space_only_forbidden_combinations(self):
-        self.assertRaisesRegexp(AssertionError, "No valid pipeline found.",
+        self.assertRaisesRegex(AssertionError, "No valid pipeline found.",
                                 SimpleClassificationPipeline,
                                 include={'classifier': ['multinomial_nb'],
                                          'feature_preprocessor': ['pca']},
@@ -434,7 +435,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
 
         # It must also be catched that no classifiers which can handle sparse
         #  data are located behind the densifier
-        self.assertRaisesRegexp(ValueError, "Cannot find a legal default "
+        self.assertRaisesRegex(ValueError, "Cannot find a legal default "
                                             "configuration.",
                                 SimpleClassificationPipeline,
                                 include={'classifier': ['liblinear_svc'],

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -8,7 +8,6 @@ import unittest.mock
 
 from joblib import Memory
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 import sklearn.datasets
 import sklearn.decomposition
@@ -427,20 +426,29 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         )
 
     def test_get_hyperparameter_search_space_only_forbidden_combinations(self):
-        self.assertRaisesRegex(AssertionError, "No valid pipeline found.",
-                                SimpleClassificationPipeline,
-                                include={'classifier': ['multinomial_nb'],
-                                         'feature_preprocessor': ['pca']},
-                                dataset_properties={'sparse': True})
+        self.assertRaisesRegex(
+            AssertionError,
+            "No valid pipeline found.",
+            SimpleClassificationPipeline,
+            include={
+                'classifier': ['multinomial_nb'],
+                'feature_preprocessor': ['pca']
+            },
+            dataset_properties={'sparse': True}
+        )
 
         # It must also be catched that no classifiers which can handle sparse
         #  data are located behind the densifier
-        self.assertRaisesRegex(ValueError, "Cannot find a legal default "
-                                            "configuration.",
-                                SimpleClassificationPipeline,
-                                include={'classifier': ['liblinear_svc'],
-                                         'feature_preprocessor': ['densifier']},
-                                dataset_properties={'sparse': True})
+        self.assertRaisesRegex(
+            ValueError,
+            "Cannot find a legal default configuration.",
+            SimpleClassificationPipeline,
+            include={
+                'classifier': ['liblinear_svc'],
+                'feature_preprocessor': ['densifier']
+            },
+            dataset_properties={'sparse': True}
+        )
 
     @unittest.skip("Wait until ConfigSpace is fixed.")
     def test_get_hyperparameter_search_space_dataset_properties(self):
@@ -479,7 +487,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         prediction = cls.predict_proba(X_test, batch_size=20)
         self.assertEqual((1647, 10), prediction.shape)
         self.assertEqual(84, cls_predict.call_count)
-        assert_array_almost_equal(prediction_, prediction)
+        np.testing.assert_array_almost_equal(prediction_, prediction)
 
     def test_predict_batched_sparse(self):
         cls = SimpleClassificationPipeline(dataset_properties={'sparse': True},
@@ -497,7 +505,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         prediction = cls.predict_proba(X_test, batch_size=20)
         self.assertEqual((1647, 10), prediction.shape)
         self.assertEqual(84, cls_predict.call_count)
-        assert_array_almost_equal(prediction_, prediction)
+        np.testing.assert_array_almost_equal(prediction_, prediction)
 
     def test_predict_proba_batched(self):
         # Multiclass
@@ -513,7 +521,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         prediction = cls.predict_proba(X_test, batch_size=20)
         self.assertEqual((1647, 10), prediction.shape)
         self.assertEqual(84, cls_predict.call_count)
-        assert_array_almost_equal(prediction_, prediction)
+        np.testing.assert_array_almost_equal(prediction_, prediction)
 
         # Multilabel
         cls = SimpleClassificationPipeline(include={'classifier': ['lda']})
@@ -529,7 +537,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         prediction = cls.predict_proba(X_test, batch_size=20)
         self.assertEqual((1647, 10), prediction.shape)
         self.assertEqual(84, cls_predict.call_count)
-        assert_array_almost_equal(prediction_, prediction)
+        np.testing.assert_array_almost_equal(prediction_, prediction)
 
     def test_predict_proba_batched_sparse(self):
 
@@ -549,7 +557,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         prediction = cls.predict_proba(X_test, batch_size=20)
         self.assertEqual((1647, 10), prediction.shape)
         self.assertEqual(84, cls_predict.call_count)
-        assert_array_almost_equal(prediction_, prediction)
+        np.testing.assert_array_almost_equal(prediction_, prediction)
 
         # Multilabel
         cls = SimpleClassificationPipeline(
@@ -568,7 +576,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         prediction = cls.predict_proba(X_test, batch_size=20)
         self.assertEqual((1647, 10), prediction.shape)
         self.assertEqual(84, cls_predict.call_count)
-        assert_array_almost_equal(prediction_, prediction)
+        np.testing.assert_array_almost_equal(prediction_, prediction)
 
     def test_set_params(self):
         pass

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -5,11 +5,11 @@ import traceback
 import unittest
 import unittest.mock
 
+import numpy as np
 import sklearn.datasets
 import sklearn.decomposition
 import sklearn.ensemble
 import sklearn.svm
-from sklearn.utils.testing import assert_array_almost_equal
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
@@ -263,7 +263,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         )
 
     def test_get_hyperparameter_search_space_only_forbidden_combinations(self):
-        self.assertRaisesRegexp(ValueError, "Cannot find a legal default "
+        self.assertRaisesRegex(ValueError, "Cannot find a legal default "
                                             "configuration.",
                                 SimpleRegressionPipeline,
                                 include={'regressor': ['random_forest'],
@@ -271,7 +271,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
 
         # It must also be catched that no classifiers which can handle sparse
         # data are located behind the densifier
-        self.assertRaisesRegexp(ValueError, "Cannot find a legal default "
+        self.assertRaisesRegex(ValueError, "Cannot find a legal default "
                                             "configuration",
                                 SimpleRegressionPipeline,
                                 include={'regressor': ['ridge_regression'],
@@ -304,7 +304,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         cs_mc_ml = SimpleRegressionPipeline.get_hyperparameter_search_space()
         self.assertEqual(cs_ml, cs_mc_ml)
 
-        self.assertRaisesRegexp(ValueError,
+        self.assertRaisesRegex(ValueError,
                                 "No regressor to build a configuration space "
                                 "for...", SimpleRegressionPipeline.
                                 get_hyperparameter_search_space,
@@ -326,7 +326,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         prediction = regressor.predict(X_test, batch_size=20)
         self.assertEqual((356,), prediction.shape)
         self.assertEqual(18, mock_predict.call_count)
-        assert_array_almost_equal(prediction_, prediction)
+        np.testing.assert_array_almost_equal(prediction_, prediction)
 
     def test_predict_batched_sparse(self):
         dataset_properties = {'sparse': True}
@@ -348,7 +348,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         prediction = regressor.predict(X_test, batch_size=20)
         self.assertEqual((356,), prediction.shape)
         self.assertEqual(18, mock_predict.call_count)
-        assert_array_almost_equal(prediction_, prediction)
+        np.testing.assert_array_almost_equal(prediction_, prediction)
 
     @unittest.skip("test_check_random_state Not yet Implemented")
     def test_check_random_state(self):

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -263,20 +263,28 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         )
 
     def test_get_hyperparameter_search_space_only_forbidden_combinations(self):
-        self.assertRaisesRegex(ValueError, "Cannot find a legal default "
-                                            "configuration.",
-                                SimpleRegressionPipeline,
-                                include={'regressor': ['random_forest'],
-                                         'feature_preprocessor': ['kitchen_sinks']})
+        self.assertRaisesRegex(
+            ValueError,
+            "Cannot find a legal default configuration.",
+            SimpleRegressionPipeline,
+            include={
+                'regressor': ['random_forest'],
+                'feature_preprocessor': ['kitchen_sinks']
+            }
+        )
 
         # It must also be catched that no classifiers which can handle sparse
         # data are located behind the densifier
-        self.assertRaisesRegex(ValueError, "Cannot find a legal default "
-                                            "configuration",
-                                SimpleRegressionPipeline,
-                                include={'regressor': ['ridge_regression'],
-                                         'feature_preprocessor': ['densifier']},
-                                dataset_properties={'sparse': True})
+        self.assertRaisesRegex(
+            ValueError,
+            "Cannot find a legal default configuration",
+            SimpleRegressionPipeline,
+            include={
+                'regressor': ['ridge_regression'],
+                'feature_preprocessor': ['densifier']
+            },
+            dataset_properties={'sparse': True}
+        )
 
     @unittest.skip("test_get_hyperparameter_search_space_dataset_properties" +
                    " Not yet Implemented")


### PR DESCRIPTION
Deprecated utilities:
sklearn.utils.testing is deprecated --> numpy assert equivalent
sklearn.externals.joblib -->use from joblib directly
sklearn.linear_model.stochastic_gradient --> from sklearn.linear_model directly
Setting a random_state has no effect since shuffle is False... --> only add random state is no shuffle
DeprecationWarning: Please use assertRaisesRegex instead. --> Removed the "p" as it is a deprecated alias https://docs.python.org/3.2/library/unittest.html
"DeprecationWarning: invalid escape sequence ( ---> re.compile('(') --> Added another backslash re.compile('\(')