### PR TITLE
Allow 1-D threshold binary predictions

### DIFF
--- a/autosklearn/metrics/__init__.py
+++ b/autosklearn/metrics/__init__.py
@@ -125,7 +125,8 @@ class _ThresholdScorer(Scorer):
             raise ValueError("{0} format is not supported".format(y_type))
 
         if y_type == "binary":
-            y_pred = y_pred[:, 1]
+            if y_pred.ndim > 1:
+                y_pred = y_pred[:, 1]
         elif isinstance(y_pred, list):
             y_pred = np.vstack([p[:, -1] for p in y_pred]).T
 


### PR DESCRIPTION
This issue is related to #875 

The threshold scorer was always assuming a one-hot encoding on the prediction.

I think the scorer should be robust enough to handle predictions without one-hot encoding, please let me know if that is not the expectation. 