### PR TITLE
[WIP] Upgrade pandas>=1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ scikit-learn>=0.22.0,<0.23
 lockfile
 joblib
 pyyaml
-pandas<1.0
+pandas>=1.0
 
 ConfigSpace>=0.4.0,<0.5
 pynisher>=0.4.2


### PR DESCRIPTION
pandas 1.0 was released in January 2020 and removed many deprecated commands.  Hopefully the travis tests can show where we are using deprecated API and we can swap them out one at a time.