### PR TITLE
Do not read predictions in memory, only after score

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -667,7 +667,7 @@ class AutoML(BaseEstimator):
 
         return predictions
 
-    def fit_ensemble(self, y, task=None, metric=None, precision='32',
+    def fit_ensemble(self, y, task=None, metric=None, precision=32,
                      dataset_name=None, ensemble_nbest=None,
                      ensemble_size=None):
         if self._resampling_strategy in ['partial-cv', 'partial-cv-iterative-fit']:
@@ -1000,7 +1000,7 @@ class BaseAutoML(AutoML):
 
         return super().refit(X, y)
 
-    def fit_ensemble(self, y, task=None, metric=None, precision='32',
+    def fit_ensemble(self, y, task=None, metric=None, precision=32,
                      dataset_name=None, ensemble_nbest=None,
                      ensemble_size=None):
         _n_outputs = 1 if len(y.shape) == 1 else y.shape[1]
@@ -1081,7 +1081,7 @@ class AutoMLClassifier(BaseAutoML):
             load_models=load_models,
         )
 
-    def fit_ensemble(self, y, task=None, metric=None, precision='32',
+    def fit_ensemble(self, y, task=None, metric=None, precision=32,
                      dataset_name=None, ensemble_nbest=None,
                      ensemble_size=None):
         y, _classes, _n_classes = self._process_target_classes(y)
@@ -1176,7 +1176,7 @@ class AutoMLRegressor(BaseAutoML):
             load_models=load_models,
         )
 
-    def fit_ensemble(self, y, task=None, metric=None, precision='32',
+    def fit_ensemble(self, y, task=None, metric=None, precision=32,
                      dataset_name=None, ensemble_nbest=None,
                      ensemble_size=None):
         y = super()._check_y(y)

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -56,7 +56,7 @@ class EnsembleTest(unittest.TestCase):
             seed=0,  # important to find the test files
         )
 
-        success = ensbuilder.read_ensemble_preds()
+        success = ensbuilder.score_ensemble_preds()
         self.assertTrue(success, str(ensbuilder.read_preds))
         self.assertEqual(len(ensbuilder.read_preds), 3)
 
@@ -93,7 +93,7 @@ class EnsembleTest(unittest.TestCase):
                 max_models_on_disc=models_in_disc,
             )
 
-            ensbuilder.read_ensemble_preds()
+            ensbuilder.score_ensemble_preds()
             sel_keys = ensbuilder.get_n_best_preds()
 
             self.assertEqual(len(sel_keys), exp)
@@ -168,7 +168,7 @@ class EnsembleTest(unittest.TestCase):
                                      ensemble_nbest=1
                                      )
 
-        ensbuilder.read_ensemble_preds()
+        ensbuilder.score_ensemble_preds()
 
         filename = os.path.join(
             self.backend.temporary_directory,
@@ -209,7 +209,7 @@ class EnsembleTest(unittest.TestCase):
                                      ensemble_nbest=1
                                      )
 
-        ensbuilder.read_ensemble_preds()
+        ensbuilder.score_ensemble_preds()
 
         d1 = os.path.join(
             self.backend.temporary_directory,
@@ -251,7 +251,7 @@ class EnsembleTest(unittest.TestCase):
         )
         ensbuilder.SAVE2DISC = False
 
-        ensbuilder.read_ensemble_preds()
+        ensbuilder.score_ensemble_preds()
 
         d2 = os.path.join(
             self.backend.temporary_directory,


### PR DESCRIPTION
- Code cleanup for _read_np_fn

- Fix the precision type when reading files, in _read_np_fn

- Score the predictions without reading them. Only read the actual file when we are sure it is the best prediction.