### PR TITLE
Fix old links in Docs

### DIFF
--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -203,16 +203,16 @@ class AutoSklearnEstimator(BaseEstimator):
 
         smac_scenario_args : dict, optional (None)
             Additional arguments inserted into the scenario of SMAC. See the
-            `SMAC documentation <https://automl.github.io/SMAC3/stable/options.html?highlight=scenario#scenario>`_
+            `SMAC documentation <https://automl.github.io/SMAC3/master/options.html?highlight=scenario#scenario>`_
             for a list of available arguments.
 
         get_smac_object_callback : callable
             Callback function to create an object of class
-            `smac.optimizer.smbo.SMBO <https://automl.github.io/SMAC3/stable/apidoc/smac.optimizer.smbo.html>`_.
+            `smac.optimizer.smbo.SMBO <https://automl.github.io/SMAC3/master/apidoc/smac.optimizer.smbo.html>`_.
             The function must accept the arguments ``scenario_dict``,
             ``instances``, ``num_params``, ``runhistory``, ``seed`` and ``ta``.
             This is an advanced feature. Use only if you are familiar with
-            `SMAC <https://automl.github.io/SMAC3/stable/index.html>`_.
+            `SMAC <https://automl.github.io/SMAC3/master/index.html>`_.
 
         logging_config : dict, optional (None)
             dictionary object specifying the logger configuration. If None,

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -113,20 +113,24 @@ Docker Image
 A Docker image is also provided as a github package. The user must authenticate following the instructions from `GitHub Packages <https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages>`_ . Then, the image can be downloaded as follows:
 
 .. code:: bash
+
     docker pull docker.pkg.github.com/automl/auto-sklearn/auto-sklearn:latest
 
 You can also verify that the images are downloaded via:
 
 .. code:: bash
+
     docker images  # Verify that the image was downloaded
 
 This image can be used to start an interactive session as follows:
 
 .. code:: bash
+
     docker run -it docker.pkg.github.com/automl/auto-sklearn/auto-sklearn:latest
 
 To start a Jupyter notebook, you could instead run e.g.:
 
 .. code:: bash
+
     docker run -it -v $PWD:/opt/nb -p 8888:8888 docker.pkg.github.com/automl/auto-sklearn/auto-sklearn:latest /bin/bash -c "mkdir -p /opt/nb && jupyter notebook --notebook-dir=/opt/nb --ip='0.0.0.0' --port=8888 --no-browser --allow-root"
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -110,10 +110,14 @@ Possible other solutions (not tested):
 
 Docker Image
 =========================
-A Docker image is also provided as a github package. The user must authenticate following the instructions from `GitHub Packages <https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages>`_ . Then, the image can be downloaded as follows.
+A Docker image is also provided as a github package. The user must authenticate following the instructions from `GitHub Packages <https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages>`_ . Then, the image can be downloaded as follows:
 
 .. code:: bash
     docker pull docker.pkg.github.com/automl/auto-sklearn/auto-sklearn:latest
+
+You can also verify that the images are downloaded via:
+
+.. code:: bash
     docker images  # Verify that the image was downloaded
 
 This image can be used to start an interactive session as follows:
@@ -121,7 +125,8 @@ This image can be used to start an interactive session as follows:
 .. code:: bash
     docker run -it docker.pkg.github.com/automl/auto-sklearn/auto-sklearn:latest
 
-To start a Jupyter notebook, you could run e.g.:
+To start a Jupyter notebook, you could instead run e.g.:
 
 .. code:: bash
     docker run -it -v $PWD:/opt/nb -p 8888:8888 docker.pkg.github.com/automl/auto-sklearn/auto-sklearn:latest /bin/bash -c "mkdir -p /opt/nb && jupyter notebook --notebook-dir=/opt/nb --ip='0.0.0.0' --port=8888 --no-browser --allow-root"
+

--- a/examples/example_parallel_manual_spawning.py
+++ b/examples/example_parallel_manual_spawning.py
@@ -8,7 +8,7 @@ Parallel Usage with manual process spawning
 the training models. A variant of *SMAC*, called *pSMAC* (parallel SMAC),
 provides a means of running several instances of *auto-sklearn* in a parallel
 mode using several computational resources (detailed information of *pSMAC*
-can be found `here <https://automl.github.io/SMAC3/stable/psmac.html>`_).
+can be found `here <https://automl.github.io/SMAC3/master/psmac.html>`_).
 
 This example shows how to spawn multiple instances of *Auto-sklearn* which
 share the same output directory and thereby run in parallel. Use this example

--- a/examples/example_parallel_n_jobs.py
+++ b/examples/example_parallel_n_jobs.py
@@ -8,7 +8,7 @@ Parallel Usage  on a single machine
 the training models. A variant of *SMAC*, called *pSMAC* (parallel SMAC),
 provides a means of running several instances of *auto-sklearn* in a parallel
 mode using several computational resources (detailed information of *pSMAC*
-can be found `here <https://automl.github.io/SMAC3/stable/psmac.html>`_).
+can be found `here <https://automl.github.io/SMAC3/master/psmac.html>`_).
 
 This example shows how to start *Auto-sklearn* to use multiple cores on a
 single machine. To run *Auto-sklearn* on multiple machines check the example

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools import setup, find_packages
 if os.name != 'posix':
     raise ValueError(
         'Detected unsupported operating system: %s. Please check '
-        'the compability information of auto-sklearn: http://automl.github.io'
-        '/auto-sklearn/stable/installation.html#windows-osx-compability' %
+        'the compability information of auto-sklearn: https://automl.github.io'
+        '/auto-sklearn/master/installation.html#windows-osx-compatibility' %
         sys.platform
     )
 


### PR DESCRIPTION
This PR enhances the documentations in 2 ways:

- It fixes broken links as stated in #904 

- It adapts the PR  #391 under new instructions (as the registry being used is from github, not docker)