### PR TITLE
Docs enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,10 @@ after_success: source ci_scripts/success.sh && source ci_scripts/create_doc.sh $
 
 deploy:
   provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN # set in the settings page of my repository
-  keep-hisotry: true
-  commiter-from-gh: true
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # set in the settings page of my repository
+  keep-history: true
+  committer-from-gh: true
   on:
     all_branches: true
     condition: $doc_result = "success"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ matrix:
 
   include:
   - os: linux
-    env: DISTRIB="conda" EXAMPLES="true" PYTHON="3.7" SKIP_TESTS="true"
+    env: DISTRIB="conda" DOCPUSH="true" PYTHON="3.7" SKIP_TESTS="true"
   - os: linux
     env: DISTRIB="conda" RUN_FLAKE8="true" SKIP_TESTS="true"
   - os: linux
     env: DISTRIB="conda" PYTHON="3.5"
   - os: linux
-    env: DISTRIB="conda" COVERAGE="true" DOCPUSH="true" PYTHON="3.6"
+    env: DISTRIB="conda" COVERAGE="true" PYTHON="3.6"
   - os: linux
     env: DISTRIB="conda" TEST_DIST="true" PYTHON="3.7"
   - os: linux

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -98,6 +98,7 @@ class AutoSklearnEstimator(BaseEstimator):
             `auto-sklearn` will stop fitting the machine learning algorithm if
             it tries to allocate more than `ml_memory_limit` MB.
             If None is provided, no memory limit is set.
+            In case of multi-processing, `ml_memory_limit` will be per job.
 
         include_estimators : list, optional (None)
             If None, all possible estimators are used. Otherwise specifies

--- a/ci_scripts/create_doc.sh
+++ b/ci_scripts/create_doc.sh
@@ -8,7 +8,7 @@ if ! [[ -z ${DOCPUSH+x} ]]; then
     if [[ "$DOCPUSH" == "true" ]]; then
 
         # install documentation building dependencies
-        pip install --upgrade matplotlib seaborn setuptools pytest coverage sphinx pillow sphinx-gallery==0.5 sphinx_bootstrap_theme cython numpydoc nbformat nbconvert mock
+        pip install --upgrade matplotlib seaborn setuptools pytest coverage sphinx pillow sphinx-gallery sphinx_bootstrap_theme cython numpydoc nbformat nbconvert mock
 
         # $1 is the branch name
         # $2 is the global variable where we set the script status

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -83,8 +83,6 @@ For more information about how these metrics are used, please read
 
 .. autoclass:: autosklearn.metrics.log_loss
 
-.. autoclass:: autosklearn.metrics.pac_score
-
 Regression metrics
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,7 +69,7 @@ sphinx_gallery_conf = {
     #'reference_url': {
     #    'autosklearn': None
     #},
-    'backreferences_dir': False,
+    'backreferences_dir': None,
     'filename_pattern': 'example.*.py$',
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,7 +69,8 @@ sphinx_gallery_conf = {
     #'reference_url': {
     #    'autosklearn': None
     #},
-    'backreferences_dir': False
+    'backreferences_dir': False,
+    'filename_pattern': 'example.*.py$',
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -14,7 +14,7 @@ auto-sklearn has the following system requirements:
 * Linux operating system (for example Ubuntu) `(get Linux here) <https://www.wikihow.com/Install-Linux>`_,
 * Python (>=3.5) `(get Python here) <https://www.python.org/downloads/>`_.
 * C++ compiler (with C++11 supports) `(get GCC here) <https://www.tutorialspoint.com/How-to-Install-Cplusplus-Compiler-on-Linux>`_ and
-* SWIG (version 3.0 or later) `(get SWIG here) <http://www.swig.org/survey.html>`_.
+* SWIG (version 3.0.* is required; >=4.0.0 is not supported) `(get SWIG here) <http://www.swig.org/survey.html>`_.
 
 For an explanation of missing Microsoft Windows and MAC OSX support please
 check the Section `Windows/OSX compatibility`_.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -98,9 +98,9 @@ Ensemble Building Process
 *auto-sklearn* uses ensemble selection by `Caruana et al. (2004) <https://dl.acm.org/doi/pdf/10.1145/1015330.1015432>`_ 
 to build an ensemble based on the models’ prediction for the validation set. The following hyperparameters control how the ensemble is constructed:
 
-* ``ensemble_size`` determines the maximal size of the ensemble. if it is set to zero, no ensemble will be constructed.
-* ``ensemble_nbest`` allows the user to directly specify the number of models used for the ensemble.  This hyperparameter can be an integer *n*, such that only the best *n* models are used in the final ensemble. If a float between 0.0 and 1.0 is provided, ``ensemble_nbest`` would be interpreted as a fraction suggesting the percentage of models to use in the ensemble building process.
- * ``max_models_on_disc`` defines the maximum number of models that are kept on the disc, as a mechanism to control the amount of disc space consummed by *auto-sklearn*. Throughout the automl process, different individual models are optimized, and their predictions (and other metadata) is stored on disc. The user can set the upper bound on how many models are acceptable to keep in disc, yet this variable takes priority in the definition of the amount of models used by the ensemble builder (that is, the minimum of ``ensemble_size``, ``ensemble_nbest`` and ``max_models_on_disc`` determines the maximal amount of models used in the ensemble). If set to None, this feature is disabled. 
+* ``ensemble_size`` determines the maximal size of the ensemble. If it is set to zero, no ensemble will be constructed.
+* ``ensemble_nbest`` allows the user to directly specify the number of models considered for the ensemble.  This hyperparameter can be an integer *n*, such that only the best *n* models are used in the final ensemble. If a float between 0.0 and 1.0 is provided, ``ensemble_nbest`` would be interpreted as a fraction suggesting the percentage of models to use in the ensemble building process (namely, if ensemble_nbest is a float, library pruning is implemented as described in `Caruana et al. (2006) <https://dl.acm.org/doi/10.1109/ICDM.2006.76>`_).
+ * ``max_models_on_disc`` defines the maximum number of models that are kept on the disc, as a mechanism to control the amount of disc space consumed by *auto-sklearn*. Throughout the automl process, different individual models are optimized, and their predictions (and other metadata) is stored on disc. The user can set the upper bound on how many models are acceptable to keep on disc, yet this variable takes priority in the definition of the number of models used by the ensemble builder (that is, the minimum of ``ensemble_size``, ``ensemble_nbest`` and ``max_models_on_disc`` determines the maximal amount of models used in the ensemble). If set to None, this feature is disabled. 
 
 Inspecting the results
 ======================
@@ -120,7 +120,7 @@ statistics can be printed for the inspection.
 obtained by running *auto-sklearn*. It additionally prints the number of both successful and unsuccessful
 algorithm runs.
 
-The results obtained from the final ensemble can be printed by calling ``show_models()``. *auto-sklearn* ensemble is composed of scikit-learn that can be inspected as exemplified by  
+The results obtained from the final ensemble can be printed by calling ``show_models()``. *auto-sklearn* ensemble is composed of scikit-learn models that can be inspected as exemplified by  
 `model inspection example <examples/example_get_pipeline_components.html>`_
 .
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -25,9 +25,11 @@ aspects of its usage:
 * `Using custom metrics <examples/example_metrics.html>`_
 * `Random search <examples/example_random_search.html>`_
 * `EIPS <examples/example_eips.html>`_
+* `Successive Halving <examples/example_successive_halving.html>`_
 * `Extending with a new classifier <examples/example_extending_classification.html>`_
 * `Extending with a new regressor <examples/example_extending_regression.html>`_
 * `Extending with a new preprocessor <examples/example_extending_preprocessor.html>`_
+* `Iterating over the models <examples/example_get_pipeline_components.html>`_
 
 
 Time and memory limits
@@ -90,6 +92,16 @@ Resampling strategies
 
 Examples for using holdout and cross-validation can be found in `auto-sklearn/examples/ <examples/>`_
 
+Ensemble Building Process
+======================
+
+*auto-sklearn* uses ensemble selection by `Caruana et al. (2004) <https://dl.acm.org/doi/pdf/10.1145/1015330.1015432>`_ 
+to build an ensemble based on the models’ prediction for the validation set. The following hyperparameters control how the ensemble is constructed:
+
+* ``ensemble_size`` determines the maximal size of the ensemble. if it is set to zero, no ensemble will be constructed.
+* ``ensemble_nbest`` allows the user to directly specify the number of models used for the ensemble.  This hyperparameter can be an integer *n*, such that only the best *n* models are used in the final ensemble. If a float between 0.0 and 1.0 is provided, ``ensemble_nbest`` would be interpreted as a fraction suggesting the percentage of models to use in the ensemble building process.
+ * ``max_models_on_disc`` defines the maximum number of models that are kept on the disc, as a mechanism to control the amount of disc space consummed by *auto-sklearn*. Throughout the automl process, different individual models are optimized, and their predictions (and other metadata) is stored on disc. The user can set the upper bound on how many models are acceptable to keep in disc, yet this variable takes priority in the definition of the amount of models used by the ensemble builder (that is, the minimum of ``ensemble_size``, ``ensemble_nbest`` and ``max_models_on_disc`` determines the maximal amount of models used in the ensemble). If set to None, this feature is disabled. 
+
 Inspecting the results
 ======================
 
@@ -107,7 +119,10 @@ statistics can be printed for the inspection.
 ``sprint_statistics()`` is a method that prints the name of the  dataset, the metric used, and the best validation score
 obtained by running *auto-sklearn*. It additionally prints the number of both successful and unsuccessful
 algorithm runs.
-The results obtained from the final ensemble can be printed by calling ``show_models()``.
+
+The results obtained from the final ensemble can be printed by calling ``show_models()``. *auto-sklearn* ensemble is composed of scikit-learn that can be inspected as exemplified by  
+`model inspection example <examples/example_get_pipeline_components.html>`_
+.
 
 Parallel computation
 ====================

--- a/examples/example_crossvalidation.py
+++ b/examples/example_crossvalidation.py
@@ -37,7 +37,6 @@ automl = autosklearn.classification.AutoSklearnClassifier(
     per_run_time_limit=30,
     tmp_folder='/tmp/autosklearn_cv_example_tmp',
     output_folder='/tmp/autosklearn_cv_example_out',
-    delete_tmp_folder_after_terminate=False,
     resampling_strategy='cv',
     resampling_strategy_arguments={'folds': 5},
 )

--- a/examples/example_crossvalidation.py
+++ b/examples/example_crossvalidation.py
@@ -20,41 +20,51 @@ import sklearn.metrics
 import autosklearn.classification
 
 
-def main():
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+############################################################################
+# Data Loading
+# ============
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-        tmp_folder='/tmp/autosklearn_cv_example_tmp',
-        output_folder='/tmp/autosklearn_cv_example_out',
-        resampling_strategy='cv',
-        resampling_strategy_arguments={'folds': 5},
-    )
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    # fit() changes the data in place, but refit needs the original data. We
-    # therefore copy the data. In practice, one should reload the data
-    automl.fit(X_train.copy(), y_train.copy(), dataset_name='breast_cancer')
+############################################################################
+# Building  and fitting the classifier
+# ====================================
 
-    print(automl.sprint_statistics())
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+    tmp_folder='/tmp/autosklearn_cv_example_tmp',
+    output_folder='/tmp/autosklearn_cv_example_out',
+    delete_tmp_folder_after_terminate=False,
+    resampling_strategy='cv',
+    resampling_strategy_arguments={'folds': 5},
+)
 
-    # One can use models trained during cross-validation directly to predict
-    # for unseen data. For this, all k models trained during k-fold
-    # cross-validation are considered as a single soft-voting ensemble inside
-    # the ensemble constructed with ensemble selection.
-    print('Before re-fit')
-    predictions = automl.predict(X_test)
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+# fit() changes the data in place, but refit needs the original data. We
+# therefore copy the data. In practice, one should reload the data
+automl.fit(X_train.copy(), y_train.copy(), dataset_name='breast_cancer')
 
-    # During fit(), models are fit on individual cross-validation folds. To use
-    # all available data, we call refit() which trains all models in the
-    # final ensemble on the whole dataset.
-    automl.refit(X_train.copy(), y_train.copy())
-    predictions = automl.predict(X_test)
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+############################################################################
+# Print Results before refit
+# ==========================
+print(automl.sprint_statistics())
 
+# One can use models trained during cross-validation directly to predict
+# for unseen data. For this, all k models trained during k-fold
+# cross-validation are considered as a single soft-voting ensemble inside
+# the ensemble constructed with ensemble selection.
+print('Before re-fit')
+predictions = automl.predict(X_test)
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
-if __name__ == '__main__':
-    main()
+############################################################################
+# Perform a refit
+# ==========================
+# During fit(), models are fit on individual cross-validation folds. To use
+# all available data, we call refit() which trains all models in the
+# final ensemble on the whole dataset.
+automl.refit(X_train.copy(), y_train.copy())
+predictions = automl.predict(X_test)
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_crossvalidation.py
+++ b/examples/example_crossvalidation.py
@@ -60,7 +60,7 @@ print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
 ############################################################################
 # Perform a refit
-# ==========================
+# ===============
 # During fit(), models are fit on individual cross-validation folds. To use
 # all available data, we call refit() which trains all models in the
 # final ensemble on the whole dataset.

--- a/examples/example_eips.py
+++ b/examples/example_eips.py
@@ -24,7 +24,7 @@ import autosklearn.classification
 
 ############################################################################
 # EIPS callback
-# ======================================
+# =============
 # create a callack to change the acquisition function inside SMAC
 def get_eips_object_callback(
         scenario_dict,
@@ -61,7 +61,7 @@ def get_eips_object_callback(
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -69,7 +69,7 @@ X_train, X_test, y_train, y_test = \
 
 ############################################################################
 # Building and fitting the classifier
-# ======================================
+# ===================================
 
 automl = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=120,
@@ -82,15 +82,15 @@ automl = autosklearn.classification.AutoSklearnClassifier(
 automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
 ############################################################################
-# Print the final ensemble constructed by auto-sklearn.
-# ======================================
+# Print the final ensemble constructed by auto-sklearn
+# ====================================================
 
 # Print the final ensemble constructed by auto-sklearn via ROAR.
 print(automl.show_models())
 
 ############################################################################
 # Print statistics about the auto-sklearn run
-# ======================================
+# ===========================================
 
 # Print statistics about the auto-sklearn run such as number of
 # iterations, number of models failed with a time out.
@@ -98,7 +98,7 @@ print(automl.sprint_statistics())
 
 ############################################################################
 # Get the Score of the final ensemble
-# ======================================
+# ===================================
 
 predictions = automl.predict(X_test)
 print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_eips.py
+++ b/examples/example_eips.py
@@ -22,6 +22,10 @@ from smac.scenario.scenario import Scenario
 import autosklearn.classification
 
 
+############################################################################
+# EIPS callback
+# ======================================
+# create a callack to change the acquisition function inside SMAC
 def get_eips_object_callback(
         scenario_dict,
         seed,
@@ -55,29 +59,46 @@ def get_eips_object_callback(
     )
 
 
-def main():
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+############################################################################
+# Data Loading
+# ======================================
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-        tmp_folder='/tmp/autosklearn_eips_example_tmp',
-        output_folder='/tmp/autosklearn_eips_example_out',
-        get_smac_object_callback=get_eips_object_callback,
-        initial_configurations_via_metalearning=0,
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    # Print the final ensemble constructed by auto-sklearn via ROAR.
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+############################################################################
+# Building and fitting the classifier
+# ======================================
 
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+    tmp_folder='/tmp/autosklearn_eips_example_tmp',
+    output_folder='/tmp/autosklearn_eips_example_out',
+    get_smac_object_callback=get_eips_object_callback,
+    initial_configurations_via_metalearning=0,
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-if __name__ == '__main__':
-    main()
+############################################################################
+# Print the final ensemble constructed by auto-sklearn.
+# ======================================
+
+# Print the final ensemble constructed by auto-sklearn via ROAR.
+print(automl.show_models())
+
+############################################################################
+# Print statistics about the auto-sklearn run
+# ======================================
+
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+
+############################################################################
+# Get the Score of the final ensemble
+# ======================================
+
+predictions = automl.predict(X_test)
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_extending_classification.py
+++ b/examples/example_extending_classification.py
@@ -19,8 +19,14 @@ from autosklearn.pipeline.components.base \
 from autosklearn.pipeline.constants import DENSE, SIGNED_DATA, UNSIGNED_DATA, \
     PREDICTIONS
 
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
 
+
+############################################################################
 # Create MLP classifier component for auto-sklearn.
+# ======================================
+
 class MLPClassifier(AutoSklearnClassificationAlgorithm):
     def __init__(self,
                  hidden_layer_depth,
@@ -106,28 +112,34 @@ class MLPClassifier(AutoSklearnClassificationAlgorithm):
         return cs
 
 
-if __name__ == '__main__':
-    # Add MLP classifier component to auto-sklearn.
-    autosklearn.pipeline.components.classification.add_classifier(MLPClassifier)
-    cs = MLPClassifier.get_hyperparameter_search_space()
-    print(cs)
+# Add MLP classifier component to auto-sklearn.
+autosklearn.pipeline.components.classification.add_classifier(MLPClassifier)
+cs = MLPClassifier.get_hyperparameter_search_space()
+print(cs)
 
-    # Generate data.
-    from sklearn.datasets import load_breast_cancer
-    from sklearn.model_selection import train_test_split
-    X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y)
+############################################################################
+# Data Loading
+# ======================================
 
-    # Fit MLP classifier to the data.
-    clf = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=30,
-        per_run_time_limit=10,
-        include_estimators=['MLPClassifier'],
-    )
-    clf.fit(X_train, y_train)
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y)
 
-    # Print test accuracy and statistics.
-    y_pred = clf.predict(X_test)
-    print("accuracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))
-    print(clf.sprint_statistics())
-    print(clf.show_models())
+############################################################################
+# Fit MLP classifier to the data.
+# ======================================
+
+clf = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=30,
+    per_run_time_limit=10,
+    include_estimators=['MLPClassifier'],
+)
+clf.fit(X_train, y_train)
+
+############################################################################
+# Print test accuracy and statistics.
+# ======================================
+
+y_pred = clf.predict(X_test)
+print("accuracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))
+print(clf.sprint_statistics())
+print(clf.show_models())

--- a/examples/example_extending_classification.py
+++ b/examples/example_extending_classification.py
@@ -1,7 +1,7 @@
 """
-====================================================================
+====================================================
 Extending Auto-Sklearn with Classification Component
-====================================================================
+====================================================
 
 The following example demonstrates how to create a new classification
 component for using in auto-sklearn.
@@ -24,8 +24,8 @@ from sklearn.model_selection import train_test_split
 
 
 ############################################################################
-# Create MLP classifier component for auto-sklearn.
-# ======================================
+# Create MLP classifier component for auto-sklearn
+# ================================================
 
 class MLPClassifier(AutoSklearnClassificationAlgorithm):
     def __init__(self,
@@ -119,14 +119,14 @@ print(cs)
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y)
 
 ############################################################################
-# Fit MLP classifier to the data.
-# ======================================
+# Fit MLP classifier to the data
+# ==============================
 
 clf = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=30,
@@ -136,8 +136,8 @@ clf = autosklearn.classification.AutoSklearnClassifier(
 clf.fit(X_train, y_train)
 
 ############################################################################
-# Print test accuracy and statistics.
-# ======================================
+# Print test accuracy and statistics
+# ==================================
 
 y_pred = clf.predict(X_test)
 print("accuracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))

--- a/examples/example_extending_preprocessor.py
+++ b/examples/example_extending_preprocessor.py
@@ -1,7 +1,7 @@
 """
-====================================================================
+==================================================
 Extending Auto-Sklearn with Preprocessor Component
-====================================================================
+==================================================
 
 The following example demonstrates how to create a wrapper around the linear
 discriminant analysis (LDA) algorithm from sklearn and use it as a preprocessor
@@ -27,8 +27,8 @@ from sklearn.model_selection import train_test_split
 
 
 ############################################################################
-# Create LDA component for auto-sklearn.
-# ======================================
+# Create LDA component for auto-sklearn
+# =====================================
 class LDA(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, solver, n_components, tol, shrinkage=None, random_state=None):
         self.solver = solver
@@ -99,22 +99,22 @@ class LDA(AutoSklearnPreprocessingAlgorithm):
 autosklearn.pipeline.components.feature_preprocessing.add_preprocessor(LDA)
 
 ############################################################################
-# Create dataset.
-# ======================================
+# Create dataset
+# ==============
 
 X, y = load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y)
 
 ############################################################################
-# Configuration space.
-# ======================================
+# Configuration space
+# ===================
 
 cs = LDA.get_hyperparameter_search_space()
 print(cs)
 
 ############################################################################
-# Fit the model using LDA as preprocessor.
-# ======================================
+# Fit the model using LDA as preprocessor
+# =======================================
 
 clf = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=30,
@@ -123,8 +123,8 @@ clf = autosklearn.classification.AutoSklearnClassifier(
 clf.fit(X_train, y_train)
 
 ############################################################################
-# Print prediction score and statistics.
-# ======================================
+# Print prediction score and statistics
+# =====================================
 
 y_pred = clf.predict(X_test)
 print("accracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))

--- a/examples/example_extending_preprocessor.py
+++ b/examples/example_extending_preprocessor.py
@@ -22,8 +22,13 @@ from autosklearn.pipeline.constants import DENSE, SIGNED_DATA, \
     UNSIGNED_DATA
 from autosklearn.util.common import check_none
 
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
 
+
+############################################################################
 # Create LDA component for auto-sklearn.
+# ======================================
 class LDA(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, solver, n_components, tol, shrinkage=None, random_state=None):
         self.solver = solver
@@ -90,29 +95,38 @@ class LDA(AutoSklearnPreprocessingAlgorithm):
         return cs
 
 
-if __name__ == '__main__':
-    # Add LDA component to auto-sklearn.
-    autosklearn.pipeline.components.feature_preprocessing.add_preprocessor(LDA)
+# Add LDA component to auto-sklearn.
+autosklearn.pipeline.components.feature_preprocessing.add_preprocessor(LDA)
 
-    # Create dataset.
-    from sklearn.datasets import load_breast_cancer
-    from sklearn.model_selection import train_test_split
-    X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y)
+############################################################################
+# Create dataset.
+# ======================================
 
-    # Configuration space.
-    cs = LDA.get_hyperparameter_search_space()
-    print(cs)
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y)
 
-    # Fit the model using LDA as preprocessor.
-    clf = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=30,
-        include_preprocessors=['LDA'],
-    )
-    clf.fit(X_train, y_train)
+############################################################################
+# Configuration space.
+# ======================================
 
-    # Print prediction score and statistics.
-    y_pred = clf.predict(X_test)
-    print("accracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))
-    print(clf.sprint_statistics())
-    print(clf.show_models())
+cs = LDA.get_hyperparameter_search_space()
+print(cs)
+
+############################################################################
+# Fit the model using LDA as preprocessor.
+# ======================================
+
+clf = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=30,
+    include_preprocessors=['LDA'],
+)
+clf.fit(X_train, y_train)
+
+############################################################################
+# Print prediction score and statistics.
+# ======================================
+
+y_pred = clf.predict(X_test)
+print("accracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))
+print(clf.sprint_statistics())
+print(clf.show_models())

--- a/examples/example_extending_regression.py
+++ b/examples/example_extending_regression.py
@@ -18,8 +18,14 @@ from autosklearn.pipeline.components.base import AutoSklearnRegressionAlgorithm
 from autosklearn.pipeline.constants import SPARSE, DENSE, \
     SIGNED_DATA, UNSIGNED_DATA, PREDICTIONS
 
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import train_test_split
 
+
+############################################################################
 # Implement kernel ridge regression component for auto-sklearn.
+# ======================================
+
 class KernelRidgeRegression(AutoSklearnRegressionAlgorithm):
     def __init__(self, alpha, kernel, gamma, degree, random_state=None):
         self.alpha = alpha
@@ -84,28 +90,33 @@ class KernelRidgeRegression(AutoSklearnRegressionAlgorithm):
         return cs
 
 
-if __name__ == '__main__':
-    # Add KRR component to auto-sklearn.
-    autosklearn.pipeline.components.regression.add_regressor(KernelRidgeRegression)
-    cs = KernelRidgeRegression.get_hyperparameter_search_space()
-    print(cs)
+# Add KRR component to auto-sklearn.
+autosklearn.pipeline.components.regression.add_regressor(KernelRidgeRegression)
+cs = KernelRidgeRegression.get_hyperparameter_search_space()
+print(cs)
 
-    # Generate data.
-    from sklearn.datasets import load_diabetes
-    from sklearn.model_selection import train_test_split
-    X, y = load_diabetes(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y)
+############################################################################
+# Generate data.
+# ======================================
 
-    # Fit the model using KRR.
-    reg = autosklearn.regression.AutoSklearnRegressor(
-        time_left_for_this_task=30,
-        per_run_time_limit=10,
-        include_estimators=['KernelRidgeRegression'],
-    )
-    reg.fit(X_train, y_train)
+X, y = load_diabetes(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y)
 
-    # Print prediction score and statistics.
-    y_pred = reg.predict(X_test)
-    print("r2 score: ", sklearn.metrics.r2_score(y_pred, y_test))
-    print(reg.sprint_statistics())
-    print(reg.show_models())
+############################################################################
+# Fit the model using KRR.
+# ======================================
+
+reg = autosklearn.regression.AutoSklearnRegressor(
+    time_left_for_this_task=30,
+    per_run_time_limit=10,
+    include_estimators=['KernelRidgeRegression'],
+)
+reg.fit(X_train, y_train)
+
+############################################################################
+# Print prediction score and statistics.
+# ======================================
+y_pred = reg.predict(X_test)
+print("r2 score: ", sklearn.metrics.r2_score(y_pred, y_test))
+print(reg.sprint_statistics())
+print(reg.show_models())

--- a/examples/example_extending_regression.py
+++ b/examples/example_extending_regression.py
@@ -1,7 +1,7 @@
 """
-====================================================================
+================================================
 Extending Auto-Sklearn with Regression Component
-====================================================================
+================================================
 
 The following example demonstrates how to create a new regression
 component for using in auto-sklearn.
@@ -23,8 +23,8 @@ from sklearn.model_selection import train_test_split
 
 
 ############################################################################
-# Implement kernel ridge regression component for auto-sklearn.
-# ======================================
+# Implement kernel ridge regression component for auto-sklearn
+# ============================================================
 
 class KernelRidgeRegression(AutoSklearnRegressionAlgorithm):
     def __init__(self, alpha, kernel, gamma, degree, random_state=None):
@@ -96,15 +96,15 @@ cs = KernelRidgeRegression.get_hyperparameter_search_space()
 print(cs)
 
 ############################################################################
-# Generate data.
-# ======================================
+# Generate data
+# =============
 
 X, y = load_diabetes(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y)
 
 ############################################################################
-# Fit the model using KRR.
-# ======================================
+# Fit the model using KRR
+# =======================
 
 reg = autosklearn.regression.AutoSklearnRegressor(
     time_left_for_this_task=30,
@@ -114,8 +114,8 @@ reg = autosklearn.regression.AutoSklearnRegressor(
 reg.fit(X_train, y_train)
 
 ############################################################################
-# Print prediction score and statistics.
-# ======================================
+# Print prediction score and statistics
+# =====================================
 y_pred = reg.predict(X_test)
 print("r2 score: ", sklearn.metrics.r2_score(y_pred, y_test))
 print(reg.sprint_statistics())

--- a/examples/example_feature_types.py
+++ b/examples/example_feature_types.py
@@ -28,35 +28,41 @@ except ImportError:
     raise
 
 
-def main():
-    # Load adult dataset from openml.org, see https://www.openml.org/t/2117
-    openml.config.apikey = '610344db6388d9ba34f6db45a3cf71de'
+############################################################################
+# Data Loading
+# ======================================
+# Load adult dataset from openml.org, see https://www.openml.org/t/2117
+openml.config.apikey = '610344db6388d9ba34f6db45a3cf71de'
 
-    task = openml.tasks.get_task(2117)
-    train_indices, test_indices = task.get_train_test_split_indices()
-    X, y = task.get_X_and_y()
+task = openml.tasks.get_task(2117)
+train_indices, test_indices = task.get_train_test_split_indices()
+X, y = task.get_X_and_y()
 
-    X_train = X[train_indices]
-    y_train = y[train_indices]
-    X_test = X[test_indices]
-    y_test = y[test_indices]
+X_train = X[train_indices]
+y_train = y[train_indices]
+X_test = X[test_indices]
+y_test = y[test_indices]
 
-    dataset = task.get_dataset()
-    _, _, categorical_indicator, _ = dataset.get_data(target=task.target_name)
+dataset = task.get_dataset()
+_, _, categorical_indicator, _ = dataset.get_data(target=task.target_name)
 
-    # Create feature type list from openml.org indicator and run autosklearn
-    feat_type = ['Categorical' if ci else 'Numerical'
-                 for ci in categorical_indicator]
+# Create feature type list from openml.org indicator and run autosklearn
+feat_type = ['Categorical' if ci else 'Numerical'
+             for ci in categorical_indicator]
 
-    cls = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-    )
-    cls.fit(X_train, y_train, feat_type=feat_type)
+############################################################################
+# Build and fit a classifier
+# ======================================
 
-    predictions = cls.predict(X_test)
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+cls = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+)
+cls.fit(X_train, y_train, feat_type=feat_type)
 
+###########################################################################
+# Get the Score of the final ensemble
+# ======================================
 
-if __name__ == "__main__":
-    main()
+predictions = cls.predict(X_test)
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_get_pipeline_components.py
+++ b/examples/example_get_pipeline_components.py
@@ -15,47 +15,56 @@ import sklearn.metrics
 
 import autosklearn.classification
 
+############################################################################
+# Data Loading
+# ======================================
 
-def main():
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+############################################################################
+# Build and fit the classifier
+# ======================================
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-        disable_evaluator_output=False,
-        resampling_strategy='holdout',
-        # We want autosklearn to use pca as preprocessor
-        include_preprocessors=['pca'],
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+    disable_evaluator_output=False,
+    resampling_strategy='holdout',
+    # We want autosklearn to use pca as preprocessor
+    include_preprocessors=['pca'],
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score:{}".format(
-        sklearn.metrics.accuracy_score(y_test, predictions))
-    )
+############################################################################
+# Report the model found by Auto-Sklearn
+# ======================================
 
-    # Iterate over the components of the model and print
-    # The explained variance ratio per stage
-    for i, (weight, pipeline) in enumerate(automl.get_models_with_weights()):
-        for stage_name, component in pipeline.named_steps.items():
-            if 'preprocessor' in stage_name:
-                print(
-                    "The {}th pipeline has a explained variance of {}".format(
-                        i,
-                        # The component is an instance of AutoSklearnChoice.
-                        # Access the sklearn object via the choice attribute
-                        # We want the explained variance attributed of
-                        # each principal component
-                        component.choice.preprocessor.explained_variance_ratio_
-                    )
+predictions = automl.predict(X_test)
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+print("Accuracy score:{}".format(
+    sklearn.metrics.accuracy_score(y_test, predictions))
+)
+
+############################################################################
+# Inspect the components of the best model
+# ======================================
+
+# Iterate over the components of the model and print
+# The explained variance ratio per stage
+for i, (weight, pipeline) in enumerate(automl.get_models_with_weights()):
+    for stage_name, component in pipeline.named_steps.items():
+        if 'preprocessor' in stage_name:
+            print(
+                "The {}th pipeline has a explained variance of {}".format(
+                    i,
+                    # The component is an instance of AutoSklearnChoice.
+                    # Access the sklearn object via the choice attribute
+                    # We want the explained variance attributed of
+                    # each principal component
+                    component.choice.preprocessor.explained_variance_ratio_
                 )
-
-
-if __name__ == '__main__':
-    main()
+            )

--- a/examples/example_get_pipeline_components.py
+++ b/examples/example_get_pipeline_components.py
@@ -17,7 +17,7 @@ import autosklearn.classification
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -25,7 +25,7 @@ X_train, X_test, y_train, y_test = \
 
 ############################################################################
 # Build and fit the classifier
-# ======================================
+# ============================
 
 automl = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=120,
@@ -51,7 +51,7 @@ print("Accuracy score:{}".format(
 
 ############################################################################
 # Inspect the components of the best model
-# ======================================
+# ========================================
 
 # Iterate over the components of the model and print
 # The explained variance ratio per stage

--- a/examples/example_get_pipeline_components.py
+++ b/examples/example_get_pipeline_components.py
@@ -5,7 +5,9 @@ Query the Classification Pipeline
 =================================
 
 The following example shows how to query from a pipeline
-built by auto-sklearn
+built by auto-sklearn. Auto-sklearn is a wrapper on top of
+the sklearn models. This example illustrates how to interact
+with the sklearn components directly, in this case a PCA preprocessor.
 """
 import sklearn.model_selection
 import sklearn.datasets

--- a/examples/example_holdout.py
+++ b/examples/example_holdout.py
@@ -19,7 +19,7 @@ import autosklearn.classification
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -27,7 +27,7 @@ X_train, X_test, y_train, y_test = \
 
 ############################################################################
 # Building the classifier
-# ======================================
+# =======================
 
 automl = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=120,
@@ -44,14 +44,14 @@ automl = autosklearn.classification.AutoSklearnClassifier(
 automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
 ############################################################################
-# Print the final ensemble constructed by auto-sklearn.
-# ======================================
+# Print the final ensemble constructed by auto-sklearn
+# ====================================================
 
 print(automl.show_models())
 
 ############################################################################
 # Print statistics about the auto-sklearn run
-# ======================================
+# ===========================================
 
 # Print statistics about the auto-sklearn run such as number of
 # iterations, number of models failed with a time out.
@@ -59,7 +59,7 @@ print(automl.sprint_statistics())
 
 ############################################################################
 # Get the Score of the final ensemble
-# ======================================
+# ===================================
 
 predictions = automl.predict(X_test)
 print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_holdout.py
+++ b/examples/example_holdout.py
@@ -17,33 +17,49 @@ import sklearn.metrics
 import autosklearn.classification
 
 
-def main():
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+############################################################################
+# Data Loading
+# ======================================
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-        tmp_folder='/tmp/autosklearn_holdout_example_tmp',
-        output_folder='/tmp/autosklearn_holdout_example_out',
-        disable_evaluator_output=False,
-        # 'holdout' with 'train_size'=0.67 is the default argument setting
-        # for AutoSklearnClassifier. It is explicitly specified in this example
-        # for demonstrational purpose.
-        resampling_strategy='holdout',
-        resampling_strategy_arguments={'train_size': 0.67}
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    # Print the final ensemble constructed by auto-sklearn.
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+############################################################################
+# Building the classifier
+# ======================================
 
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+    tmp_folder='/tmp/autosklearn_holdout_example_tmp',
+    output_folder='/tmp/autosklearn_holdout_example_out',
+    disable_evaluator_output=False,
+    # 'holdout' with 'train_size'=0.67 is the default argument setting
+    # for AutoSklearnClassifier. It is explicitly specified in this example
+    # for demonstrational purpose.
+    resampling_strategy='holdout',
+    resampling_strategy_arguments={'train_size': 0.67}
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-if __name__ == '__main__':
-    main()
+############################################################################
+# Print the final ensemble constructed by auto-sklearn.
+# ======================================
+
+print(automl.show_models())
+
+############################################################################
+# Print statistics about the auto-sklearn run
+# ======================================
+
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+
+############################################################################
+# Get the Score of the final ensemble
+# ======================================
+
+predictions = automl.predict(X_test)
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_metrics.py
+++ b/examples/example_metrics.py
@@ -21,6 +21,10 @@ import autosklearn.classification
 import autosklearn.metrics
 
 
+############################################################################
+# Custom metrics definition
+# ======================================
+
 def accuracy(solution, prediction):
     # custom function defining accuracy
     return np.mean(solution == prediction)
@@ -43,132 +47,142 @@ def error_wk(solution, prediction, dummy):
     return np.mean(solution != prediction)
 
 
-def main():
+############################################################################
+# Data Loading
+# ======================================
 
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    # Print a list of available metrics
-    print("Available CLASSIFICATION metrics autosklearn.metrics.*:")
-    print("\t*" + "\n\t*".join(autosklearn.metrics.CLASSIFICATION_METRICS))
+############################################################################
+# Print a list of available metrics
+# ======================================
 
-    print("Available REGRESSION autosklearn.metrics.*:")
-    print("\t*" + "\n\t*".join(autosklearn.metrics.REGRESSION_METRICS))
+print("Available CLASSIFICATION metrics autosklearn.metrics.*:")
+print("\t*" + "\n\t*".join(autosklearn.metrics.CLASSIFICATION_METRICS))
 
-    # First example: Use predefined accuracy metric
-    print("#"*80)
-    print("Use predefined accuracy metric")
-    cls = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=60,
-        per_run_time_limit=30,
-        seed=1,
+print("Available REGRESSION autosklearn.metrics.*:")
+print("\t*" + "\n\t*".join(autosklearn.metrics.REGRESSION_METRICS))
+
+############################################################################
+# First example: Use predefined accuracy metric
+# ======================================
+
+print("#"*80)
+print("Use predefined accuracy metric")
+cls = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=60,
+    per_run_time_limit=30,
+    seed=1,
+)
+cls.fit(X_train, y_train, metric=autosklearn.metrics.accuracy)
+
+predictions = cls.predict(X_test)
+print("Accuracy score {:g} using {:s}".
+      format(sklearn.metrics.accuracy_score(y_test, predictions),
+             cls._automl[0]._metric.name))
+
+############################################################################
+# Second example: Use own accuracy metric
+# ======================================
+
+print("#"*80)
+print("Use self defined accuracy metric")
+accuracy_scorer = autosklearn.metrics.make_scorer(
+    name="accu",
+    score_func=accuracy,
+    optimum=1,
+    greater_is_better=True,
+    needs_proba=False,
+    needs_threshold=False,
+)
+cls = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=60,
+    per_run_time_limit=30,
+    seed=1,
+)
+cls.fit(X_train, y_train, metric=accuracy_scorer)
+
+predictions = cls.predict(X_test)
+print("Accuracy score {:g} using {:s}".
+      format(sklearn.metrics.accuracy_score(y_test, predictions),
+             cls._automl[0]._metric.name))
+
+print("#"*80)
+print("Use self defined error metric")
+error_rate = autosklearn.metrics.make_scorer(
+    name='error',
+    score_func=error,
+    optimum=0,
+    greater_is_better=False,
+    needs_proba=False,
+    needs_threshold=False
+)
+cls = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=60,
+    per_run_time_limit=30,
+    seed=1
+)
+cls.fit(X_train, y_train, metric=error_rate)
+
+cls.predictions = cls.predict(X_test)
+print("Error rate {:g} using {:s}".
+      format(error_rate(y_test, predictions),
+             cls._automl[0]._metric.name))
+
+############################################################################
+# Third example: Use own accuracy metric with additional argument
+# ======================================
+
+print("#"*80)
+print("Use self defined accuracy with additional argument")
+accuracy_scorer = autosklearn.metrics.make_scorer(
+    name="accu_add",
+    score_func=accuracy_wk,
+    optimum=1,
+    greater_is_better=True,
+    needs_proba=False,
+    needs_threshold=False,
+    dummy=None,
+)
+cls = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=60,
+    per_run_time_limit=30,
+    seed=1,
+)
+cls.fit(X_train, y_train, metric=accuracy_scorer)
+
+predictions = cls.predict(X_test)
+print(
+    "Accuracy score {:g} using {:s}".format(
+        sklearn.metrics.accuracy_score(y_test, predictions),
+        cls._automl[0]._metric.name
     )
-    cls.fit(X_train, y_train, metric=autosklearn.metrics.accuracy)
+)
 
-    predictions = cls.predict(X_test)
-    print("Accuracy score {:g} using {:s}".
-          format(sklearn.metrics.accuracy_score(y_test, predictions),
-                 cls._automl[0]._metric.name))
+print("#"*80)
+print("Use self defined error with additional argument")
+error_rate = autosklearn.metrics.make_scorer(
+    name="error_add",
+    score_func=error_wk,
+    optimum=0,
+    greater_is_better=True,
+    needs_proba=False,
+    needs_threshold=False,
+    dummy=None,
+)
+cls = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=60,
+    per_run_time_limit=30,
+    seed=1,
+)
+cls.fit(X_train, y_train, metric=error_rate)
 
-    # Second example: Use own accuracy metric
-    print("#"*80)
-    print("Use self defined accuracy metric")
-    accuracy_scorer = autosklearn.metrics.make_scorer(
-        name="accu",
-        score_func=accuracy,
-        optimum=1,
-        greater_is_better=True,
-        needs_proba=False,
-        needs_threshold=False,
+predictions = cls.predict(X_test)
+print(
+    "Error rate {:g} using {:s}".format(
+        error_rate(y_test, predictions),
+        cls._automl[0]._metric.name
     )
-    cls = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=60,
-        per_run_time_limit=30,
-        seed=1,
-    )
-    cls.fit(X_train, y_train, metric=accuracy_scorer)
-
-    predictions = cls.predict(X_test)
-    print("Accuracy score {:g} using {:s}".
-          format(sklearn.metrics.accuracy_score(y_test, predictions),
-                 cls._automl[0]._metric.name))
-
-    print("#"*80)
-    print("Use self defined error metric")
-    error_rate = autosklearn.metrics.make_scorer(
-        name='error',
-        score_func=error,
-        optimum=0,
-        greater_is_better=False,
-        needs_proba=False,
-        needs_threshold=False
-    )
-    cls = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=60,
-        per_run_time_limit=30,
-        seed=1
-    )
-    cls.fit(X_train, y_train, metric=error_rate)
-
-    cls.predictions = cls.predict(X_test)
-    print("Error rate {:g} using {:s}".
-          format(error_rate(y_test, predictions),
-                 cls._automl[0]._metric.name))
-
-    # Third example: Use own accuracy metric with additional argument
-    print("#"*80)
-    print("Use self defined accuracy with additional argument")
-    accuracy_scorer = autosklearn.metrics.make_scorer(
-        name="accu_add",
-        score_func=accuracy_wk,
-        optimum=1,
-        greater_is_better=True,
-        needs_proba=False,
-        needs_threshold=False,
-        dummy=None,
-    )
-    cls = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=60,
-        per_run_time_limit=30,
-        seed=1,
-    )
-    cls.fit(X_train, y_train, metric=accuracy_scorer)
-
-    predictions = cls.predict(X_test)
-    print(
-        "Accuracy score {:g} using {:s}".format(
-            sklearn.metrics.accuracy_score(y_test, predictions),
-            cls._automl[0]._metric.name
-        )
-    )
-
-    print("#"*80)
-    print("Use self defined error with additional argument")
-    error_rate = autosklearn.metrics.make_scorer(
-        name="error_add",
-        score_func=error_wk,
-        optimum=0,
-        greater_is_better=True,
-        needs_proba=False,
-        needs_threshold=False,
-        dummy=None,
-    )
-    cls = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=60,
-        per_run_time_limit=30,
-        seed=1,
-    )
-    cls.fit(X_train, y_train, metric=error_rate)
-
-    predictions = cls.predict(X_test)
-    print(
-        "Error rate {:g} using {:s}".format(
-            error_rate(y_test, predictions),
-            cls._automl[0]._metric.name
-        )
-    )
-
-
-if __name__ == "__main__":
-    main()
+)

--- a/examples/example_metrics.py
+++ b/examples/example_metrics.py
@@ -23,7 +23,7 @@ import autosklearn.metrics
 
 ############################################################################
 # Custom metrics definition
-# ======================================
+# =========================
 
 def accuracy(solution, prediction):
     # custom function defining accuracy
@@ -49,7 +49,7 @@ def error_wk(solution, prediction, dummy):
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -57,7 +57,7 @@ X_train, X_test, y_train, y_test = \
 
 ############################################################################
 # Print a list of available metrics
-# ======================================
+# =================================
 
 print("Available CLASSIFICATION metrics autosklearn.metrics.*:")
 print("\t*" + "\n\t*".join(autosklearn.metrics.CLASSIFICATION_METRICS))
@@ -67,7 +67,7 @@ print("\t*" + "\n\t*".join(autosklearn.metrics.REGRESSION_METRICS))
 
 ############################################################################
 # First example: Use predefined accuracy metric
-# ======================================
+# =============================================
 
 print("#"*80)
 print("Use predefined accuracy metric")
@@ -85,7 +85,7 @@ print("Accuracy score {:g} using {:s}".
 
 ############################################################################
 # Second example: Use own accuracy metric
-# ======================================
+# =======================================
 
 print("#"*80)
 print("Use self defined accuracy metric")
@@ -133,7 +133,7 @@ print("Error rate {:g} using {:s}".
 
 ############################################################################
 # Third example: Use own accuracy metric with additional argument
-# ======================================
+# ===============================================================
 
 print("#"*80)
 print("Use self defined accuracy with additional argument")

--- a/examples/example_parallel_manual_spawning.py
+++ b/examples/example_parallel_manual_spawning.py
@@ -39,6 +39,10 @@ for dir_ in [tmp_folder, output_folder]:
         pass
 
 
+############################################################################
+# Define the spawner
+# ======================================
+
 def get_spawn_classifier(X_train, y_train):
     def spawn_classifier(seed, dataset_name):
         """Spawn a subprocess.
@@ -86,54 +90,58 @@ def get_spawn_classifier(X_train, y_train):
     return spawn_classifier
 
 
-def main():
+############################################################################
+# Data Loading
+# ======================================
 
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    processes = []
-    spawn_classifier = get_spawn_classifier(X_train, y_train)
-    for i in range(4):  # set this at roughly half of your cores
-        p = multiprocessing.Process(
-            target=spawn_classifier,
-            args=(i, 'breast_cancer'),
-        )
-        p.start()
-        processes.append(p)
-    for p in processes:
-        p.join()
-
-    print('Starting to build an ensemble!')
-    automl = AutoSklearnClassifier(
-        time_left_for_this_task=30,
-        per_run_time_limit=15,
-        ml_memory_limit=1024,
-        shared_mode=True,
-        ensemble_size=50,
-        ensemble_nbest=200,
-        tmp_folder=tmp_folder,
-        output_folder=output_folder,
-        initial_configurations_via_metalearning=0,
-        seed=1,
+############################################################################
+# Build and fit the classifier
+# ======================================
+processes = []
+spawn_classifier = get_spawn_classifier(X_train, y_train)
+for i in range(4):  # set this at roughly half of your cores
+    p = multiprocessing.Process(
+        target=spawn_classifier,
+        args=(i, 'breast_cancer'),
     )
+    p.start()
+    processes.append(p)
+for p in processes:
+    p.join()
 
-    # Both the ensemble_size and ensemble_nbest parameters can be changed now if
-    # necessary
-    automl.fit_ensemble(
-        y_train,
-        task=MULTICLASS_CLASSIFICATION,
-        metric=accuracy,
-        precision='32',
-        dataset_name='digits',
-        ensemble_size=20,
-        ensemble_nbest=50,
-    )
+print('Starting to build an ensemble!')
+automl = AutoSklearnClassifier(
+    time_left_for_this_task=30,
+    per_run_time_limit=15,
+    ml_memory_limit=1024,
+    shared_mode=True,
+    ensemble_size=50,
+    ensemble_nbest=200,
+    tmp_folder=tmp_folder,
+    output_folder=output_folder,
+    initial_configurations_via_metalearning=0,
+    seed=1,
+)
 
-    predictions = automl.predict(X_test)
-    print(automl.show_models())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+# Both the ensemble_size and ensemble_nbest parameters can be changed now if
+# necessary
+automl.fit_ensemble(
+    y_train,
+    task=MULTICLASS_CLASSIFICATION,
+    metric=accuracy,
+    precision='32',
+    dataset_name='digits',
+    ensemble_size=20,
+    ensemble_nbest=50,
+)
 
-
-if __name__ == '__main__':
-    main()
+############################################################################
+# Report the score of the final ensemble
+# ======================================
+predictions = automl.predict(X_test)
+print(automl.show_models())
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_parallel_manual_spawning.py
+++ b/examples/example_parallel_manual_spawning.py
@@ -40,8 +40,8 @@ for dir_ in [tmp_folder, output_folder]:
 
 
 ############################################################################
-# Define the spawner
-# ======================================
+# Define utility function for multiprocessing
+# ===========================================
 
 def get_spawn_classifier(X_train, y_train):
     def spawn_classifier(seed, dataset_name):
@@ -92,7 +92,7 @@ def get_spawn_classifier(X_train, y_train):
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -100,7 +100,8 @@ X_train, X_test, y_train, y_test = \
 
 ############################################################################
 # Build and fit the classifier
-# ======================================
+# ============================
+
 processes = []
 spawn_classifier = get_spawn_classifier(X_train, y_train)
 for i in range(4):  # set this at roughly half of your cores
@@ -142,6 +143,7 @@ automl.fit_ensemble(
 ############################################################################
 # Report the score of the final ensemble
 # ======================================
+
 predictions = automl.predict(X_test)
 print(automl.show_models())
 print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_parallel_n_jobs.py
+++ b/examples/example_parallel_n_jobs.py
@@ -22,39 +22,52 @@ import sklearn.metrics
 import autosklearn.classification
 
 
-def main():
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+############################################################################
+# Data Loading
+# ======================================
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-        tmp_folder='/tmp/autosklearn_parallel_1_example_tmp',
-        output_folder='/tmp/autosklearn_parallel_1_example_out',
-        disable_evaluator_output=False,
-        # 'holdout' with 'train_size'=0.67 is the default argument setting
-        # for AutoSklearnClassifier. It is explicitly specified in this example
-        # for demonstrational purpose.
-        resampling_strategy='holdout',
-        resampling_strategy_arguments={'train_size': 0.67},
-        n_jobs=4,
-        # Each one of the 4 jobs is allocated 1024 MB
-        ml_memory_limit=1024,
-        seed=5,
-        delete_output_folder_after_terminate=False,
-        delete_tmp_folder_after_terminate=False,
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+############################################################################
+# Build and fit a classifier
+# ======================================
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+    tmp_folder='/tmp/autosklearn_parallel_1_example_tmp',
+    output_folder='/tmp/autosklearn_parallel_1_example_out',
+    disable_evaluator_output=False,
+    # 'holdout' with 'train_size'=0.67 is the default argument setting
+    # for AutoSklearnClassifier. It is explicitly specified in this example
+    # for demonstrational purpose.
+    resampling_strategy='holdout',
+    resampling_strategy_arguments={'train_size': 0.67},
+    n_jobs=4,
+    # Each one of the 4 jobs is allocated 3GB
+    ml_memory_limit=3072,
+    seed=5,
+    delete_output_folder_after_terminate=False,
+    delete_tmp_folder_after_terminate=False,
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-    # Print the final ensemble constructed by auto-sklearn.
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+############################################################################
+# Print the final ensemble constructed by auto-sklearn.
+# ======================================
+print(automl.show_models())
 
+############################################################################
+# Print statistics about the auto-sklearn run
+# ======================================
 
-if __name__ == '__main__':
-    main()
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+
+############################################################################
+# Get the Score of the final ensemble
+# ======================================
+
+predictions = automl.predict(X_test)
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_parallel_n_jobs.py
+++ b/examples/example_parallel_n_jobs.py
@@ -24,14 +24,14 @@ import autosklearn.classification
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
     sklearn.model_selection.train_test_split(X, y, random_state=1)
 
 ############################################################################
 # Build and fit a classifier
-# ======================================
+# ==========================
 automl = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=120,
     per_run_time_limit=30,
@@ -53,13 +53,13 @@ automl = autosklearn.classification.AutoSklearnClassifier(
 automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
 ############################################################################
-# Print the final ensemble constructed by auto-sklearn.
-# ======================================
+# Print the final ensemble constructed by auto-sklearn
+# ====================================================
 print(automl.show_models())
 
 ############################################################################
 # Print statistics about the auto-sklearn run
-# ======================================
+# ===========================================
 
 # Print statistics about the auto-sklearn run such as number of
 # iterations, number of models failed with a time out.
@@ -67,7 +67,7 @@ print(automl.sprint_statistics())
 
 ############################################################################
 # Get the Score of the final ensemble
-# ======================================
+# ===================================
 
 predictions = automl.predict(X_test)
 print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_parallel_n_jobs.py
+++ b/examples/example_parallel_n_jobs.py
@@ -39,6 +39,8 @@ def main():
         resampling_strategy='holdout',
         resampling_strategy_arguments={'train_size': 0.67},
         n_jobs=4,
+        # Each one of the 4 jobs is allocated 1024 MB
+        ml_memory_limit=1024,
         seed=5,
         delete_output_folder_after_terminate=False,
         delete_tmp_folder_after_terminate=False,

--- a/examples/example_random_search.py
+++ b/examples/example_random_search.py
@@ -24,7 +24,7 @@ import autosklearn.classification
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -33,7 +33,7 @@ X_train, X_test, y_train, y_test = \
 
 ############################################################################
 # Fit a classifier using ROAR
-# ======================================
+# ===========================
 def get_roar_object_callback(
     scenario_dict,
     seed,
@@ -76,7 +76,7 @@ print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
 ############################################################################
 # Fit a classifier using Random Search
-# ======================================
+# ====================================
 def get_random_search_object_callback(
         scenario_dict,
         seed,

--- a/examples/example_random_search.py
+++ b/examples/example_random_search.py
@@ -22,6 +22,18 @@ from smac.scenario.scenario import Scenario
 import autosklearn.classification
 
 
+############################################################################
+# Data Loading
+# ======================================
+
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
+
+
+############################################################################
+# Fit a classifier using ROAR
+# ======================================
 def get_roar_object_callback(
     scenario_dict,
     seed,
@@ -42,6 +54,29 @@ def get_roar_object_callback(
     )
 
 
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120, per_run_time_limit=30,
+    tmp_folder='/tmp/autosklearn_random_search_example_tmp',
+    output_folder='/tmp/autosklearn_random_search_example_out',
+    get_smac_object_callback=get_roar_object_callback,
+    initial_configurations_via_metalearning=0,
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
+
+print('#' * 80)
+print('Results for ROAR.')
+# Print the final ensemble constructed by auto-sklearn via ROAR.
+print(automl.show_models())
+predictions = automl.predict(X_test)
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+
+
+############################################################################
+# Fit a classifier using Random Search
+# ======================================
 def get_random_search_object_callback(
         scenario_dict,
         seed,
@@ -64,50 +99,25 @@ def get_random_search_object_callback(
     )
 
 
-def main():
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+    tmp_folder='/tmp/autosklearn_random_search_example_tmp',
+    output_folder='/tmp/autosklearn_random_search_example_out',
+    get_smac_object_callback=get_random_search_object_callback,
+    initial_configurations_via_metalearning=0,
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120, per_run_time_limit=30,
-        tmp_folder='/tmp/autosklearn_random_search_example_tmp',
-        output_folder='/tmp/autosklearn_random_search_example_out',
-        get_smac_object_callback=get_roar_object_callback,
-        initial_configurations_via_metalearning=0,
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+print('#' * 80)
+print('Results for random search.')
 
-    print('#' * 80)
-    print('Results for ROAR.')
-    # Print the final ensemble constructed by auto-sklearn via ROAR.
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+# Print the final ensemble constructed by auto-sklearn via random search.
+print(automl.show_models())
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-        tmp_folder='/tmp/autosklearn_random_search_example_tmp',
-        output_folder='/tmp/autosklearn_random_search_example_out',
-        get_smac_object_callback=get_random_search_object_callback,
-        initial_configurations_via_metalearning=0,
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
 
-    print('#' * 80)
-    print('Results for random search.')
-    # Print the final ensemble constructed by auto-sklearn via random search.
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
-
-
-if __name__ == '__main__':
-    main()
+predictions = automl.predict(X_test)
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_regression.py
+++ b/examples/example_regression.py
@@ -16,7 +16,7 @@ import autosklearn.regression
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = sklearn.datasets.load_boston(return_X_y=True)
 feature_types = (['numerical'] * 3) + ['categorical'] + (['numerical'] * 9)
@@ -25,7 +25,7 @@ X_train, X_test, y_train, y_test = \
 
 ############################################################################
 # Build and fit a regressor
-# ======================================
+# =========================
 
 automl = autosklearn.regression.AutoSklearnRegressor(
     time_left_for_this_task=120,
@@ -37,14 +37,14 @@ automl.fit(X_train, y_train, dataset_name='boston',
            feat_type=feature_types)
 
 ############################################################################
-# Print the final ensemble constructed by auto-sklearn.
-# ======================================
+# Print the final ensemble constructed by auto-sklearn
+# ====================================================
 
 print(automl.show_models())
 
 ###########################################################################
 # Get the Score of the final ensemble
-# ======================================
+# ===================================
 
 predictions = automl.predict(X_test)
 print("R2 score:", sklearn.metrics.r2_score(y_test, predictions))

--- a/examples/example_regression.py
+++ b/examples/example_regression.py
@@ -14,25 +14,37 @@ import sklearn.metrics
 import autosklearn.regression
 
 
-def main():
-    X, y = sklearn.datasets.load_boston(return_X_y=True)
-    feature_types = (['numerical'] * 3) + ['categorical'] + (['numerical'] * 9)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+############################################################################
+# Data Loading
+# ======================================
 
-    automl = autosklearn.regression.AutoSklearnRegressor(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-        tmp_folder='/tmp/autosklearn_regression_example_tmp',
-        output_folder='/tmp/autosklearn_regression_example_out',
-    )
-    automl.fit(X_train, y_train, dataset_name='boston',
-               feat_type=feature_types)
+X, y = sklearn.datasets.load_boston(return_X_y=True)
+feature_types = (['numerical'] * 3) + ['categorical'] + (['numerical'] * 9)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    print("R2 score:", sklearn.metrics.r2_score(y_test, predictions))
+############################################################################
+# Build and fit a regressor
+# ======================================
 
+automl = autosklearn.regression.AutoSklearnRegressor(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+    tmp_folder='/tmp/autosklearn_regression_example_tmp',
+    output_folder='/tmp/autosklearn_regression_example_out',
+)
+automl.fit(X_train, y_train, dataset_name='boston',
+           feat_type=feature_types)
 
-if __name__ == '__main__':
-    main()
+############################################################################
+# Print the final ensemble constructed by auto-sklearn.
+# ======================================
+
+print(automl.show_models())
+
+###########################################################################
+# Get the Score of the final ensemble
+# ======================================
+
+predictions = automl.predict(X_test)
+print("R2 score:", sklearn.metrics.r2_score(y_test, predictions))

--- a/examples/example_sequential.py
+++ b/examples/example_sequential.py
@@ -16,32 +16,45 @@ import sklearn.metrics
 import autosklearn.classification
 
 
-def main():
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1)
+############################################################################
+# Data Loading
+# ======================================
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=120,
-        per_run_time_limit=30,
-        tmp_folder='/tmp/autosklearn_sequential_example_tmp',
-        output_folder='/tmp/autosklearn_sequential_example_out',
-        # Do not construct ensembles in parallel to avoid using more than one
-        # core at a time. The ensemble will be constructed after auto-sklearn
-        # finished fitting all machine learning models.
-        ensemble_size=0,
-        delete_tmp_folder_after_terminate=False,
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
-    # This call to fit_ensemble uses all models trained in the previous call
-    # to fit to build an ensemble which can be used with automl.predict()
-    automl.fit_ensemble(y_train, ensemble_size=50)
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1)
 
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+############################################################################
+# Build and fit the classifier
+# ======================================
 
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120,
+    per_run_time_limit=30,
+    tmp_folder='/tmp/autosklearn_sequential_example_tmp',
+    output_folder='/tmp/autosklearn_sequential_example_out',
+    # Do not construct ensembles in parallel to avoid using more than one
+    # core at a time. The ensemble will be constructed after auto-sklearn
+    # finished fitting all machine learning models.
+    ensemble_size=0,
+    delete_tmp_folder_after_terminate=False,
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-if __name__ == '__main__':
-    main()
+# This call to fit_ensemble uses all models trained in the previous call
+# to fit to build an ensemble which can be used with automl.predict()
+automl.fit_ensemble(y_train, ensemble_size=50)
+
+############################################################################
+# Print the final ensemble constructed by auto-sklearn.
+# ======================================
+
+print(automl.show_models())
+
+############################################################################
+# Get the Score of the final ensemble
+# ======================================
+
+predictions = automl.predict(X_test)
+print(automl.sprint_statistics())
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_sequential.py
+++ b/examples/example_sequential.py
@@ -46,14 +46,14 @@ automl.fit(X_train, y_train, dataset_name='breast_cancer')
 automl.fit_ensemble(y_train, ensemble_size=50)
 
 ############################################################################
-# Print the final ensemble constructed by auto-sklearn.
-# ======================================
+# Print the final ensemble constructed by auto-sklearn
+# ====================================================
 
 print(automl.show_models())
 
 ############################################################################
 # Get the Score of the final ensemble
-# ======================================
+# ===================================
 
 predictions = automl.predict(X_test)
 print(automl.sprint_statistics())

--- a/examples/example_successive_halving.py
+++ b/examples/example_successive_halving.py
@@ -19,7 +19,7 @@ import autosklearn.classification
 
 
 ############################################################################
-# Define a small callback that instantiates SuccessiveHalving
+# Define a callback that instantiates SuccessiveHalving
 # ======================================
 
 def get_smac_object_callback(budget_type):

--- a/examples/example_successive_halving.py
+++ b/examples/example_successive_halving.py
@@ -18,6 +18,10 @@ import sklearn.metrics
 import autosklearn.classification
 
 
+############################################################################
+# Define a small callback that instantiates SuccessiveHalving
+# ======================================
+
 def get_smac_object_callback(budget_type):
     def get_smac_object(
         scenario_dict,
@@ -63,151 +67,165 @@ def get_smac_object_callback(budget_type):
     return get_smac_object
 
 
-def main():
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
+############################################################################
+# Data Loading
+# ======================================
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=30,
-        per_run_time_limit=5,
-        tmp_folder='/tmp/autosklearn_sh_example_tmp',
-        output_folder='/tmp/autosklearn_sh_example_out',
-        disable_evaluator_output=False,
-        # 'holdout' with 'train_size'=0.67 is the default argument setting
-        # for AutoSklearnClassifier. It is explicitly specified in this example
-        # for demonstrational purpose.
-        resampling_strategy='holdout',
-        resampling_strategy_arguments={'train_size': 0.67},
-        include_estimators=['extra_trees', 'gradient_boosting', 'random_forest', 'sgd',
-                            'passive_aggressive'],
-        include_preprocessors=['no_preprocessing'],
-        get_smac_object_callback=get_smac_object_callback('iterations'),
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
 
-    # Print the final ensemble constructed by auto-sklearn.
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+############################################################################
+# Build and fit a classifier
+# ======================================
 
-    # We can also use cross-validation with successive halving
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=30,
+    per_run_time_limit=5,
+    tmp_folder='/tmp/autosklearn_sh_example_tmp',
+    output_folder='/tmp/autosklearn_sh_example_out',
+    disable_evaluator_output=False,
+    # 'holdout' with 'train_size'=0.67 is the default argument setting
+    # for AutoSklearnClassifier. It is explicitly specified in this example
+    # for demonstrational purpose.
+    resampling_strategy='holdout',
+    resampling_strategy_arguments={'train_size': 0.67},
+    include_estimators=['extra_trees', 'gradient_boosting', 'random_forest', 'sgd',
+                        'passive_aggressive'],
+    include_preprocessors=['no_preprocessing'],
+    get_smac_object_callback=get_smac_object_callback('iterations'),
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=30,
-        per_run_time_limit=5,
-        tmp_folder='/tmp/autosklearn_sh_example_tmp',
-        output_folder='/tmp/autosklearn_sh_example_out',
-        disable_evaluator_output=False,
-        resampling_strategy='cv',
-        include_estimators=['extra_trees', 'gradient_boosting', 'random_forest', 'sgd',
-                            'passive_aggressive'],
-        include_preprocessors=['no_preprocessing'],
-        get_smac_object_callback=get_smac_object_callback('iterations'),
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+print(automl.show_models())
+predictions = automl.predict(X_test)
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
-    # Print the final ensemble constructed by auto-sklearn.
-    print(automl.show_models())
-    automl.refit(X_train, y_train)
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+############################################################################
+# We can also use cross-validation with successive halving
+# ======================================
 
-    # It is also possible to use an iterative fit cross-validation with successive halving
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=30,
-        per_run_time_limit=5,
-        tmp_folder='/tmp/autosklearn_sh_example_tmp',
-        output_folder='/tmp/autosklearn_sh_example_out',
-        disable_evaluator_output=False,
-        resampling_strategy='cv-iterative-fit',
-        include_estimators=['extra_trees', 'gradient_boosting', 'random_forest', 'sgd',
-                            'passive_aggressive'],
-        include_preprocessors=['no_preprocessing'],
-        get_smac_object_callback=get_smac_object_callback('iterations'),
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=30,
+    per_run_time_limit=5,
+    tmp_folder='/tmp/autosklearn_sh_example_tmp',
+    output_folder='/tmp/autosklearn_sh_example_out',
+    disable_evaluator_output=False,
+    resampling_strategy='cv',
+    include_estimators=['extra_trees', 'gradient_boosting', 'random_forest', 'sgd',
+                        'passive_aggressive'],
+    include_preprocessors=['no_preprocessing'],
+    get_smac_object_callback=get_smac_object_callback('iterations'),
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-    # Print the final ensemble constructed by auto-sklearn.
-    print(automl.show_models())
-    automl.refit(X_train, y_train)
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+# Print the final ensemble constructed by auto-sklearn.
+print(automl.show_models())
+automl.refit(X_train, y_train)
+predictions = automl.predict(X_test)
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
-    # Next, we see the use of subsampling as a budget in Auto-sklearn
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
+############################################################################
+# It is also possible to use an iterative fit cross-validation with successive halving
+# ======================================
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=30,
-        per_run_time_limit=5,
-        tmp_folder='/tmp/autosklearn_sh_example_tmp',
-        output_folder='/tmp/autosklearn_sh_example_out',
-        disable_evaluator_output=False,
-        # 'holdout' with 'train_size'=0.67 is the default argument setting
-        # for AutoSklearnClassifier. It is explicitly specified in this example
-        # for demonstrational purpose.
-        resampling_strategy='holdout',
-        resampling_strategy_arguments={'train_size': 0.67},
-        get_smac_object_callback=get_smac_object_callback('subsample'),
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
 
-    # Print the final ensemble constructed by auto-sklearn.
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=30,
+    per_run_time_limit=5,
+    tmp_folder='/tmp/autosklearn_sh_example_tmp',
+    output_folder='/tmp/autosklearn_sh_example_out',
+    disable_evaluator_output=False,
+    resampling_strategy='cv-iterative-fit',
+    include_estimators=['extra_trees', 'gradient_boosting', 'random_forest', 'sgd',
+                        'passive_aggressive'],
+    include_preprocessors=['no_preprocessing'],
+    get_smac_object_callback=get_smac_object_callback('iterations'),
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-    # Finally, there's a mixed budget type which uses iterations where possible and
-    # subsamples otherwise
-    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = \
-        sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
+# Print the final ensemble constructed by auto-sklearn.
+print(automl.show_models())
+automl.refit(X_train, y_train)
+predictions = automl.predict(X_test)
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
-    automl = autosklearn.classification.AutoSklearnClassifier(
-        time_left_for_this_task=30,
-        per_run_time_limit=5,
-        tmp_folder='/tmp/autosklearn_sh_example_tmp',
-        output_folder='/tmp/autosklearn_sh_example_out',
-        disable_evaluator_output=False,
-        # 'holdout' with 'train_size'=0.67 is the default argument setting
-        # for AutoSklearnClassifier. It is explicitly specified in this example
-        # for demonstrational purpose.
-        resampling_strategy='holdout',
-        resampling_strategy_arguments={'train_size': 0.67},
-        include_estimators=['extra_trees', 'gradient_boosting', 'random_forest', 'sgd'],
-        get_smac_object_callback=get_smac_object_callback('mixed'),
-    )
-    automl.fit(X_train, y_train, dataset_name='breast_cancer')
+############################################################################
+# Next, we see the use of subsampling as a budget in Auto-sklearn
+# ======================================
 
-    # Print the final ensemble constructed by auto-sklearn.
-    print(automl.show_models())
-    predictions = automl.predict(X_test)
-    # Print statistics about the auto-sklearn run such as number of
-    # iterations, number of models failed with a time out.
-    print(automl.sprint_statistics())
-    print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
 
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=30,
+    per_run_time_limit=5,
+    tmp_folder='/tmp/autosklearn_sh_example_tmp',
+    output_folder='/tmp/autosklearn_sh_example_out',
+    disable_evaluator_output=False,
+    # 'holdout' with 'train_size'=0.67 is the default argument setting
+    # for AutoSklearnClassifier. It is explicitly specified in this example
+    # for demonstrational purpose.
+    resampling_strategy='holdout',
+    resampling_strategy_arguments={'train_size': 0.67},
+    get_smac_object_callback=get_smac_object_callback('subsample'),
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-if __name__ == '__main__':
-    main()
+# Print the final ensemble constructed by auto-sklearn.
+print(automl.show_models())
+predictions = automl.predict(X_test)
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+
+############################################################################
+# Finally, there's a mixed budget type which uses iterations where possible and
+# subsamples otherwise
+# ======================================
+
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = \
+    sklearn.model_selection.train_test_split(X, y, random_state=1, shuffle=True)
+
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=30,
+    per_run_time_limit=5,
+    tmp_folder='/tmp/autosklearn_sh_example_tmp',
+    output_folder='/tmp/autosklearn_sh_example_out',
+    disable_evaluator_output=False,
+    # 'holdout' with 'train_size'=0.67 is the default argument setting
+    # for AutoSklearnClassifier. It is explicitly specified in this example
+    # for demonstrational purpose.
+    resampling_strategy='holdout',
+    resampling_strategy_arguments={'train_size': 0.67},
+    include_estimators=['extra_trees', 'gradient_boosting', 'random_forest', 'sgd'],
+    get_smac_object_callback=get_smac_object_callback('mixed'),
+)
+automl.fit(X_train, y_train, dataset_name='breast_cancer')
+
+# Print the final ensemble constructed by auto-sklearn.
+print(automl.show_models())
+predictions = automl.predict(X_test)
+# Print statistics about the auto-sklearn run such as number of
+# iterations, number of models failed with a time out.
+print(automl.sprint_statistics())
+print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/example_successive_halving.py
+++ b/examples/example_successive_halving.py
@@ -2,7 +2,14 @@
 ==================
 Successive Halving
 ==================
-"""
+
+This advanced  example illustrates how to interact with
+the SMAC callback and get relevant information from the run, like
+the number of iterations. Particularly, it exemplifies how to select
+the intensification strategy to use in smac, in this case:
+`SuccessiveHalving <http://proceedings.mlr.press/v80/falkner18a/falkner18a-supp.pdf>`_.
+"""  # noqa (links are too long)
+
 
 import sklearn.model_selection
 import sklearn.datasets

--- a/examples/example_successive_halving.py
+++ b/examples/example_successive_halving.py
@@ -20,7 +20,7 @@ import autosklearn.classification
 
 ############################################################################
 # Define a callback that instantiates SuccessiveHalving
-# ======================================
+# =====================================================
 
 def get_smac_object_callback(budget_type):
     def get_smac_object(
@@ -69,7 +69,7 @@ def get_smac_object_callback(budget_type):
 
 ############################################################################
 # Data Loading
-# ======================================
+# ============
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -77,7 +77,7 @@ X_train, X_test, y_train, y_test = \
 
 ############################################################################
 # Build and fit a classifier
-# ======================================
+# ==========================
 
 automl = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=30,
@@ -106,7 +106,7 @@ print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
 ############################################################################
 # We can also use cross-validation with successive halving
-# ======================================
+# ========================================================
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -136,8 +136,8 @@ print(automl.sprint_statistics())
 print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
 ############################################################################
-# It is also possible to use an iterative fit cross-validation with successive halving
-# ======================================
+# Use an iterative fit cross-validation with successive halving
+# =============================================================
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -168,7 +168,7 @@ print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
 ############################################################################
 # Next, we see the use of subsampling as a budget in Auto-sklearn
-# ======================================
+# ===============================================================
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \
@@ -198,9 +198,10 @@ print(automl.sprint_statistics())
 print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
 
 ############################################################################
+# Mixed budget approach
+# =====================
 # Finally, there's a mixed budget type which uses iterations where possible and
 # subsamples otherwise
-# ======================================
 
 X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = \


### PR DESCRIPTION
This PR enhances the documentation of autosklearn via:

- Rendering the examples in the web page: Aligned travis configuration to what openml has, fixed some docs configurations that where outdated and re-arenged examples so that they could be rendered via rest code blocks (else output is shown before code).

- Improved ML memory limit via example addition and API doc

- Updated installation documentation due to #856

- 