### PR TITLE
715 ml memory

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -304,7 +304,11 @@ class AutoML(BaseEstimator):
             return num_run
 
         self._logger.info("Starting to create dummy predictions.")
-        memory_limit = int(self._ml_memory_limit)
+
+        memory_limit = self._ml_memory_limit
+        if memory_limit is not None:
+            memory_limit = int(memory_limit)
+
         scenario_mock = unittest.mock.Mock()
         scenario_mock.wallclock_limit = self._time_for_task
         # This stats object is a hack - maybe the SMAC stats object should

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -97,6 +97,7 @@ class AutoSklearnEstimator(BaseEstimator):
             Memory limit in MB for the machine learning algorithm.
             `auto-sklearn` will stop fitting the machine learning algorithm if
             it tries to allocate more than `ml_memory_limit` MB.
+            If None is provided, no memory limit is set.
 
         include_estimators : list, optional (None)
             If None, all possible estimators are used. Otherwise specifies


### PR DESCRIPTION
Fix one point in autosklearn that forces ml memory limit to be an integer, so we can use https://github.com/sfalkner/pynisher with None.

Updated API if None is provided, so no memory limit is enforced