### PR TITLE
Fix BaseCV objects early crashes

### DIFF
--- a/autosklearn/evaluation/train_evaluator.py
+++ b/autosklearn/evaluation/train_evaluator.py
@@ -909,7 +909,7 @@ class TrainEvaluator(AbstractEvaluator):
                     raise ValueError('Unknown CrossValidator.')
                 ref_arg_dict = __baseCrossValidator_defaults__[class_name]
 
-                y = D.data['Y_train'].ravel()
+                y = D.data['Y_train']
                 if class_name == 'PredefinedSplit':
                     if 'test_fold' not in self.resampling_strategy_args:
                         raise ValueError('Must provide parameter test_fold'
@@ -922,7 +922,7 @@ class TrainEvaluator(AbstractEvaluator):
                         raise ValueError('Must provide parameter groups '
                                          'for chosen CrossValidator.')
                     try:
-                        if self.resampling_strategy_args['groups'].shape != y.shape:
+                        if self.resampling_strategy_args['groups'].shape[-1] != y.shape[-1]:
                             raise ValueError('Groups must be array-like '
                                              'with shape (n_samples,).')
                     except Exception:
@@ -930,7 +930,7 @@ class TrainEvaluator(AbstractEvaluator):
                                          'with shape (n_samples,).')
                 else:
                     if 'groups' in self.resampling_strategy_args:
-                        if self.resampling_strategy_args['groups'].shape != y.shape:
+                        if self.resampling_strategy_args['groups'].shape[-1] != y.shape[-1]:
                             raise ValueError('Groups must be array-like'
                                              ' with shape (n_samples,).')
 

--- a/autosklearn/evaluation/train_evaluator.py
+++ b/autosklearn/evaluation/train_evaluator.py
@@ -28,7 +28,7 @@ __baseCrossValidator_defaults__ = {'GroupKFold': {'n_splits': 3},
                                    'LeavePGroupsOut': {'n_groups': 2},
                                    'LeaveOneOut': {},
                                    'LeavePOut': {'p': 2},
-                                   'PredefinedSplit': {},
+                                   'PredefinedSplit': {'test_fold': [0, 1, 2, 3]},
                                    'RepeatedKFold': {'n_splits': 5,
                                                      'n_repeats': 10,
                                                      'random_state': None},
@@ -948,6 +948,10 @@ class TrainEvaluator(AbstractEvaluator):
                 init_dict.pop('groups', None)
                 if 'folds' in init_dict:
                     init_dict['n_splits'] = init_dict.pop('folds', None)
+                # delete redundent variables in init_dict
+                delete = [key for key in init_dict if key not in ref_arg_dict]
+                for key in delete:
+                    init_dict.pop(key, None)
                 cv = copy.deepcopy(self.resampling_strategy)(**init_dict)
 
                 if 'groups' not in self.resampling_strategy_args:


### PR DESCRIPTION
When specifying customized cross validation objects,  AutoML process tends to crash in its early stage.
The corresponding debug message shown below
```
[DEBUG] [2020-06-25 13:06:54,163:AutoMLSMBO(2176371645)::129e649232a63f02b1825a7f17c56883]
Return: Status: <StatusType.CRASHED: 3>, cost: 1.000000, time: 0.059507, 
additional: {'traceback': 'Traceback      (most recent call last):
\n  File "/home/charles/anaconda3/envs/autoskdev/lib/python3.7/site-packages/autosklearn/evaluation/__init__.py", line 29, 
in fit_predict_try_except_decorator\n    return ta(queue=queue, **kwargs)\n  
File "/home/charles/anaconda3/envs/autoskdev/lib/python3.7/site-packages/autosklearn/evaluation/train_evaluator.py", 
line 1237, in eval_cv\n    budget_type=budget_type,\n  
File "/home/charles/anaconda3/envs/autoskdev/lib/python3.7/site-packages/autosklearn/evaluation/train_evaluator.py",
 line 180, in __init__\n    self.splitter = self.get_splitter(self.datamanager)\n  
File  "/home/charles/anaconda3/envs/autoskdev/lib/python3.7/site-packages/autosklearn/evaluation/train_evaluator.py", 
line 952, in get_splitter\n    cv = copy.deepcopy(self.resampling_strategy)(**init_dict)
\nTypeError: __init__() got an unexpected keyword argument \'cost_for_crash\'\n', 'error': 
'TypeError("__init__() got an unexpected keyword argument \'cost_for_crash\'")', 
'configuration_origin': 'Random initial design.'}
```


It is basically caused by deepcopying _resampling_strategy_args_ into _init_dict_ in **train_evaluator.py**. It obtains extra parameters that are not for initializing cross validation objects. Therefore, I did some modification to make sure init_dict only contain defaults arguments defined in the beginning of **train_evaluator.py**. Besides, due to the change mentioned, PredefinedSplits also got default arguments to avoid failure in unit test.


The results of same resampling_strategy for example KFold and 'cv' should get the same results with same arguments and seeds. However, they have quite different outcomes in cv_results_, pipeline, and hyper-parameters in the end('cv' apparently overfitted and KFold did not). Not sure what caused this. I will do more research on it later this week.