### PR TITLE
Fix 916

### DIFF
--- a/autosklearn/pipeline/base.py
+++ b/autosklearn/pipeline/base.py
@@ -385,7 +385,7 @@ class BasePipeline(Pipeline):
 
         return rval
 
-    def _get_pipeline_steps(self, dataset_properties=None):
+    def _get_pipeline_steps(self, dataset_properties):
         raise NotImplementedError()
 
     def _get_estimator_hyperparameter_name(self):

--- a/autosklearn/pipeline/base.py
+++ b/autosklearn/pipeline/base.py
@@ -28,7 +28,7 @@ class BasePipeline(Pipeline):
             dataset_properties is not None else {}
 
         if steps is None:
-            self.steps = self._get_pipeline_steps()
+            self.steps = self._get_pipeline_steps(dataset_properties=dataset_properties)
         else:
             self.steps = steps
 
@@ -385,7 +385,7 @@ class BasePipeline(Pipeline):
 
         return rval
 
-    def _get_pipeline_steps(self):
+    def _get_pipeline_steps(self, dataset_properties=None):
         raise NotImplementedError()
 
     def _get_estimator_hyperparameter_name(self):

--- a/autosklearn/pipeline/base.py
+++ b/autosklearn/pipeline/base.py
@@ -173,7 +173,7 @@ class BasePipeline(Pipeline):
                 return y
 
     def set_hyperparameters(self, configuration, init_params=None):
-        self.configuration = configuration
+        self.config = configuration
 
         for node_idx, n_ in enumerate(self.steps):
             node_name, node = n_

--- a/autosklearn/pipeline/classification.py
+++ b/autosklearn/pipeline/classification.py
@@ -81,14 +81,14 @@ class SimpleClassificationPipeline(ClassifierMixin, BasePipeline):
         if fit_params is None:
             fit_params = {}
 
-        if self.configuration['balancing:strategy'] == 'weighting':
+        if self.config['balancing:strategy'] == 'weighting':
             balancing = Balancing(strategy='weighting')
             _init_params, _fit_params = balancing.get_weights(
-                y, self.configuration['classifier:__choice__'],
-                self.configuration['feature_preprocessor:__choice__'],
+                y, self.config['classifier:__choice__'],
+                self.config['feature_preprocessor:__choice__'],
                 {}, {})
             _init_params.update(self.init_params)
-            self.set_hyperparameters(configuration=self.configuration,
+            self.set_hyperparameters(configuration=self.config,
                                      init_params=_init_params)
 
             if _fit_params is not None:

--- a/autosklearn/pipeline/classification.py
+++ b/autosklearn/pipeline/classification.py
@@ -274,10 +274,12 @@ class SimpleClassificationPipeline(ClassifierMixin, BasePipeline):
         self.dataset_properties = dataset_properties
         return cs
 
-    def _get_pipeline_steps(self):
+    def _get_pipeline_steps(self, dataset_properties=None):
         steps = []
 
         default_dataset_properties = {'target_type': 'classification'}
+        if dataset_properties is not None and isinstance(dataset_properties, dict):
+            default_dataset_properties.update(dataset_properties)
 
         steps.extend([
             ["data_preprocessing",

--- a/autosklearn/pipeline/classification.py
+++ b/autosklearn/pipeline/classification.py
@@ -274,7 +274,7 @@ class SimpleClassificationPipeline(ClassifierMixin, BasePipeline):
         self.dataset_properties = dataset_properties
         return cs
 
-    def _get_pipeline_steps(self, dataset_properties=None):
+    def _get_pipeline_steps(self, dataset_properties):
         steps = []
 
         default_dataset_properties = {'target_type': 'classification'}

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -7,6 +7,8 @@ import sys
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_random_state
 
+from autosklearn.pipeline.constants import SPARSE
+
 
 def find_components(package, directory, base_class):
     components = OrderedDict()
@@ -376,13 +378,14 @@ class AutoSklearnChoice(object):
             elif exclude is not None and name in exclude:
                 continue
 
-            # Add support for components that do not support
-            # sparse data. That is, we don't want to add them as choices
-            properties = available_comp[name].get_properties()
             if 'sparse' in dataset_properties and dataset_properties['sparse']:
                 # In case the dataset is sparse, ignore
                 # components that do not handle sparse data
-                if not properties['handles_sparse']:
+                # Auto-sklearn uses SPARSE constant as a mechanism
+                # to indicate whether a component can handle sparse data.
+                # If SPARSE is not in the input properties of the component, it
+                # means SPARSE is not a valid input to this component, so filter it out
+                if SPARSE not in available_comp[name].get_properties()['input']:
                     continue
 
             components_dict[name] = available_comp[name]

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -383,7 +383,6 @@ class AutoSklearnChoice(object):
                 # In case the dataset is sparse, ignore
                 # components that do not handle sparse data
                 if not properties['handles_sparse']:
-                    print(f"skipping {name}")
                     continue
 
             components_dict[name] = available_comp[name]

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -376,7 +376,15 @@ class AutoSklearnChoice(object):
             elif exclude is not None and name in exclude:
                 continue
 
-            # TODO maybe check for sparse?
+            # Add support for components that do not support
+            # sparse data. That is, we don't want to add them as choices
+            properties = available_comp[name].get_properties()
+            if 'sparse' in dataset_properties and dataset_properties['sparse']:
+                # In case the dataset is sparse, ignore
+                # components that do not handle sparse data
+                if not properties['handles_sparse']:
+                    print(f"skipping {name}")
+                    continue
 
             components_dict[name] = available_comp[name]
 

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing.py
@@ -46,6 +46,7 @@ class DataPreprocessor(AutoSklearnComponent):
         # of the dataset
         # Configuration of the data-preprocessor is different from the configuration of
         # the categorical pipeline. Hence, force to None
+        # It is actually the call to set_hyperparameter who properly sets this argument
         # TODO: Extract the child configuration space from the datapreprocessor to the
         # pipeline if needed
         self.categ_ppl = CategoricalPreprocessingPipeline(
@@ -56,6 +57,7 @@ class DataPreprocessor(AutoSklearnComponent):
         # of the dataset
         # Configuration of the data-preprocessor is different from the configuration of
         # the numerical pipeline. Hence, force to None
+        # It is actually the call to set_hyperparameter who properly sets this argument
         # TODO: Extract the child configuration space from the datapreprocessor to the
         # pipeline if needed
         self.numer_ppl = NumericalPreprocessingPipeline(

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing.py
@@ -44,14 +44,24 @@ class DataPreprocessor(AutoSklearnComponent):
 
         # The pipeline that will be applied to the categorical features (i.e. columns)
         # of the dataset
+        # Configuration of the data-preprocessor is different from the configuration of
+        # the categorical pipeline. Hence, force to None
+        # TODO: Extract the child configuration space from the datapreprocessor to the
+        # pipeline if needed
         self.categ_ppl = CategoricalPreprocessingPipeline(
-            config, pipeline, dataset_properties, include, exclude,
-            random_state, init_params)
+            config=None, steps=pipeline, dataset_properties=dataset_properties,
+            include=include, exclude=exclude, random_state=random_state,
+            init_params=init_params)
         # The pipeline that will be applied to the numerical features (i.e. columns)
         # of the dataset
+        # Configuration of the data-preprocessor is different from the configuration of
+        # the numerical pipeline. Hence, force to None
+        # TODO: Extract the child configuration space from the datapreprocessor to the
+        # pipeline if needed
         self.numer_ppl = NumericalPreprocessingPipeline(
-            config, pipeline, dataset_properties, include, exclude,
-            random_state, init_params)
+            config=None, steps=pipeline, dataset_properties=dataset_properties,
+            include=include, exclude=exclude, random_state=random_state,
+            init_params=init_params)
         self._transformers = [
             ["categorical_transformer", self.categ_ppl],
             ["numerical_transformer", self.numer_ppl],

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing.py
@@ -56,8 +56,11 @@ class DataPreprocessor(AutoSklearnComponent):
             ["categorical_transformer", self.categ_ppl],
             ["numerical_transformer", self.numer_ppl],
         ]
+        if self.config:
+            self.set_hyperparameters(self.config, init_params=init_params)
 
     def fit(self, X, y=None):
+
         n_feats = X.shape[1]
         # If categorical_features is none or an array made just of False booleans, then
         # only the numerical transformer is used
@@ -114,7 +117,7 @@ class DataPreprocessor(AutoSklearnComponent):
         if init_params is not None and 'categorical_features' in init_params.keys():
             self.categorical_features = init_params['categorical_features']
 
-        self.configuration = configuration
+        self.config = configuration
 
         for transf_name, transf_op in self._transformers:
             sub_configuration_space = transf_op.get_hyperparameter_search_space(

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_categorical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_categorical.py
@@ -87,8 +87,11 @@ class CategoricalPreprocessingPipeline(BasePipeline):
         self.dataset_properties_ = dataset_properties
         return cs
 
-    def _get_pipeline_steps(self):
+    def _get_pipeline_steps(self, dataset_properties=None):
         steps = []
+        default_dataset_properties = {}
+        if dataset_properties is not None and isinstance(dataset_properties, dict):
+            default_dataset_properties.update(dataset_properties)
 
         steps.extend([
             ["category_shift", CategoryShift()],

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_categorical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_categorical.py
@@ -84,11 +84,11 @@ class CategoricalPreprocessingPipeline(BasePipeline):
             exclude=exclude, include=include, pipeline=self.steps)
 
         self.configuration_space_ = cs
-        self.dataset_properties_ = dataset_properties
         return cs
 
     def _get_pipeline_steps(self, dataset_properties=None):
         steps = []
+
         default_dataset_properties = {}
         if dataset_properties is not None and isinstance(dataset_properties, dict):
             default_dataset_properties.update(dataset_properties)
@@ -96,8 +96,8 @@ class CategoricalPreprocessingPipeline(BasePipeline):
         steps.extend([
             ["category_shift", CategoryShift()],
             ["imputation", CategoricalImputation()],
-            ["category_coalescence", CoalescenseChoice(self.dataset_properties)],
-            ["categorical_encoding", OHEChoice(self.dataset_properties)],
+            ["category_coalescence", CoalescenseChoice(default_dataset_properties)],
+            ["categorical_encoding", OHEChoice(default_dataset_properties)],
             ])
 
         return steps

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_numerical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_numerical.py
@@ -89,15 +89,17 @@ class NumericalPreprocessingPipeline(BasePipeline):
         self.dataset_properties_ = dataset_properties
         return cs
 
-    def _get_pipeline_steps(self):
+    def _get_pipeline_steps(self, dataset_properties=None):
         steps = []
 
-        default_dataset_props = {'target_type': 'classification'}
+        default_dataset_properties = {'target_type': 'classification'}
+        if dataset_properties is not None and isinstance(dataset_properties, dict):
+            default_dataset_properties.update(dataset_properties)
 
         steps.extend([
             ["imputation", NumericalImputation()],
             ["variance_threshold", VarianceThreshold()],
-            ["rescaling", rescaling_components.RescalingChoice(default_dataset_props)],
+            ["rescaling", rescaling_components.RescalingChoice(default_dataset_properties)],
             ])
 
         return steps

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_numerical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_numerical.py
@@ -86,13 +86,12 @@ class NumericalPreprocessingPipeline(BasePipeline):
             exclude=exclude, include=include, pipeline=self.steps)
 
         self.configuration_space_ = cs
-        self.dataset_properties_ = dataset_properties
         return cs
 
     def _get_pipeline_steps(self, dataset_properties=None):
         steps = []
 
-        default_dataset_properties = {'target_type': 'classification'}
+        default_dataset_properties = {}
         if dataset_properties is not None and isinstance(dataset_properties, dict):
             default_dataset_properties.update(dataset_properties)
 

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/minmax.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/minmax.py
@@ -25,7 +25,7 @@ class MinMaxScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
                 'handles_multioutput': True,
                 'is_deterministic': True,
                 # TODO find out if this is right!
-                'handles_sparse': True,
+                'handles_sparse': False,
                 'handles_dense': True,
                 'input': (DENSE, UNSIGNED_DATA),
                 'output': (INPUT, SIGNED_DATA),

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/quantile_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/quantile_transformer.py
@@ -2,7 +2,7 @@ from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformIntegerHyperparameter, \
     CategoricalHyperparameter
 
-from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, SIGNED_DATA, INPUT
+from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, SIGNED_DATA, SPARSE, INPUT
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
 from autosklearn.pipeline.components.base import \
@@ -33,7 +33,7 @@ class QuantileTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm)
                 # TODO find out if this is right!
                 'handles_sparse': True,
                 'handles_dense': True,
-                'input': (DENSE, UNSIGNED_DATA),
+                'input': (SPARSE, DENSE, UNSIGNED_DATA),
                 'output': (INPUT, SIGNED_DATA),
                 'preferred_dtype': None}
 

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/robust_scaler.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/robust_scaler.py
@@ -1,3 +1,4 @@
+from scipy import sparse
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter
 
@@ -44,3 +45,9 @@ class RobustScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
         )
         cs.add_hyperparameters((q_min, q_max))
         return cs
+
+    def fit(self, X, y=None):
+        if sparse.isspmatrix(X):
+            self.preprocessor.set_params(with_centering=False)
+
+        return super(RobustScalerComponent, self).fit(X, y)

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/robust_scaler.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/robust_scaler.py
@@ -2,7 +2,7 @@ from scipy import sparse
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter
 
-from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, SIGNED_DATA, INPUT
+from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, SIGNED_DATA, INPUT, SPARSE
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
 from autosklearn.pipeline.components.base import \
@@ -31,7 +31,7 @@ class RobustScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
                 # TODO find out if this is right!
                 'handles_sparse': True,
                 'handles_dense': True,
-                'input': (DENSE, UNSIGNED_DATA),
+                'input': (SPARSE, DENSE, UNSIGNED_DATA),
                 'output': (INPUT, SIGNED_DATA),
                 'preferred_dtype': None}
 

--- a/autosklearn/pipeline/regression.py
+++ b/autosklearn/pipeline/regression.py
@@ -225,7 +225,7 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
     def _get_estimator_components(self):
         return regression_components._regressors
 
-    def _get_pipeline_steps(self, dataset_properties=None, init_params=None):
+    def _get_pipeline_steps(self, dataset_properties, init_params=None):
         steps = []
 
         default_dataset_properties = {'target_type': 'regression'}

--- a/autosklearn/pipeline/regression.py
+++ b/autosklearn/pipeline/regression.py
@@ -225,10 +225,12 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
     def _get_estimator_components(self):
         return regression_components._regressors
 
-    def _get_pipeline_steps(self, init_params=None):
+    def _get_pipeline_steps(self, dataset_properties=None, init_params=None):
         steps = []
 
         default_dataset_properties = {'target_type': 'regression'}
+        if dataset_properties is not None and isinstance(dataset_properties, dict):
+            default_dataset_properties.update(dataset_properties)
 
         steps.extend([
             ['data_preprocessing',

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -70,18 +70,6 @@ class DummyPreprocessor(AutoSklearnPreprocessingAlgorithm):
         return cs
 
 
-def translate_config_to_implementation(config, matching_string):
-    """
-    Given a configuration, this utility extracts from a given config,
-    the relevant matching_string configuration.
-    In other words, config is expected to be a super configuration
-    from which we want to extract a subset of it that complies with
-    matching_string
-    """
-    translated_dict = {}
-    return translated_dict
-
-
 class SimpleClassificationPipelineTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -755,7 +755,10 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                         for sub_name, sub_step in pipeline.items():
                             # If it is a Choice, make sure it is the correct one!
                             if isinstance(sub_step, AutoSklearnChoice):
-                                key = f"data_preprocessing:{data_type}:{sub_name}:__choice__"
+                                key = "data_preprocessing:{}:{}:__choice__".format(
+                                    data_type,
+                                    sub_name
+                                )
                                 keys_checked.extend(
                                     self._test_set_hyperparameter_choice(
                                         key, sub_step, config_dict
@@ -765,7 +768,10 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                             elif isinstance(sub_step, AutoSklearnComponent):
                                 keys_checked.extend(
                                     self._test_set_hyperparameter_component(
-                                        f"data_preprocessing:{data_type}:{sub_name}",
+                                        "data_preprocessing:{}:{}".format(
+                                            data_type,
+                                            sub_name
+                                        ),
                                         sub_step, config_dict
                                     )
                                 )

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 import os
 import resource
 import tempfile
@@ -663,7 +664,6 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         keys_checked = [expected_key]
         implementation_type = config_dict[expected_key]
         expected_type = implementation.get_components()[implementation_type]
-        keys_checked.append(expected_key)
         self.assertIsInstance(implementation.choice, expected_type)
 
         # Are there further hyperparams?
@@ -720,13 +720,14 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         configuration from Config was checked
         """
 
-        for dataset_properties in [
-                {'sparse': True, 'multilabel': True},
-                {'multilabel': True, 'multiclass': True},
-                {'multilabel': False, 'multiclass': False},
-                {'signed': True},
-                {'signed': False},
-        ]:
+        all_combinations = list(itertools.combinations([True, False], r=4))
+        for sparse, multilabel, signed, multiclass, in all_combinations:
+            dataset_properties = {
+                'sparse': sparse,
+                'multilabel': multilabel,
+                'multiclass': multiclass,
+                'signed': signed,
+            }
             cls = SimpleClassificationPipeline(
                 random_state=1,
                 dataset_properties=dataset_properties,

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 import resource
 import sys
 import tempfile
@@ -446,7 +447,6 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         keys_checked = [expected_key]
         implementation_type = config_dict[expected_key]
         expected_type = implementation.get_components()[implementation_type]
-        keys_checked.append(expected_key)
         self.assertIsInstance(implementation.choice, expected_type)
 
         # Are there further hyperparams?
@@ -502,13 +502,14 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         configuration from Config was checked
         """
 
-        for dataset_properties in [
-                {'sparse': True, 'multilabel': True},
-                {'multilabel': True, 'multiclass': True},
-                {'multilabel': False, 'multiclass': False},
-                {'signed': True},
-                {'signed': False},
-        ]:
+        all_combinations = list(itertools.combinations([True, False], r=4))
+        for sparse, multilabel, signed, multiclass, in all_combinations:
+            dataset_properties = {
+                'sparse': sparse,
+                'multilabel': multilabel,
+                'multiclass': multiclass,
+                'signed': signed,
+            }
             auto = SimpleRegressionPipeline(
                 random_state=1,
                 dataset_properties=dataset_properties,

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -537,7 +537,10 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                         for sub_name, sub_step in pipeline.items():
                             # If it is a Choice, make sure it is the correct one!
                             if isinstance(sub_step, AutoSklearnChoice):
-                                key = f"data_preprocessing:{data_type}:{sub_name}:__choice__"
+                                key = "data_preprocessing:{}:{}:__choice__".format(
+                                    data_type,
+                                    sub_name
+                                )
                                 keys_checked.extend(
                                     self._test_set_hyperparameter_choice(
                                         key, sub_step, config_dict
@@ -547,7 +550,10 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                             elif isinstance(sub_step, AutoSklearnComponent):
                                 keys_checked.extend(
                                     self._test_set_hyperparameter_component(
-                                        f"data_preprocessing:{data_type}:{sub_name}",
+                                        "data_preprocessing:{}:{}".format(
+                                            data_type,
+                                            sub_name
+                                        ),
                                         sub_step, config_dict
                                     )
                                 )

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -21,6 +21,7 @@ from autosklearn.pipeline.regression import SimpleRegressionPipeline
 from autosklearn.pipeline.components.base import \
     AutoSklearnPreprocessingAlgorithm, AutoSklearnRegressionAlgorithm
 import autosklearn.pipeline.components.regression as regression_components
+from autosklearn.pipeline.components.base import AutoSklearnComponent, AutoSklearnChoice
 import autosklearn.pipeline.components.feature_preprocessing as preprocessing_components
 from autosklearn.pipeline.util import get_dataset
 from autosklearn.pipeline.constants import SPARSE, DENSE, SIGNED_DATA, UNSIGNED_DATA, PREDICTIONS
@@ -435,3 +436,146 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
 
     def test_get_params(self):
         pass
+
+    def _test_set_hyperparameter_choice(self, expected_key, implementation, config_dict):
+        """
+        Given a configuration in config, this procedure makes sure that
+        the given implementation, which should be a Choice component, honors
+        the type of the object, and any hyperparameter associated to it
+        """
+        keys_checked = [expected_key]
+        implementation_type = config_dict[expected_key]
+        expected_type = implementation.get_components()[implementation_type]
+        keys_checked.append(expected_key)
+        self.assertIsInstance(implementation.choice, expected_type)
+
+        # Are there further hyperparams?
+        # A choice component might have attribute requirements that we need to check
+        expected_sub_key = expected_key.replace(':__choice__', ':') + implementation_type
+        expected_attributes = {}
+        for key, value in config_dict.items():
+            if key != expected_key and expected_sub_key in key:
+                expected_attributes[key.split(':')[-1]] = value
+                keys_checked.append(key)
+        if expected_attributes:
+            attributes = vars(implementation.choice)
+            # Cannot check the whole dictionary, just names, as some
+            # classes map the text hyperparameter directly to a function!
+            for expected_attribute in expected_attributes.keys():
+                self.assertIn(expected_attribute, attributes.keys())
+        return keys_checked
+
+    def _test_set_hyperparameter_component(self, expected_key, implementation, config_dict):
+        """
+        Given a configuration in config, this procedure makes sure that
+        the given implementation, which should be a autosklearn component, honors
+        is created with the desired hyperparameters stated in config_dict
+        """
+        keys_checked = []
+        attributes = vars(implementation)
+        expected_attributes = {}
+        for key, value in config_dict.items():
+            if expected_key in key:
+                keys_checked.append(key)
+                key = key.replace(expected_key + ':', '')
+                if ':' in key:
+                    raise ValueError("This utility should only be called with a "
+                                     "matching string that produces leaf configurations, "
+                                     "that is no further colons are expected, yet key={}"
+                                     "".format(
+                                            key
+                                        )
+                                     )
+                expected_attributes[key] = value
+        # Cannot check the whole dictionary, just names, as some
+        # classes map the text hyperparameter directly to a function!
+        for expected_attribute in expected_attributes.keys():
+            self.assertIn(expected_attribute, attributes.keys())
+        return keys_checked
+
+    def test_set_hyperparameters_honors_configuration(self):
+        """Makes sure that a given configuration is honored in practice.
+
+        This method tests that the set hyperparameters actually create objects
+        that comply with the given configuration. It iterates trough the pipeline to
+        make sure we did not miss a step, but also checks at the end that every
+        configuration from Config was checked
+        """
+
+        for dataset_properties in [
+                {'sparse': True, 'multilabel': True},
+                {'multilabel': True, 'multiclass': True},
+                {'multilabel': False, 'multiclass': False},
+                {'signed': True},
+                {'signed': False},
+        ]:
+            auto = SimpleRegressionPipeline(
+                random_state=1,
+                dataset_properties=dataset_properties,
+            )
+            cs = auto.get_hyperparameter_search_space()
+            config = cs.sample_configuration()
+
+            # Set hyperparameters takes a given config and translate
+            # a config to an actual implementation
+            auto.set_hyperparameters(config)
+            config_dict = config.get_dictionary()
+
+            # keys to check is our mechanism to ensure that every
+            # every config key is checked
+            keys_checked = []
+
+            for name, step in auto.named_steps.items():
+                if name == 'data_preprocessing':
+                    # We have to check both the numerical and categorical
+                    to_check = {
+                        'numerical_transformer': step.numer_ppl.named_steps,
+                        'categorical_transformer': step.categ_ppl.named_steps,
+                    }
+
+                    for data_type, pipeline in to_check.items():
+                        for sub_name, sub_step in pipeline.items():
+                            # If it is a Choice, make sure it is the correct one!
+                            if isinstance(sub_step, AutoSklearnChoice):
+                                key = f"data_preprocessing:{data_type}:{sub_name}:__choice__"
+                                keys_checked.extend(
+                                    self._test_set_hyperparameter_choice(
+                                        key, sub_step, config_dict
+                                    )
+                                )
+                            # If it is a component, make sure it has the correct hyperparams
+                            elif isinstance(sub_step, AutoSklearnComponent):
+                                keys_checked.extend(
+                                    self._test_set_hyperparameter_component(
+                                        f"data_preprocessing:{data_type}:{sub_name}",
+                                        sub_step, config_dict
+                                    )
+                                )
+                            else:
+                                raise ValueError("New type of pipeline component!")
+                elif name == 'balancing':
+                    keys_checked.extend(
+                        self._test_set_hyperparameter_component(
+                            'balancing',
+                            step, config_dict
+                        )
+                    )
+                elif name == 'feature_preprocessor':
+                    keys_checked.extend(
+                        self._test_set_hyperparameter_choice(
+                            'feature_preprocessor:__choice__', step, config_dict
+                        )
+                    )
+                elif name == 'regressor':
+                    keys_checked.extend(
+                        self._test_set_hyperparameter_choice(
+                            'regressor:__choice__', step, config_dict
+                        )
+                    )
+                else:
+                    raise ValueError("Found another type of step! Need to update this check"
+                                     " {}. ".format(name)
+                                     )
+
+            # Make sure we checked the whole configuration
+            self.assertSetEqual(set(config_dict.keys()), set(keys_checked))


### PR DESCRIPTION
This was definitely hard to debug issue :( :(


The fundamental problem is that when joblib of column transformer created a new object in one o the workers, such object was created with the default configuration space and hence the problem.

This PR has a bunch of changes, because before finding the real issue, I bumped into a lot of things. Here's why:


1. We originally thought that the configuration was not honored due to a message that printed always the default configuration. The fundamental problem here is that the __repr__ method was wrongly using the default config always, so what you printed was misleading. This was fixed.
2.  Above message made me believe that something was wrong so I coded a test to make sure the configuration is honored and the correct classes are created, and it turned out they where.
3. During fit, I noticed that objects where created by the joblib (correctly) BUT the worker still called an unexpected fit. it turned out that data preprocessor has a pipeline by itself, that doesn't comply with the estimator principle that all arguments should honor set/get params.
4. I had to rename all self.configuration to self.config to comply with this principle
5. Then, to make sure that when the worker creates a new dataprocessor pipeline, we do set hyperparameters again, with the self.config arguments.
6. Then I created a new test to make sure that the fit method is called from the desired object, to prevent a situation like this to show up in the future.
