### PR TITLE
More robust tmp file naming

### DIFF
--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -427,7 +427,7 @@ class EnsembleBuilder(multiprocessing.Process):
                                             all_scoring_functions=False)
 
                     if self.read_preds[y_ens_fn]["ens_score"] > -1:
-                        self.logger.critical(
+                        self.logger.debug(
                             'Changing ensemble score for file %s from %f to %f '
                             'because file modification time changed? %f - %f',
                             y_ens_fn,

--- a/autosklearn/util/backend.py
+++ b/autosklearn/util/backend.py
@@ -1,15 +1,13 @@
 import glob
-from hashlib import md5
 import os
 import tempfile
 import time
-import random
 import lockfile
 import numpy as np
 import pickle
 import shutil
-import socket
 from typing import Union
+import uuid
 
 from autosklearn.util import logging_ as logging
 
@@ -37,23 +35,15 @@ def get_randomized_directory_names(
     temporary_directory=None,
     output_directory=None,
 ):
-    random_number = random.randint(0, 10000)
-    pid = os.getpid()
-    m5_hash = str(md5(
-        str(time.localtime()).encode('utf-8')
-    ).hexdigest())
-    hostname = socket.gethostname()
+    uuid_str = str(uuid.uuid1(clock_seq=os.getpid()))
 
     temporary_directory = (
         temporary_directory
         if temporary_directory
         else os.path.join(
             tempfile.gettempdir(),
-            "autosklearn_tmp_{}_{}_{}_{}".format(
-                pid,
-                random_number,
-                m5_hash,
-                hostname
+            "autosklearn_tmp_{}".format(
+                uuid_str,
             ),
         )
     )
@@ -63,11 +53,8 @@ def get_randomized_directory_names(
         if output_directory
         else os.path.join(
             tempfile.gettempdir(),
-            "autosklearn_output_{}_{}_{}_{}".format(
-                pid,
-                random_number,
-                m5_hash,
-                hostname
+            "autosklearn_output_{}".format(
+                uuid_str,
             ),
         )
     )
@@ -226,7 +213,7 @@ class Backend(object):
             raise ValueError("Start time must be a float, but is %s." % type(start_time))
 
         if os.path.exists(filepath):
-            raise Exception(
+            raise ValueError(
                 "{filepath} already exist. Different seeds should be provided for different jobs."
             )
 


### PR DESCRIPTION
Make the critical error a debug message --- when writing to same area

Add a check to crash the job if multiple jobs with same seed write to same directory

Make the file naming more robust, for random filenames