### PR TITLE
Flaky PCA handling

### DIFF
--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -1,6 +1,6 @@
 pip --version
 # Install general requirements the way setup.py suggests
-pip install pytest>=4.6 pep8 codecov pytest-cov flake8 flaky
+pip install pytest==4.6.* pep8 codecov pytest-cov flake8 flaky
 
 # Install the packages in the correct order specified by the requirements.txt file
 cat requirements.txt | xargs -n 1 -L 1 pip install

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -1,6 +1,6 @@
 pip --version
 # Install general requirements the way setup.py suggests
-pip install pytest pep8 codecov pytest-cov flake8
+pip install pytest>=4.6 pep8 codecov pytest-cov flake8 flaky
 
 # Install the packages in the correct order specified by the requirements.txt file
 cat requirements.txt | xargs -n 1 -L 1 pip install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 setuptools
-pytest>=4.6
 Cython
 
 numpy>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,17 @@ with open(os.path.join(HERE, 'requirements.txt')) as fp:
     install_reqs = [r.rstrip() for r in fp.readlines()
                     if not r.startswith('#') and not r.startswith('git+')]
 
+extras_reqs={
+    "test": [
+        "pytest>=4.6",
+        "pytest-xdist",
+        "pytest-timeout",
+        "flaky",
+        "pytest-cov",
+
+    ]
+}
+
 with open("autosklearn/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")
 
@@ -43,6 +54,7 @@ setup(
     version=version,
     packages=find_packages(exclude=['test', 'scripts', 'examples']),
     setup_requires=setup_reqs,
+    extras_require=extras_reqs,
     install_requires=install_reqs,
     include_package_data=True,
     license='BSD',

--- a/test/test_pipeline/components/feature_preprocessing/test_kernel_pca.py
+++ b/test/test_pipeline/components/feature_preprocessing/test_kernel_pca.py
@@ -1,6 +1,8 @@
 import sys
 import unittest
 
+import pytest
+
 from sklearn.linear_model import RidgeClassifier
 from autosklearn.pipeline.components.feature_preprocessing.kernel_pca import \
     KernelPCA
@@ -11,6 +13,7 @@ import sklearn.metrics
 
 class KernelPCAComponentTest(PreprocessingTestCase):
     @unittest.skipIf(sys.version_info < (3, 7), 'Random failures for Python < 3.7')
+    @pytest.mark.flaky()
     def test_default_configuration(self):
         transformation, original = _test_preprocessing(KernelPCA,
                                                        dataset='digits',
@@ -25,6 +28,7 @@ class KernelPCAComponentTest(PreprocessingTestCase):
         self.assertEqual(transformation.shape[0], original.shape[0])
         self.assertFalse((transformation == 0).all())
 
+    @pytest.mark.flaky()
     def test_default_configuration_classify(self):
         for i in range(5):
             X_train, Y_train, X_test, Y_test = get_dataset(dataset='digits',


### PR DESCRIPTION
PCA Runtime warning rerun with flaky

No need for extra exception in test pipeline as runtime error is already handled