### PR TITLE
Sensible default value of 'score_func' for SelectPercentileRegression

### DIFF
--- a/autosklearn/pipeline/components/feature_preprocessing/select_percentile_regression.py
+++ b/autosklearn/pipeline/components/feature_preprocessing/select_percentile_regression.py
@@ -10,7 +10,7 @@ from autosklearn.pipeline.constants import *
 class SelectPercentileRegression(SelectPercentileBase,
                                  AutoSklearnPreprocessingAlgorithm):
 
-    def __init__(self, percentile, score_func="f_classif", random_state=None):
+    def __init__(self, percentile, score_func="f_regression", random_state=None):
         """ Parameters:
         random state : ignored
 


### PR DESCRIPTION
Currently default value of `score_func` for SelectPercentileRegression is `f_classif`, which is an invalid value, and will surely be rejected and will not work.

The `__init__` method itself also guards that only `f_regression` and  `mutual_info_regression` would be accepted.

Ref in sklearn doc: https://scikit-learn.org/stable/modules/feature_selection.html#univariate-feature-selection