### PR TITLE
Fix #558 - improve error message by giving actionable advice

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -88,7 +88,7 @@ class AutoML(BaseEstimator):
                  ensemble_size=1,
                  ensemble_nbest=1,
                  max_models_on_disc=1,
-                 ensemble_memory_limit=1000,
+                 ensemble_memory_limit: Optional[int] = 1024,
                  seed=1,
                  ml_memory_limit=3072,
                  metadata_directory=None,

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -45,7 +45,7 @@ class EnsembleBuilder(multiprocessing.Process):
             max_iterations: int = None,
             precision: int = 32,
             sleep_duration: int = 2,
-            memory_limit: int = 1000,
+            memory_limit: Optional[int] = 1024,
             read_at_most: int = 5,
             random_state: Optional[Union[int, np.random.RandomState]] = None,
             queue: multiprocessing.Queue = None
@@ -100,8 +100,8 @@ class EnsembleBuilder(multiprocessing.Process):
                 precision of floats to read the predictions
             sleep_duration: int
                 duration of sleeping time between two iterations of this script (in sec)
-            memory_limit: int
-                memory limit in mb
+            memory_limit: Optional[int]
+                memory limit in mb. If ``None``, no memory limit is enforced.
             read_at_most: int
                 read at most n new prediction files in each iteration
         """
@@ -246,8 +246,8 @@ class EnsembleBuilder(multiprocessing.Process):
                     self.logger.critical(
                         "Memory Exception -- Unable to further reduce the number of ensemble "
                         "members -- please restart Auto-sklearn with a higher value for the "
-                        "argument 'ensemble_memory_limit' (current limit is %d MB).",
-                        self.memory_limit,
+                        "argument 'ensemble_memory_limit' (current limit is {} MB)."
+                        "".format(self.memory_limit)
                     )
                 else:
                     if isinstance(self.ensemble_nbest, numbers.Integral):

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -243,8 +243,12 @@ class EnsembleBuilder(multiprocessing.Process):
                 # reduce nbest to reduce memory consumption and try it again
                 if isinstance(self.ensemble_nbest, numbers.Integral) and \
                         self.ensemble_nbest == 1:
-                    self.logger.critical("Memory Exception --"
-                                         " Unable to escape from memory exception")
+                    self.logger.critical(
+                        "Memory Exception -- Unable to further reduce the number of ensemble "
+                        "members -- please restart Auto-sklearn with a higher value for the "
+                        "argument 'ensemble_memory_limit' (current limit is %d MB).",
+                        self.memory_limit,
+                    )
                 else:
                     if isinstance(self.ensemble_nbest, numbers.Integral):
                         self.ensemble_nbest = int(self.ensemble_nbest / 2)

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -26,7 +26,7 @@ class AutoSklearnEstimator(BaseEstimator):
         ensemble_size: int = 50,
         ensemble_nbest=50,
         max_models_on_disc=50,
-        ensemble_memory_limit=1024,
+        ensemble_memory_limit: Optional[int] = 1024,
         seed=1,
         ml_memory_limit=3072,
         include_estimators=None,
@@ -90,6 +90,7 @@ class AutoSklearnEstimator(BaseEstimator):
             Memory limit in MB for the ensemble building process.
             `auto-sklearn` will reduce the number of considered models
             (``ensemble_nbest``) if the memory limit is reached.
+            If ``None``, no memory limit is enforced.
 
         seed : int, optional (default=1)
             Used to seed SMAC. Will determine the output file names.


### PR DESCRIPTION
When the ensemble failed due to not being able to build an ensemble of a single model, the ensemble builder process now gives useful advice on how to mitigate the problem of not being able to build an ensemble by increasing the relevant memory limit.