### PR TITLE
Added pandas support

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -986,8 +986,6 @@ class BaseAutoML(AutoML):
     def fit_ensemble(self, y, task=None, precision=32,
                      dataset_name=None, ensemble_nbest=None,
                      ensemble_size=None):
-        # Make sure that input is valid
-        y = self.InputValidator.validate_target(y)
 
         return super().fit_ensemble(
             y, task=task, precision=precision,
@@ -1047,6 +1045,18 @@ class AutoMLClassifier(BaseAutoML):
             load_models=load_models,
         )
 
+    def fit_ensemble(self, y, task=None, precision=32,
+                     dataset_name=None, ensemble_nbest=None,
+                     ensemble_size=None):
+        # Make sure that input is valid
+        y = self.InputValidator.validate_target(y, is_classification=True)
+
+        return super().fit_ensemble(
+            y, task=task, precision=precision,
+            dataset_name=dataset_name, ensemble_nbest=ensemble_nbest,
+            ensemble_size=ensemble_size
+        )
+
     def predict(self, X, batch_size=None, n_jobs=1):
         predicted_probabilities = super().predict(X, batch_size=batch_size,
                                                   n_jobs=n_jobs)
@@ -1100,4 +1110,16 @@ class AutoMLRegressor(BaseAutoML):
             dataset_name=dataset_name,
             only_return_configuration_space=only_return_configuration_space,
             load_models=load_models,
+        )
+
+    def fit_ensemble(self, y, task=None, precision=32,
+                     dataset_name=None, ensemble_nbest=None,
+                     ensemble_size=None):
+        # Make sure that input is valid
+        y = self.InputValidator.validate_target(y)
+
+        return super().fit_ensemble(
+            y, task=task, precision=precision,
+            dataset_name=dataset_name, ensemble_nbest=ensemble_nbest,
+            ensemble_size=ensemble_size
         )

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -530,9 +530,6 @@ class AutoML(BaseEstimator):
         if self.ensemble_ is None:
             raise ValueError("Refit can only be called if 'ensemble_size != 0'")
 
-        # Input Validation happens on estimator
-        # So no need to call input validator here
-
         random_state = np.random.RandomState(self._seed)
         for identifier in self.models_:
             model = self.models_[identifier]

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -192,7 +192,7 @@ class AutoML(BaseEstimator):
         self._debug_mode = debug_mode
 
         self.InputValidator = InputValidator()
-        
+
         # Place holder for the run history of the
         # Ensemble building process
         self.ensemble_performance_history = []

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -126,7 +126,7 @@ class InputValidator:
 
         # In code check to make sure everything is numeric
         if hasattr(y, "iloc"):
-            is_number = np.vectorize(lambda x: np.issubdtype(x, np.number))
+            is_number = np.vectorize(lambda x: pd.api.types.is_numeric_dtype(x))
             if not np.all(is_number(y.dtypes)):
                 raise ValueError(
                     "Input dataframe to autosklearn must only contain numerical"
@@ -268,7 +268,7 @@ class InputValidator:
 
         # In code check to make sure everything is numeric
         if hasattr(X, "iloc"):
-            is_number = np.vectorize(lambda x: np.issubdtype(x, np.number))
+            is_number = np.vectorize(lambda x: pd.api.types.is_numeric_dtype(x))
             if not np.all(is_number(X.dtypes)):
                 raise ValueError(
                     "Failed to convert the input dataframe to numerical dtypes: {}".format(

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -1,0 +1,297 @@
+# -*- encoding: utf-8 -*-
+
+from typing import Union, Tuple
+import warnings
+
+import numpy as np
+import pandas as pd
+
+import sklearn.utils
+from sklearn import preprocessing
+from sklearn.compose import make_column_transformer
+
+import scipy.sparse
+
+
+class InputValidator:
+    """
+    Makes sure the input data complies with Auto-sklearn requirements.
+    Categorical inputs are encoded via a Label Encoder, if the input
+    is a dataframe.
+
+    This class also perform checks for data integrity and flags the user
+    via informative errors.
+    """
+    def __init__(
+        self,
+        feature_encoder_type: str = 'OrdinalEncoder',
+        target_encoder_type: str = 'LabelEncoder',
+    ):
+        self.valid_pd_enc_dtypes = ['category', 'bool']
+
+        # Whether we should treat the feature as a
+        # categorical or numerical input. If None,
+        # (The input was not a dataframe)
+        # The estimator will try to guess
+        self.feature_types = None
+
+        # Whereas autosklearn performed encoding on the dataframe
+        # We need the target encoder as a decoder mechanism
+        self.feature_encoder = None
+        self.target_encoder = None
+        self.enc_columns = []
+
+        self.feature_encoder_type = feature_encoder_type
+        self.target_encoder_type = target_encoder_type
+
+    def validate(
+        self,
+        X: Union[pd.DataFrame, np.ndarray],
+        y: Union[pd.DataFrame, np.ndarray],
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Wrapper for feature/targets validation
+
+        Makes sure consistent number of samples within target and
+        features.
+        """
+
+        X = self.validate_features(X)
+        y = self.validate_target(y)
+
+        if X.shape[0] != y.shape[0]:
+            raise ValueError(
+                "The number of samples from the features X={} should match "
+                "the number of samples from the target y={}".format(
+                    X.shape[0],
+                    y.shape[0]
+                )
+            )
+        return X, y
+
+    def validate_features(
+        self,
+        X: Union[pd.DataFrame, np.ndarray],
+    ) -> np.ndarray:
+        """
+        Wrapper around sklearn check_array. Translates a pandas
+        Dataframe to a valid input for sklearn.
+        """
+
+        # Pre-process dataframe to make them numerical
+        if hasattr(X, "iloc"):
+            # Pandas validation provide extra user information
+            X = self._validate_dataframe_features(X)
+
+        if scipy.sparse.issparse(X):
+            X.sort_indices()
+
+        # sklearn check array will make sure we have the
+        # correct numerical features for the array
+        # Also, a numpy array will be created
+        X = sklearn.utils.check_array(
+            X,
+            force_all_finite=False,
+            accept_sparse='csr'
+        )
+        return X
+
+    def validate_target(
+        self,
+        y: Union[pd.DataFrame, np.ndarray],
+    ) -> np.ndarray:
+        """
+        Wrapper around sklearn check_array. Translates a pandas
+        Dataframe to a valid input for sklearn.
+        """
+        # Support also Pandas object in the targets
+        if hasattr(y, "iloc"):
+            y = self._validate_dataframe_target(y)
+
+        y = np.atleast_1d(y)
+        if y.ndim == 2 and y.shape[1] == 1:
+            warnings.warn("A column-vector y was passed when a 1d array was"
+                          " expected. Will change shape via np.ravel().",
+                          sklearn.utils.DataConversionWarning, stacklevel=2)
+            y = np.ravel(y)
+
+        # sklearn check array will make sure we have the
+        # correct numerical features for the array
+        # Also, a numpy array will be created
+        y = sklearn.utils.check_array(
+            y,
+            force_all_finite=True,
+            accept_sparse='csr',
+            ensure_2d=False,
+        )
+        return y
+
+    def _validate_dataframe_features(
+        self,
+        X: pd.DataFrame,
+    ) -> Union[pd.DataFrame, np.ndarray]:
+        """
+        Interprets a Pandas
+        Uses .iloc as a safe way to deal with pandas object
+        """
+
+        # Start with the features
+
+        # Register if a column needs encoding
+        enc_columns = []
+
+        # Also, register the feature types for the estimator
+        feature_types = []
+
+        # Make sure each column is a valid type
+        for i, column in enumerate(X.columns):
+            if X[column].dtype.name in self.valid_pd_enc_dtypes:
+                enc_columns.append(i)
+                feature_types.append('categorical')
+            elif not np.issubdtype(X[column].dtype, np.number):
+                if X[column].dtype.name == 'Object':
+                    raise ValueError(
+                        "Input Column {} has invalid type object. "
+                        "Cast it to a numerical value before using it in Auto-Sklearn."
+                        "You can use pandas.to_numeric() to do this".format(
+                            column,
+                        )
+                    )
+                elif pd.core.dtypes.common.is_datetime_or_timedelta_dtype(
+                    X[column].dtype
+                ):
+                    raise ValueError(
+                        "Input Column {} has invalid time-type. "
+                        "Please convert the time information to a categorical value. "
+                        "Usually, time information can be separated into a set of categorical "
+                        "features. For example, hour of the day can be converted to 24 "
+                        " categories.".format(
+                            column,
+                        )
+                    )
+                else:
+                    raise ValueError(
+                        "Input Column {} has unsupported dtype {}. "
+                        "Supported column types are categorical/bool/numerical dtypes. "
+                        "Make sure your data is formatted in a correct way, "
+                        "before feeding it to Auto-Sklearn.".format(
+                            column,
+                            X[column].dtype.name,
+                        )
+                    )
+            else:
+                feature_types.append('numerical')
+
+        # Make sure we only set this once. It should not change
+        if not self.feature_types:
+            self.feature_types = feature_types
+
+        # This proc has to handle multiple calls, for X_train
+        # and X_test scenarios. We have to make sure also that
+        # data is consistent within calls
+        if enc_columns:
+            if self.enc_columns and self.enc_columns != enc_columns:
+                raise ValueError(
+                    "Validation was already performed on input with enc columns={} "
+                    "yet, another set of features with columns to encode={} was "
+                    "provided. Feature changing after fit is not allowed.".format(
+                        enc_columns,
+                        self.enc_columns
+                    )
+                )
+            else:
+                self.enc_columns = enc_columns
+
+            if not self.feature_encoder:
+                if self.feature_encoder_type == 'OneHotEncoder':
+                    encoder = preprocessing.OneHotEncoder(sparse=False)
+                elif self.feature_encoder_type == 'OrdinalEncoder':
+                    encoder = preprocessing.OrdinalEncoder()
+                else:
+                    raise ValueError(
+                        "Unsupported feature encoder provided {}".format(
+                            self.feature_encoder_type
+                        )
+                    )
+
+                self.feature_encoder = make_column_transformer(
+                    (encoder, self.enc_columns),
+                    remainder="passthrough"
+                )
+
+                self.feature_encoder.fit(X)
+
+        if self.feature_encoder:
+            X = self.feature_encoder.transform(X)
+
+        return X
+
+    def _validate_dataframe_target(
+        self,
+        y: Union[pd.DataFrame, np.ndarray],
+    ) -> Union[pd.DataFrame, np.ndarray]:
+        """
+        This method encodes
+        categorical series to a numerical equivalent.
+
+        No change to numerical values.
+
+        Dataframes with more than 1 column are ambiguous because
+        two column could be a label or multilabel. Force the user
+        to use numerical encoding via sklearn checks
+        """
+
+        # Convert pd.Series to dataframe as categorical series
+        # lack many useful methods
+        if isinstance(y, pd.Series):
+            y = y.to_frame().reset_index(drop=True)
+
+        # handle categorical encoding of a Dataframes
+        # with a single column
+        # A dataframe target with multiple columns is ambiguous
+        # We don't know if all columns should share same encoding
+        # or Not
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            if y.dtypes[0].name in self.valid_pd_enc_dtypes:
+                if self.target_encoder_type == 'OneHotEncoder':
+                    self.target_encoder = preprocessing.OneHotEncoder(sparse=False)
+                elif self.target_encoder_type == 'OrdinalEncoder':
+                    self.target_encoder = preprocessing.OrdinalEncoder()
+                elif self.target_encoder_type == 'LabelEncoder':
+                    self.target_encoder = preprocessing.LabelEncoder()
+                else:
+                    raise ValueError(
+                        "Unsupported feature encoder provided {}".format(
+                            self.target_encoder_type
+                        )
+                    )
+                self.target_encoder.fit(y.values.reshape(-1, 1))
+            elif not np.issubdtype(y.dtypes[0], np.number):
+                raise ValueError(
+                    "Target Series y has unsupported dtype {}. "
+                    "Supported column types are categorical/bool/numerical dtypes. "
+                    "Make sure your data is formatted in a correct way, "
+                    "before feeding it to Auto-Sklearn.".format(
+                        y.dtypes[0].name,
+                    )
+                )
+            if self.target_encoder:
+                y = self.target_encoder.transform(y)
+
+        return y
+
+    def decode(
+        self,
+        y: np.ndarray,
+    ) -> np.ndarray:
+        """
+        If the original target features were encoded,
+        this method employs the inverse transform method of the encoder
+        to decode the original features
+        """
+        if self.target_encoder is None:
+            raise ValueError(
+                "No point in calling decode when the input y was not encoded"
+            )
+        return self.target_encoder.inverse_transform(y)

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -282,7 +282,7 @@ class InputValidator:
                              "missing/NaN values. The OrdinalEncoder used by "
                              "Auto-sklearn cannot handle this yet (due to a "
                              "limitation on scikit-learn being addressed via: "
-                             "https://github.com/scikit-learn/scikit-learn/issues/17123)""
+                             "https://github.com/scikit-learn/scikit-learn/issues/17123)"
                              )
         elif np.any(pd.isnull(X)):
             # After above check it means that if there is a NaN

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -28,10 +28,12 @@ class InputValidator:
     ):
         self.valid_pd_enc_dtypes = ['category', 'bool']
 
-        # Whether we should treat the feature as a
-        # categorical or numerical input. If None,
-        # (The input was not a dataframe)
-        # The estimator will try to guess
+        # If a dataframe was provided, we populate
+        # this attribute with the column types from the dataframe
+        # That is, this attribute contains whether autosklearn
+        # should treat a column as categorical or numerical
+        # During fit, if the user provided feature_types, the user
+        # constrain is honored. If not, this attribute is used.
         self.feature_types = None
 
         # Whereas autosklearn performed encoding on the dataframe

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -40,7 +40,10 @@ class InputValidator:
         self.target_encoder = None
         self.enc_columns = []
 
-        # Check for n-outputs change
+        # During consecutive calls to the validator,
+        # track the number of outputs of the targets
+        # We need to make sure y_train/y_test have the
+        # same dimensionality
         self._n_outputs = None
 
     def validate(
@@ -129,13 +132,17 @@ class InputValidator:
             is_number = np.vectorize(lambda x: pd.api.types.is_numeric_dtype(x))
             if not np.all(is_number(y.dtypes)):
                 raise ValueError(
+                    "During the target validation (y_train/y_test) an invalid"
+                    " input was detected. "
                     "Input dataframe to autosklearn must only contain numerical"
-                    " dtypes, yet it has: {}".format(
+                    " dtypes, yet it has: {} dtypes.".format(
                         y.dtypes
                     )
                 )
         elif not np.issubdtype(y.dtype, np.number):
             raise ValueError(
+                "During the target validation (y_train/y_test) an invalid"
+                " input was detected. "
                 "Input to autosklearn must have a numerical dtype, yet it is: {}".format(
                     y.dtype
                 )

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -278,10 +278,11 @@ class InputValidator:
         if np.any(pd.isnull(X.dropna(axis='columns', how='all'))):
             # Ignore all NaN columns, and if still a NaN
             # Error out
-            raise ValueError("Categorical features array cannot contain missing/NaN values. "
-                             "You can pre-process your data via: "
-                             "https://scikit-learn.org/stable/modules/impute.html "
-                             "before feeding it to auto-sklearn."
+            raise ValueError("Categorical features in a dataframe cannot contain "
+                             "missing/NaN values. The OrdinalEncoder used by "
+                             "Auto-sklearn cannot handle this yet (due to a "
+                             "limitation on scikit-learn being addressed via: "
+                             "https://github.com/scikit-learn/scikit-learn/issues/17123)""
                              )
         elif np.any(pd.isnull(X)):
             # After above check it means that if there is a NaN
@@ -296,8 +297,8 @@ class InputValidator:
             enc_columns, feature_types = self._check_and_get_columns_to_encode(X)
         else:
             if len(X.shape) < 1:
-                raise ValueError("Expected features to have more than 1 dimensionality"
-                                 "Your features should be reshaped to a 2-D like array object."
+                raise ValueError("Input data X cannot be one dimensional "
+                                 "and need to be reshaped to a 2-D array-like object."
                                  "You can do so via np.reshape(-1,1). "
                                  )
             enc_columns = list(range(X.shape[1]))

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -8,7 +8,7 @@ from sklearn.base import BaseEstimator
 from sklearn.utils.multiclass import type_of_target
 import joblib
 
-from autosklearn.automl import AutoMLClassifier, AutoMLRegressor, BaseAutoML
+from autosklearn.automl import AutoMLClassifier, AutoMLRegressor, AutoML
 from autosklearn.util.backend import create, get_randomized_directory_names
 
 
@@ -271,7 +271,7 @@ class AutoSklearnEstimator(BaseEstimator):
         self.metadata_directory = metadata_directory
         self._metric = metric
 
-        self._automl = None  # type: Optional[List[BaseAutoML]]
+        self._automl = None  # type: Optional[List[AutoML]]
         # n_jobs after conversion to a number (b/c default is None)
         self._n_jobs = None
         super().__init__()

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -63,7 +63,8 @@ class AutoMLTest(Base, unittest.TestCase):
 
             auto.models_ = {(1, 1, 50.0): failing_model}
 
-            X = np.array([1, 2, 3])
+            # Make sure a valid 2D array is given to automl
+            X = np.array([1, 2, 3]).reshape(-1, 1)
             y = np.array([1, 2, 3])
             auto.refit(X, y)
 

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -674,7 +674,7 @@ class AutoMLClassifierTest(Base, unittest.TestCase):
 
     def test_classification_pandas_support(self):
         X, y = sklearn.datasets.fetch_openml(
-            data_id=2,  # diabetes
+            data_id=40981,  # cat/num Australian
             return_X_y=True,
             as_frame=True,
         )
@@ -685,21 +685,25 @@ class AutoMLClassifierTest(Base, unittest.TestCase):
         # This test only make sense if input is dataframe
         self.assertTrue(isinstance(X, pd.DataFrame))
         self.assertTrue(isinstance(y, pd.Series))
+        print(f"Got here")
         automl = AutoSklearnClassifier(
             time_left_for_this_task=30,
             per_run_time_limit=5,
         )
 
+        print(f"Got there")
         automl.fit(X, y)
 
         # Make sure that at least better than random.
         # We use same X_train==X_test to test code quality
         self.assertTrue(automl.score(X, y) > 0.5)
 
+        print(f"Got uthere")
         automl.refit(X, y)
 
         # Make sure that at least better than random.
         # accuracy in sklearn needs valid data
+        print(f"Got vthere")
         y = automl._automl[0].InputValidator.encode_target(y)
         prediction = automl._automl[0].InputValidator.encode_target(automl.predict(X))
         self.assertTrue(accuracy(y, prediction) > 0.5)

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -685,25 +685,21 @@ class AutoMLClassifierTest(Base, unittest.TestCase):
         # This test only make sense if input is dataframe
         self.assertTrue(isinstance(X, pd.DataFrame))
         self.assertTrue(isinstance(y, pd.Series))
-        print(f"Got here")
         automl = AutoSklearnClassifier(
             time_left_for_this_task=30,
             per_run_time_limit=5,
         )
 
-        print(f"Got there")
         automl.fit(X, y)
 
         # Make sure that at least better than random.
         # We use same X_train==X_test to test code quality
         self.assertTrue(automl.score(X, y) > 0.5)
 
-        print(f"Got uthere")
         automl.refit(X, y)
 
         # Make sure that at least better than random.
         # accuracy in sklearn needs valid data
-        print(f"Got vthere")
         y = automl._automl[0].InputValidator.encode_target(y)
         prediction = automl._automl[0].InputValidator.encode_target(automl.predict(X))
         self.assertTrue(accuracy(y, prediction) > 0.5)

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -657,7 +657,7 @@ class AutoMLClassifierTest(Base, unittest.TestCase):
 
     def test_classification_pandas_support(self):
         X, y = sklearn.datasets.fetch_openml(
-            data_id=40981,  # cat/num Australian
+            data_id=2,  # cat/num dataset
             return_X_y=True,
             as_frame=True,
         )
@@ -671,6 +671,8 @@ class AutoMLClassifierTest(Base, unittest.TestCase):
         automl = AutoSklearnClassifier(
             time_left_for_this_task=30,
             per_run_time_limit=5,
+            exclude_estimators=['libsvm_svc'],
+            seed=5,
         )
 
         automl.fit(X, y)

--- a/test/test_data/test_validation.py
+++ b/test/test_data/test_validation.py
@@ -99,6 +99,71 @@ class InputValidatorTest(unittest.TestCase):
         )
         self.assertEqual('binary', type_of_target(y_valid))
 
+        # Make sure binary also works with PD dataframes
+        validator = InputValidator()
+
+        # Just 2 classes, 1 and 2
+        y_train = validator.validate_target(
+            pd.DataFrame([1.0, 2.0, 2.0, 1.0], dtype='category'),
+            is_classification=True,
+        )
+        self.assertEqual('binary', type_of_target(y_train))
+
+    def test_multiclass_conversion(self):
+        # Multiclass conversion for different datatype
+        for input_object in [
+            [1.0, 2.0, 2.0, 4.0, 3],
+            np.array([1.0, 2.0, 2.0, 4.0, 3], dtype=np.float64),
+            pd.DataFrame([1.0, 2.0, 2.0, 4.0, 3], dtype='category'),
+        ]:
+            validator = InputValidator()
+            y_train = validator.validate_target(
+                input_object,
+                is_classification=True,
+            )
+            self.assertEqual('multiclass', type_of_target(y_train))
+
+    def test_multilabel_conversion(self):
+        # Multi-label conversion for different datatype
+        for input_object in [
+            [[1, 0, 0, 1], [0, 0, 1, 1], [0, 0, 0, 0]],
+            np.array([[1, 0, 0, 1], [0, 0, 1, 1], [0, 0, 0, 0]]),
+            pd.DataFrame([[1, 0, 0, 1], [0, 0, 1, 1], [0, 0, 0, 0]], dtype='category'),
+        ]:
+            validator = InputValidator()
+            y_train = validator.validate_target(
+                input_object,
+                is_classification=True,
+            )
+            self.assertEqual('multilabel-indicator', type_of_target(y_train))
+
+    def test_continuous_multioutput_conversion(self):
+        # Regression multi out conversion for different datatype
+        for input_object in [
+            [[31.4, 94], [40.5, 109], [25.0, 30]],
+            np.array([[31.4, 94], [40.5, 109], [25.0, 30]]),
+            pd.DataFrame([[31.4, 94], [40.5, 109], [25.0, 30]]),
+        ]:
+            validator = InputValidator()
+            y_train = validator.validate_target(
+                input_object,
+                is_classification=False,
+            )
+            self.assertEqual('continuous-multioutput', type_of_target(y_train))
+
+    def test_regression_conversion(self):
+        for input_object in [
+            [1.0, 76.9, 123, 4.0, 81.1],
+            np.array([1.0, 76.9, 123, 4.0, 81.1]),
+            pd.DataFrame([1.0, 76.9, 123, 4.0, 81.1]),
+        ]:
+            validator = InputValidator()
+            y_train = validator.validate_target(
+                input_object,
+                is_classification=False,
+            )
+            self.assertEqual('continuous', type_of_target(y_train))
+
     def test_dataframe_input_unsupported(self):
         validator = InputValidator()
         with self.assertRaisesRegex(ValueError, "Auto-sklearn does not support time"):

--- a/test/test_data/test_validation.py
+++ b/test/test_data/test_validation.py
@@ -91,6 +91,14 @@ class InputValidatorTest(unittest.TestCase):
                 pd.DataFrame({'string': ['foo']})
             )
 
+        X = pd.DataFrame(data=['a', 'b', 'c'], dtype='category')
+        with unittest.mock.patch('autosklearn.data.validation.InputValidator._check_and_get_columns_to_encode') as mock_foo:  # noqa E501
+            # Mock that all columns are ok. There should be a
+            # checker to catch for bugs
+            mock_foo.return_value = ([], [])
+            with self.assertRaisesRegex(ValueError, 'Failed to convert the input'):
+                validator.validate_features(X)
+
     def test_dataframe_econding_1D(self):
         validator = InputValidator()
         y = validator.validate_target(

--- a/test/test_data/test_validation.py
+++ b/test/test_data/test_validation.py
@@ -4,6 +4,7 @@ from autosklearn.data.validation import InputValidator
 
 import numpy as np
 import pandas as pd
+from scipy import sparse
 
 
 class InputValidatorTest(unittest.TestCase):
@@ -16,12 +17,12 @@ class InputValidatorTest(unittest.TestCase):
         ]
         self.y = [0, 1, 0]
 
-    def test_array_input(self):
+    def test_list_input(self):
         validator = InputValidator()
         X, y = validator.validate(self.X, self.y)
 
-        self.assertTrue(isinstance(X, np.ndarray))
-        self.assertTrue(isinstance(y, np.ndarray))
+        self.assertIsInstance(X, np.ndarray)
+        self.assertIsInstance(y, np.ndarray)
 
     def test_numpy_input(self):
         validator = InputValidator()
@@ -30,10 +31,27 @@ class InputValidatorTest(unittest.TestCase):
             np.array(self.y)
         )
 
-        self.assertTrue(isinstance(X, np.ndarray))
-        self.assertTrue(isinstance(y, np.ndarray))
-        self.assertTrue(validator.target_encoder is None)
-        self.assertTrue(validator.feature_encoder is None)
+        self.assertIsInstance(X, np.ndarray)
+        self.assertIsInstance(y, np.ndarray)
+        self.assertIsNone(validator.target_encoder)
+        self.assertIsNone(validator.feature_encoder)
+
+    def test_sparse_input(self):
+        validator = InputValidator()
+
+        # Sparse data
+        row_ind = np.array([0, 1, 2])
+        col_ind = np.array([1, 2, 1])
+        X_sparse = sparse.csr_matrix((np.ones(3), (row_ind, col_ind)))
+        X, y = validator.validate(
+            X_sparse,
+            np.array(self.y)
+        )
+
+        self.assertIsInstance(X, sparse.csr.csr_matrix)
+        self.assertIsInstance(y, np.ndarray)
+        self.assertIsNone(validator.target_encoder)
+        self.assertIsNone(validator.feature_encoder)
 
     def test_dataframe_input_numerical(self):
         for test_type in ['int64', 'float64', 'int8']:
@@ -43,10 +61,10 @@ class InputValidatorTest(unittest.TestCase):
                 pd.DataFrame(data=self.y, dtype=test_type),
             )
 
-            self.assertTrue(isinstance(X, np.ndarray))
-            self.assertTrue(isinstance(y, np.ndarray))
-            self.assertTrue(validator.target_encoder is None)
-            self.assertTrue(validator.feature_encoder is None)
+            self.assertIsInstance(X, np.ndarray)
+            self.assertIsInstance(y, np.ndarray)
+            self.assertIsNone(validator.target_encoder)
+            self.assertIsNone(validator.feature_encoder)
 
     def test_dataframe_input_categorical(self):
         for test_type in ['bool', 'category']:
@@ -54,32 +72,30 @@ class InputValidatorTest(unittest.TestCase):
             X, y = validator.validate(
                 pd.DataFrame(data=self.X, dtype=test_type),
                 pd.DataFrame(data=self.y, dtype=test_type),
+                is_classification=True,
             )
 
-            self.assertTrue(isinstance(X, np.ndarray))
-            self.assertTrue(isinstance(y, np.ndarray))
-            self.assertTrue(validator.target_encoder is not None)
-            self.assertTrue(validator.feature_encoder is not None)
+            self.assertIsInstance(X, np.ndarray)
+            self.assertIsInstance(y, np.ndarray)
+            self.assertIsNotNone(validator.target_encoder)
+            self.assertIsNotNone(validator.feature_encoder)
 
     def test_dataframe_input_unsupported(self):
         validator = InputValidator()
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "Auto-sklearn does not support time"):
             validator.validate_features(
                 pd.DataFrame({'datetime': [pd.Timestamp('20180310')]})
             )
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "has invalid type object"):
             validator.validate_features(
                 pd.DataFrame({'string': ['foo']})
             )
-        with self.assertRaises(ValueError):
-            validator.validate_features(
-                pd.DataFrame({'object': InputValidator()})
-            )
 
-    def test_dataframe_econding(self):
+    def test_dataframe_econding_1D(self):
         validator = InputValidator()
         y = validator.validate_target(
             pd.DataFrame(data=self.y, dtype=bool),
+            is_classification=True,
         )
         np.testing.assert_array_almost_equal(np.array([0, 1, 0]), y)
 
@@ -87,5 +103,31 @@ class InputValidatorTest(unittest.TestCase):
         y = validator.validate_target(y)
         np.testing.assert_array_almost_equal(np.array([0, 1, 0]), y)
 
-        y_decoded = validator.decode(y)
+        y_decoded = validator.decode_target(y)
         np.testing.assert_array_almost_equal(np.array(self.y, dtype=bool), y_decoded)
+
+        # Now go with categorical data
+        validator = InputValidator()
+        y = validator.validate_target(
+            pd.DataFrame(data=['a', 'a', 'b', 'c', 'a'], dtype='category'),
+            is_classification=True,
+        )
+        np.testing.assert_array_almost_equal(np.array([0, 0, 1, 2, 0]), y)
+
+        y_decoded = validator.decode_target(y)
+        self.assertListEqual(['a', 'a', 'b', 'c', 'a'], y_decoded.tolist())
+
+    def test_dataframe_econding_2D(self):
+        validator = InputValidator()
+        multi_label = pd.DataFrame(
+            np.array([[1, 0, 0, 1], [0, 0, 1, 1], [0, 0, 0, 0]]),
+            dtype=bool
+        )
+        y = validator.validate_target(multi_label, is_classification=True)
+
+        # Result should not change on a multi call
+        y_new = validator.validate_target(multi_label)
+        np.testing.assert_array_almost_equal(y_new, y)
+
+        y_decoded = validator.decode_target(y)
+        np.testing.assert_array_almost_equal(y, y_decoded)

--- a/test/test_data/test_validation.py
+++ b/test/test_data/test_validation.py
@@ -436,7 +436,7 @@ class InputValidatorTest(unittest.TestCase):
         y[1] = np.nan
         y = pd.DataFrame(y)
 
-        with self.assertRaisesRegex(ValueError, 'Categorical features array cannot contain'):
+        with self.assertRaisesRegex(ValueError, 'Categorical features in a dataframe cannot'):
             InputValidator().validate_features(x)
 
         with self.assertRaisesRegex(ValueError, 'Target values cannot contain missing/NaN'):
@@ -498,7 +498,7 @@ class InputValidatorTest(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            'Categorical features array cannot contain missing/NaN values'
+            'Categorical features in a dataframe cannot contain missing/NaN'
         ):
             x_t, y_t = validator.validate(x, y, is_classification=True)
 

--- a/test/test_data/test_validation.py
+++ b/test/test_data/test_validation.py
@@ -1,0 +1,91 @@
+import unittest
+
+from autosklearn.data.validation import InputValidator
+
+import numpy as np
+import pandas as pd
+
+
+class InputValidatorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.X = [
+            [2.5, 3.3, 2, 5, 1, 1],
+            [1.0, 0.7, 1, 5, 1, 0],
+            [1.3, 0.8, 1, 4, 1, 1]
+        ]
+        self.y = [0, 1, 0]
+
+    def test_array_input(self):
+        validator = InputValidator()
+        X, y = validator.validate(self.X, self.y)
+
+        self.assertTrue(isinstance(X, np.ndarray))
+        self.assertTrue(isinstance(y, np.ndarray))
+
+    def test_numpy_input(self):
+        validator = InputValidator()
+        X, y = validator.validate(
+            np.array(self.X),
+            np.array(self.y)
+        )
+
+        self.assertTrue(isinstance(X, np.ndarray))
+        self.assertTrue(isinstance(y, np.ndarray))
+        self.assertTrue(validator.target_encoder is None)
+        self.assertTrue(validator.feature_encoder is None)
+
+    def test_dataframe_input_numerical(self):
+        for test_type in ['int64', 'float64', 'int8']:
+            validator = InputValidator()
+            X, y = validator.validate(
+                pd.DataFrame(data=self.X, dtype=test_type),
+                pd.DataFrame(data=self.y, dtype=test_type),
+            )
+
+            self.assertTrue(isinstance(X, np.ndarray))
+            self.assertTrue(isinstance(y, np.ndarray))
+            self.assertTrue(validator.target_encoder is None)
+            self.assertTrue(validator.feature_encoder is None)
+
+    def test_dataframe_input_categorical(self):
+        for test_type in ['bool', 'category']:
+            validator = InputValidator()
+            X, y = validator.validate(
+                pd.DataFrame(data=self.X, dtype=test_type),
+                pd.DataFrame(data=self.y, dtype=test_type),
+            )
+
+            self.assertTrue(isinstance(X, np.ndarray))
+            self.assertTrue(isinstance(y, np.ndarray))
+            self.assertTrue(validator.target_encoder is not None)
+            self.assertTrue(validator.feature_encoder is not None)
+
+    def test_dataframe_input_unsupported(self):
+        validator = InputValidator()
+        with self.assertRaises(ValueError):
+            validator.validate_features(
+                pd.DataFrame({'datetime': [pd.Timestamp('20180310')]})
+            )
+        with self.assertRaises(ValueError):
+            validator.validate_features(
+                pd.DataFrame({'string': ['foo']})
+            )
+        with self.assertRaises(ValueError):
+            validator.validate_features(
+                pd.DataFrame({'object': InputValidator()})
+            )
+
+    def test_dataframe_econding(self):
+        validator = InputValidator()
+        y = validator.validate_target(
+            pd.DataFrame(data=self.y, dtype=bool),
+        )
+        np.testing.assert_array_almost_equal(np.array([0, 1, 0]), y)
+
+        # Result should not change on a multi call
+        y = validator.validate_target(y)
+        np.testing.assert_array_almost_equal(np.array([0, 1, 0]), y)
+
+        y_decoded = validator.decode(y)
+        np.testing.assert_array_almost_equal(np.array(self.y, dtype=bool), y_decoded)


### PR DESCRIPTION
Sklearn check-array method is used to give numerical dataframe support already.

Nevertheless, when a categorical value is given, we want to automatically encode it.

Also, we want to better guide the user when a dataframe is having a problematic type.

Added test to make sure dataframes can be handled.