### PR TITLE
metadata requires liac-arff

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ lockfile
 joblib
 pyyaml
 pandas<1.0
+liac-arff
 
 ConfigSpace>=0.4.0,<0.5
 pynisher>=0.4.2


### PR DESCRIPTION
We are missing a requirement for the following:
https://github.com/automl/auto-sklearn/blob/1c6af59ff61f1d0a3b54b16a35ffbc5d2d3828cd/scripts/2015_nips_paper/run/remove_dataset_from_metadata.py#L3


Which causes:
```
Traceback (most recent call last):

  File "/bench/frameworks/autosklearn_090/exec.py", line 15, in <module>

    from autosklearn.estimators import AutoSklearnClassifier, AutoSklearnRegressor

  File "/bench/frameworks/autosklearn_090/venv/lib/python3.6/site-packages/autosklearn/estimators.py", line 11, in <module>

    from autosklearn.automl import AutoMLClassifier, AutoMLRegressor, AutoML

  File "/bench/frameworks/autosklearn_090/venv/lib/python3.6/site-packages/autosklearn/automl.py", line 42, in <module>

    from autosklearn.smbo import AutoMLSMBO

  File "/bench/frameworks/autosklearn_090/venv/lib/python3.6/site-packages/autosklearn/smbo.py", line 25, in <module>

    from autosklearn.metalearning.metalearning.meta_base import MetaBase

  File "/bench/frameworks/autosklearn_090/venv/lib/python3.6/site-packages/autosklearn/metalearning/metalearning/meta_base.py", line 4, in <module>

    from ..input import aslib_simple

  File "/bench/frameworks/autosklearn_090/venv/lib/python3.6/site-packages/autosklearn/metalearning/input/aslib_simple.py", line 6, in <module>

    import arff

ModuleNotFoundError: No module named 'arff'

```