### PR TITLE
Fix dataprocessing get params

### DIFF
--- a/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
@@ -11,6 +11,7 @@ from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, SIGNED_
 class Balancing(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, strategy='none', random_state=None):
         self.strategy = strategy
+        self.random_state = random_state
 
     def fit(self, X, y=None):
         return self

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing.py
@@ -32,7 +32,15 @@ class DataPreprocessor(AutoSklearnComponent):
             if categorical_features.dtype != 'bool':
                 raise ValueError('Parameter categorical_features must'
                                  ' only contain booleans.')
+        self.config = config
+        self.pipeline = pipeline
+        self.dataset_properties = dataset_properties
+        self.include = include
+        self.exclude = exclude
+        self.random_state = random_state
+        self.init_params = init_params
         self.categorical_features = categorical_features
+        self.force_sparse_output = force_sparse_output
 
         # The pipeline that will be applied to the categorical features (i.e. columns)
         # of the dataset
@@ -48,7 +56,6 @@ class DataPreprocessor(AutoSklearnComponent):
             ["categorical_transformer", self.categ_ppl],
             ["numerical_transformer", self.numer_ppl],
         ]
-        self.force_sparse = force_sparse_output
 
     def fit(self, X, y=None):
         n_feats = X.shape[1]
@@ -73,7 +80,7 @@ class DataPreprocessor(AutoSklearnComponent):
                 ["numerical_transformer", self.numer_ppl, num_feats]
             ]
 
-        self.sparse_ = sparse.issparse(X) or self.force_sparse
+        self.sparse_ = sparse.issparse(X) or self.force_sparse_output
         self.column_transformer = sklearn.compose.ColumnTransformer(
             transformers=sklearn_transf_spec,
             sparse_threshold=float(self.sparse_),

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -8,6 +8,7 @@ import unittest.mock
 import numpy as np
 import sklearn.datasets
 import sklearn.decomposition
+from sklearn.base import clone
 import sklearn.ensemble
 import sklearn.svm
 
@@ -369,6 +370,30 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
     @unittest.skip("test_validate_input_Y Not yet Implemented")
     def test_validate_input_Y(self):
         raise NotImplementedError()
+
+    def test_pipeline_clonability(self):
+        X_train, Y_train, X_test, Y_test = get_dataset(dataset='boston')
+        auto = SimpleRegressionPipeline()
+        auto = auto.fit(X_train, Y_train)
+        auto_clone = clone(auto)
+        auto_clone_params = auto_clone.get_params()
+
+        # Make sure all keys are copied properly
+        for k, v in auto.get_params().items():
+            self.assertIn(k, auto_clone_params)
+
+        # Make sure the params getter of estimator are honored
+        klass = auto.__class__
+        new_object_params = auto.get_params(deep=False)
+        for name, param in new_object_params.items():
+            new_object_params[name] = clone(param, safe=False)
+        new_object = klass(**new_object_params)
+        params_set = new_object.get_params(deep=False)
+
+        for name in new_object_params:
+            param1 = new_object_params[name]
+            param2 = params_set[name]
+            self.assertEqual(param1, param2)
 
     def test_set_params(self):
         pass


### PR DESCRIPTION
This issue is Related to #876 

Autosklearn relies on get  parameters to clone a estimator as can be seen in https://github.com/scikit-learn/scikit-learn/blob/fd237278e/sklearn/base.py#L152

The data preprocessing was missing some element's definition in the constructor of the method.

This PR is meant to fix this and add a check to make sure we can safely clone an estimator.