### PR TITLE
Add exceptions to log file, not just stdout

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -402,11 +402,7 @@ class AutoML(BaseEstimator):
         # == Perform dummy predictions
         num_run = 1
         # if self._resampling_strategy in ['holdout', 'holdout-iterative-fit']:
-        try:
-            num_run = self._do_dummy_prediction(datamanager, num_run)
-        except Exception as e:
-            self._logger.exception(e)
-            raise
+        num_run = self._do_dummy_prediction(datamanager, num_run)
 
         # = Create a searchspace
         # Do this before One Hot Encoding to make sure that it creates a

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -390,47 +390,6 @@ class AutoMLTest(Base, unittest.TestCase):
         self._tearDown(backend_api.temporary_directory)
         self._tearDown(backend_api.output_directory)
 
-    @unittest.mock.patch('autosklearn.evaluation.ExecuteTaFuncWithQueue.run')
-    def test_exceptions_inside_log_in_ta(self, ta_run_mock):
-
-        # Make sure that any exception during the AutoML fit due to
-        # SMAC are properly captured in a log file
-        backend_api = self._create_backend('test_exceptions_inside_log')
-        self._tearDown(backend_api.temporary_directory)
-        self._tearDown(backend_api.output_directory)
-
-        automl = autosklearn.automl.AutoML(backend_api, 20, 5)
-
-        output_file = 'test_exceptions_inside_log.log'
-        setup_logger(output_file=output_file)
-        logger = get_logger('test_exceptions_inside_log')
-
-        # Create a custom exception to prevent other errors to slip in
-        class MyException(Exception):
-            pass
-
-        X_train, Y_train, X_test, Y_test = putil.get_dataset('iris')
-        # The first call is on dummy predictor failure
-        message = str(np.random.randint(100)) + '_do_dummy_prediction'
-        ta_run_mock.side_effect = MyException(message)
-
-        with unittest.mock.patch('autosklearn.automl.AutoML._get_logger') as mock:
-            mock.return_value = logger
-            with self.assertRaises(MyException):
-                automl.fit(
-                    X_train,
-                    Y_train,
-                    metric=accuracy,
-                    task=MULTICLASS_CLASSIFICATION,
-                )
-            with open(output_file) as f:
-                self.assertTrue(message in f.read())
-
-        # Cleanup
-        os.unlink(output_file)
-        self._tearDown(backend_api.temporary_directory)
-        self._tearDown(backend_api.output_directory)
-
     @unittest.mock.patch('autosklearn.smbo.AutoMLSMBO.run_smbo')
     def test_exceptions_inside_log_in_smbo(self, smbo_run_mock):
 

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -390,6 +390,88 @@ class AutoMLTest(Base, unittest.TestCase):
         self._tearDown(backend_api.temporary_directory)
         self._tearDown(backend_api.output_directory)
 
+    @unittest.mock.patch('autosklearn.evaluation.ExecuteTaFuncWithQueue.run')
+    def test_exceptions_inside_log_in_ta(self, ta_run_mock):
+
+        # Make sure that any exception during the AutoML fit due to
+        # SMAC are properly captured in a log file
+        backend_api = self._create_backend('test_exceptions_inside_log')
+        self._tearDown(backend_api.temporary_directory)
+        self._tearDown(backend_api.output_directory)
+
+        automl = autosklearn.automl.AutoML(backend_api, 20, 5)
+
+        output_file = 'test_exceptions_inside_log.log'
+        setup_logger(output_file=output_file)
+        logger = get_logger('test_exceptions_inside_log')
+
+        # Create a custom exception to prevent other errors to slip in
+        class MyException(Exception):
+            pass
+
+        X_train, Y_train, X_test, Y_test = putil.get_dataset('iris')
+        # The first call is on dummy predictor failure
+        message = str(np.random.randint(100)) + '_do_dummy_prediction'
+        ta_run_mock.side_effect = MyException(message)
+
+        with unittest.mock.patch('autosklearn.automl.AutoML._get_logger') as mock:
+            mock.return_value = logger
+            with self.assertRaises(MyException):
+                automl.fit(
+                    X_train,
+                    Y_train,
+                    metric=accuracy,
+                    task=MULTICLASS_CLASSIFICATION,
+                )
+            with open(output_file) as f:
+                self.assertTrue(message in f.read())
+
+        # Cleanup
+        os.unlink(output_file)
+        self._tearDown(backend_api.temporary_directory)
+        self._tearDown(backend_api.output_directory)
+
+    @unittest.mock.patch('autosklearn.smbo.AutoMLSMBO.run_smbo')
+    def test_exceptions_inside_log_in_smbo(self, smbo_run_mock):
+
+        # Make sure that any exception during the AutoML fit due to
+        # SMAC are properly captured in a log file
+        backend_api = self._create_backend('test_exceptions_inside_log')
+        self._tearDown(backend_api.temporary_directory)
+        self._tearDown(backend_api.output_directory)
+
+        automl = autosklearn.automl.AutoML(backend_api, 20, 5)
+
+        output_file = 'test_exceptions_inside_log.log'
+        setup_logger(output_file=output_file)
+        logger = get_logger('test_exceptions_inside_log')
+
+        # Create a custom exception to prevent other errors to slip in
+        class MyException(Exception):
+            pass
+
+        X_train, Y_train, X_test, Y_test = putil.get_dataset('iris')
+        # The first call is on dummy predictor failure
+        message = str(np.random.randint(100)) + '_run_smbo'
+        smbo_run_mock.side_effect = MyException(message)
+
+        with unittest.mock.patch('autosklearn.automl.AutoML._get_logger') as mock:
+            mock.return_value = logger
+            with self.assertRaises(MyException):
+                automl.fit(
+                    X_train,
+                    Y_train,
+                    metric=accuracy,
+                    task=MULTICLASS_CLASSIFICATION,
+                )
+            with open(output_file) as f:
+                self.assertTrue(message in f.read())
+
+        # Cleanup
+        os.unlink(output_file)
+        self._tearDown(backend_api.temporary_directory)
+        self._tearDown(backend_api.output_directory)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Catch calls to AbstractTAFunc so that they are registered in the log file

Added 2 test, 1 to make sure direct calls two ExecuteTaFuncWithQueue are caught and the other abstract calls to smbo 