### PR TITLE
Test base pipeline init params

### DIFF
--- a/test/test_pipeline/test_base.py
+++ b/test/test_pipeline/test_base.py
@@ -105,6 +105,8 @@ class BaseTest(unittest.TestCase):
     def test_init_params_handling(self):
         """
         Makes sure that init params is properly passed to nodes
+
+        Also, makes sure that _check_init_params_honored raises the expected exceptions
         """
         cs = ConfigSpace.configuration_space.ConfigurationSpace()
         base = BasePipelineMock()
@@ -122,14 +124,31 @@ class BaseTest(unittest.TestCase):
                 ({}, {}),
                 (None, None),
                 ({'M:key': 'value'}, {'key': 'value'}),
-                ({'N:key': 'value'}, {}),
             ]:
                 node = unittest.mock.Mock(
                     spec=autosklearn.pipeline.components.base.AutoSklearnComponent
                 )
                 node.get_hyperparameter_search_space.return_value = cs
+                node.key = 'value'
                 base.steps = [('M', node)]
                 base.set_hyperparameters(cs.sample_configuration(), init_params=init_params)
                 self.assertEqual(node.set_hyperparameters.call_args[1]['init_params'],
                                  expected_init_params)
 
+            # Check for proper exception raising
+            node = unittest.mock.Mock(
+                spec=autosklearn.pipeline.components.base.AutoSklearnComponent
+            )
+            node.get_hyperparameter_search_space.return_value = cs
+            base.steps = [('M', node)]
+            with self.assertRaisesRegex(ValueError, "Unsupported argument to init_params"):
+                base.set_hyperparameters(cs.sample_configuration(), init_params={'key': 'value'})
+
+            # An invalid node name is passed
+            with self.assertRaisesRegex(ValueError, "The current node name specified via key"):
+                base.set_hyperparameters(cs.sample_configuration(), init_params={'N:key': 'value'})
+
+            # The value was not properly set -- Here it happens because the
+            # object is a magic mock, calling the method doesn't set a new parameter
+            with self.assertRaisesRegex(ValueError, "Cannot properly set the pair"):
+                base.set_hyperparameters(cs.sample_configuration(), init_params={'M:key': 'value'})

--- a/test/test_pipeline/test_base.py
+++ b/test/test_pipeline/test_base.py
@@ -1,8 +1,10 @@
 import unittest
+import unittest.mock
 
 import ConfigSpace.configuration_space
 
 import autosklearn.pipeline.base
+import autosklearn.pipeline.components.base
 import autosklearn.pipeline.components.feature_preprocessing
 import autosklearn.pipeline.components.classification
 
@@ -99,3 +101,35 @@ class BaseTest(unittest.TestCase):
         # for clause in sorted([str(clause) for clause in cs.forbidden_clauses]):
         #    print(clause)
         self.assertEqual(359, len(cs.forbidden_clauses))
+
+    def test_init_params_handling(self):
+        """
+        Makes sure that init params is properly passed to nodes
+        """
+        cs = ConfigSpace.configuration_space.ConfigurationSpace()
+        base = BasePipelineMock()
+        base.dataset_properties = {}
+
+        # Make sure that component irrespective, we check the init params
+        for node_type in [
+            autosklearn.pipeline.components.base.AutoSklearnComponent,
+            autosklearn.pipeline.components.base.AutoSklearnChoice,
+            autosklearn.pipeline.base.BasePipeline,
+        ]:
+
+            # We have couple of posibilities
+            for init_params, expected_init_params in [
+                ({}, {}),
+                (None, None),
+                ({'M:key': 'value'}, {'key': 'value'}),
+                ({'N:key': 'value'}, {}),
+            ]:
+                node = unittest.mock.Mock(
+                    spec=autosklearn.pipeline.components.base.AutoSklearnComponent
+                )
+                node.get_hyperparameter_search_space.return_value = cs
+                base.steps = [('M', node)]
+                base.set_hyperparameters(cs.sample_configuration(), init_params=init_params)
+                self.assertEqual(node.set_hyperparameters.call_args[1]['init_params'],
+                                 expected_init_params)
+

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -255,7 +255,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                 'X_test': X_test, 'Y_test': Y_test}
 
         init_params = {
-            'categorical_encoding:one_hot_encoding:categorical_features':
+            'data_preprocessing:categorical_features':
                 categorical
         }
 
@@ -265,23 +265,28 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
     @unittest.mock.patch('autosklearn.pipeline.components.data_preprocessing'
                          '.data_preprocessing.DataPreprocessor.set_hyperparameters')
     def test_categorical_passed_to_one_hot_encoder(self, ohe_mock):
-        cls = SimpleClassificationPipeline(
-            init_params={'data_preprocessing:categorical_features': [True, False]}
-        )
 
-        self.assertEqual(
-            ohe_mock.call_args[1]['init_params'],
-            {'categorical_features': [True, False]}
-        )
-        default = cls.get_hyperparameter_search_space().get_default_configuration()
-        cls.set_hyperparameters(
-            configuration=default,
-            init_params={'data_preprocessing:categorical_features': [True, True, False]},
-        )
-        self.assertEqual(
-            ohe_mock.call_args[1]['init_params'],
-            {'categorical_features': [True, True, False]}
-        )
+        # Mock the _check_init_params_honored as there is no object created,
+        # _check_init_params_honored will fail as a datapreprocessor was never created
+        with unittest.mock.patch('autosklearn.pipeline.classification.SimpleClassificationPipeline'
+                                 '._check_init_params_honored'):
+            cls = SimpleClassificationPipeline(
+                init_params={'data_preprocessing:categorical_features': [True, False]}
+            )
+
+            self.assertEqual(
+                ohe_mock.call_args[1]['init_params'],
+                {'categorical_features': [True, False]}
+            )
+            default = cls.get_hyperparameter_search_space().get_default_configuration()
+            cls.set_hyperparameters(
+                configuration=default,
+                init_params={'data_preprocessing:categorical_features': [True, True, False]},
+            )
+            self.assertEqual(
+                ohe_mock.call_args[1]['init_params'],
+                {'categorical_features': [True, True, False]}
+            )
 
     def _test_configurations(self, configurations_space, make_sparse=False,
                              data=None, init_params=None,


### PR DESCRIPTION
The goal of this push is to add a check that makes sure that nodes in the pipeline get a properly processed init params, regardless of the type of Node. 