### PR TITLE
Resolve #905

### DIFF
--- a/autosklearn/__version__.py
+++ b/autosklearn/__version__.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.10.0dev"
+__version__ = "0.9.0"


### PR DESCRIPTION
Link to issue: [#905 ](https://github.com/automl/auto-sklearn/issues/905).

Instance of class `AutoSklearn2Classifier` will be able to be pickled with the following conditions:
1. Replace `joblib` with [dill](https://github.com/uqfoundation/dill) for model serialisation:  The original error described in the issue is due to joblib not being able to serialise functions.
2. Applying the changes in the PR: Pickling using `dill` alone is not enough. You will still encounter error after dumping because `multiprocessing`'s `Lock` object is not allowed to be passed as an object through functions. This PR converts it to be a global variable