### PR TITLE
Track testing/train performance of ensemble

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -416,7 +416,12 @@ class AutoML(BaseEstimator):
 
             # Create a queue to communicate with the ensemble process
             # And get the run history
-            queue = multiprocessing.Queue()
+            # Use a Manager as a workaround to memory errors cause
+            # by three subprocesses (Automl-ensemble_builder-pynisher)
+            mgr = multiprocessing.Manager()
+            mgr.Namespace()
+            queue = mgr.Queue()
+
             self._proc_ensemble = self._get_ensemble_process(
                 time_left_for_ensembles,
                 queue=queue,
@@ -517,6 +522,7 @@ class AutoML(BaseEstimator):
             self.ensemble_performance_history = self._proc_ensemble.get_ensemble_history()
 
         self._proc_ensemble = None
+
         if load_models:
             self._load_models()
 

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 import io
 import json
+import multiprocessing
 import os
 from typing import Optional, List
 import unittest.mock
@@ -187,6 +188,10 @@ class AutoML(BaseEstimator):
         self._can_predict = False
 
         self._debug_mode = debug_mode
+
+        # Place holder for the run history of the
+        # Ensemble building process
+        self.ensemble_performance_history = []
 
         if not isinstance(self._time_for_task, int):
             raise ValueError("time_left_for_this_task not of type integer, "
@@ -408,7 +413,14 @@ class AutoML(BaseEstimator):
         else:
             self._logger.info(
                 'Start Ensemble with %5.2fsec time left' % time_left_for_ensembles)
-            self._proc_ensemble = self._get_ensemble_process(time_left_for_ensembles)
+
+            # Create a queue to communicate with the ensemble process
+            # And get the run history
+            queue = multiprocessing.Queue()
+            self._proc_ensemble = self._get_ensemble_process(
+                time_left_for_ensembles,
+                queue=queue,
+            )
             self._proc_ensemble.start()
 
         self._stopwatch.stop_task(ensemble_task_name)
@@ -502,6 +514,7 @@ class AutoML(BaseEstimator):
         # while the ensemble builder tries to access the data
         if self._proc_ensemble is not None and self._ensemble_size > 0:
             self._proc_ensemble.join()
+            self.ensemble_performance_history = self._proc_ensemble.get_ensemble_history()
 
         self._proc_ensemble = None
         if load_models:
@@ -644,6 +657,7 @@ class AutoML(BaseEstimator):
             1, task, precision, dataset_name, max_iterations=1,
             ensemble_nbest=ensemble_nbest, ensemble_size=ensemble_size)
         self._proc_ensemble.main()
+        self.ensemble_performance_history = self._proc_ensemble.get_ensemble_history()
         self._proc_ensemble = None
         self._load_models()
         return self
@@ -651,7 +665,7 @@ class AutoML(BaseEstimator):
     def _get_ensemble_process(self, time_left_for_ensembles,
                               task=None, precision=None,
                               dataset_name=None, max_iterations=None,
-                              ensemble_nbest=None, ensemble_size=None):
+                              ensemble_nbest=None, ensemble_size=None, queue=None):
 
         if task is None:
             task = self._task
@@ -694,6 +708,7 @@ class AutoML(BaseEstimator):
             read_at_most=np.inf,
             memory_limit=self._ensemble_memory_limit,
             random_state=self._seed,
+            queue=queue,
         )
 
     def _load_models(self):

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -11,6 +11,7 @@ import traceback
 from typing import Optional, Union
 
 import numpy as np
+import pandas as pd
 import pynisher
 import lockfile
 from sklearn.utils.validation import check_random_state
@@ -47,6 +48,7 @@ class EnsembleBuilder(multiprocessing.Process):
             memory_limit: int = 1000,
             read_at_most: int = 5,
             random_state: Optional[Union[int, np.random.RandomState]] = None,
+            queue: multiprocessing.Queue = None
     ):
         """
             Constructor
@@ -204,6 +206,24 @@ class EnsembleBuilder(multiprocessing.Process):
 
         self.validation_performance_ = np.inf
 
+        # Track the ensemble performance
+        self.datamanager = self.backend.load_datamanager()
+        self.y_valid = self.datamanager.data.get('Y_valid')
+        self.y_test = self.datamanager.data.get('Y_test')
+
+        # Support for tracking the performance across time
+        # A Queue is needed to handle multiprocessing, not only
+        # internally for pynisher calls, but to return data
+        # to the main process
+        # We need to do a put/get to properly initialize the queue
+        # else we run into pynisher problems. For that reason we initialize
+        # a queue namespace. This makes the code robust against a termination
+        mgr = multiprocessing.Manager()
+        mgr.Namespace()
+        self.queue = queue if queue is not None else multiprocessing.Queue()
+        self.queue.put([])
+        self.queue.get()
+
     def run(self):
         buffer_time = 5  # TODO: Buffer time should also be used in main!?
         while True:
@@ -314,6 +334,11 @@ class EnsembleBuilder(multiprocessing.Process):
             # train ensemble
             ensemble = self.fit_ensemble(selected_keys=candidate_models)
             if ensemble is not None:
+                train_pred = self.predict(set_="train",
+                                          ensemble=ensemble,
+                                          selected_keys=candidate_models,
+                                          n_preds=len(candidate_models),
+                                          index_run=iteration)
                 # We can't use candidate_models here, as n_sel_* might be empty
                 valid_pred = self.predict(set_="valid",
                                           ensemble=ensemble,
@@ -327,8 +352,16 @@ class EnsembleBuilder(multiprocessing.Process):
                                          selected_keys=n_sel_test,
                                          n_preds=len(candidate_models),
                                          index_run=iteration)
+
+                # Add a score to run history to see ensemble progress
+                self._add_ensemble_trajectory(
+                    train_pred,
+                    valid_pred,
+                    test_pred
+                )
             else:
                 time.sleep(self.sleep_duration)
+
         if return_pred:
             return valid_pred, test_pred
 
@@ -857,15 +890,23 @@ class EnsembleBuilder(multiprocessing.Process):
         if self.SAVE2DISC:
             self.backend.save_ensemble(ensemble, index_run, self.seed)
 
+        if set_ == 'valid':
+            pred_set = Y_VALID
+        elif set_ == 'test':
+            pred_set = Y_TEST
+        else:
+            pred_set = Y_ENSEMBLE
         predictions = np.array([
-            self.read_preds[k][Y_VALID if set_ == 'valid' else Y_TEST]
+            self.read_preds[k][pred_set]
             for k in selected_keys
         ])
 
         if n_preds == predictions.shape[0]:
             y = ensemble.predict(predictions)
             if self.task_type == BINARY_CLASSIFICATION:
-                y = y[:, 1]
+                # If on a binary task, and uncertain predictions (0.5)
+                # Make sure we round to 0/1
+                y = np.around(y[:, 1], decimals=0)
             if self.SAVE2DISC:
                 self.backend.save_predictions_as_txt(
                     predictions=y,
@@ -885,6 +926,68 @@ class EnsembleBuilder(multiprocessing.Process):
             )
             return None
         # TODO: ADD saving of predictions on "ensemble data"
+
+    def get_ensemble_history(self):
+        """
+        Getter method to obtain the performance of the ensemble
+        building process across time
+
+        Return
+        ----------
+        dict that tracks the performance of the ensemble
+        building process on testing/training sets
+
+        """
+        ensemble_history = []
+        while(self.queue.qsize()):
+            ensemble_history.append(self.queue.get())
+        return ensemble_history
+
+    def _add_ensemble_trajectory(self, train_pred, valid_pred, test_pred):
+        """
+        Records a snapshot of how the performance look at a given training
+        time.
+
+        Parameters
+        ----------
+        ensemble: EnsembleSelection
+            The ensemble selection object to record
+        valid_pred: np.ndarray
+            The predictions on the validation set using ensemble
+        test_pred: np.ndarray
+            The predictions on the test set using ensemble
+
+        """
+        performance_stamp = {
+            'Timestamp': pd.Timestamp.now(),
+            'train_score': calculate_score(
+                solution=self.y_true_ensemble,
+                prediction=train_pred,
+                task_type=self.task_type,
+                metric=self.metric,
+                all_scoring_functions=False
+            )
+        }
+        if valid_pred is not None:
+            performance_stamp['val_score'] = calculate_score(
+                solution=self.y_valid,
+                prediction=valid_pred,
+                task_type=self.task_type,
+                metric=self.metric,
+                all_scoring_functions=False
+            )
+
+        # In case test_pred was provided
+        if test_pred is not None:
+            performance_stamp['test_score'] = calculate_score(
+                solution=self.y_test,
+                prediction=test_pred,
+                task_type=self.task_type,
+                metric=self.metric,
+                all_scoring_functions=False
+            )
+
+        self.queue.put(performance_stamp)
 
     def _get_list_of_sorted_preds(self):
         """

--- a/autosklearn/metrics/__init__.py
+++ b/autosklearn/metrics/__init__.py
@@ -50,7 +50,13 @@ class _PredictScorer(Scorer):
             Score function applied to prediction of estimator on X.
         """
         type_true = type_of_target(y_true)
-        if len(y_pred.shape) == 1 or y_pred.shape[1] == 1 or \
+        if type_true == 'binary' and type_of_target(y_pred) == 'continuous' and \
+                len(y_pred.shape) == 1:
+            # For a pred scorer, no threshold, nor probability is required
+            # If y_true is binary, and y_pred is continuous
+            # it means that a rounding is necessary to obtain the binary class
+            y_pred = np.around(y_pred, decimals=0)
+        elif len(y_pred.shape) == 1 or y_pred.shape[1] == 1 or \
                 type_true == 'continuous':
             # must be regression, all other task types would return at least
             # two probabilities

--- a/autosklearn/util/backend.py
+++ b/autosklearn/util/backend.py
@@ -259,7 +259,7 @@ class Backend(object):
         filepath = self._get_targets_ensemble_filename()
 
         # Try to open the file without locking it, this will reduce the
-        # number of times where we erronously keep a lock on the ensemble
+        # number of times where we erroneously keep a lock on the ensemble
         # targets file although the process already was killed
         try:
             existing_targets = np.load(filepath, allow_pickle=True)

--- a/examples/example_feature_types.py
+++ b/examples/example_feature_types.py
@@ -8,7 +8,7 @@ In *auto-sklearn* it is possible to specify the feature types of a dataset when 
 :meth:`fit() <autosklearn.classification.AutoSklearnClassifier.fit>` by specifying the argument
 ``feat_type``. The following example demonstrates a way it can be done.
 """
-
+import pandas as pd
 import sklearn.model_selection
 import sklearn.datasets
 import sklearn.metrics
@@ -41,7 +41,7 @@ cls = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=120,
     per_run_time_limit=30,
 )
-cls.fit(X_train, y_train, feat_type=feat_type)
+cls.fit(X_train, y_train, X_test, y_test, feat_type=feat_type)
 
 ###########################################################################
 # Get the Score of the final ensemble
@@ -49,3 +49,9 @@ cls.fit(X_train, y_train, feat_type=feat_type)
 
 predictions = cls.predict(X_test)
 print("Accuracy score", sklearn.metrics.accuracy_score(y_test, predictions))
+
+############################################################################
+# Print the ensemble performance
+# ===================================
+ensemble_performance_frame = pd.DataFrame(cls._automl[0].ensemble_performance_history)
+print(ensemble_performance_frame)


### PR DESCRIPTION
An ensemble can be created directly through fit_ensemble (not with multiprocessing) and within the fit method, which involves multiple stages of multiprocessing (pynisher)

To standardize how we communicated between non/multiprocessing task, the ensemble builder can receive (or create by itself) a Queue where we annotate the performance at a given point in time. It is a robust way to keep information even when pynisher kills the job.

An example was updated on how to print this information in a dataframe.

Also fixed some typos I found and a bug in the test where the data we were working with is multi-label, not binary.