### PR TITLE
3 minor fixes

### DIFF
--- a/autosklearn/evaluation/abstract_evaluator.py
+++ b/autosklearn/evaluation/abstract_evaluator.py
@@ -20,7 +20,7 @@ from autosklearn.constants import (
 from autosklearn.pipeline.implementations.util import (
     convert_multioutput_multiclass_to_multilabel
 )
-from autosklearn.metrics import calculate_score, CLASSIFICATION_METRICS
+from autosklearn.metrics import calculate_score, CLASSIFICATION_METRICS, REGRESSION_METRICS
 from autosklearn.util.logging_ import get_logger
 
 from ConfigSpace import Configuration
@@ -256,9 +256,12 @@ class AbstractEvaluator(object):
         if hasattr(score, '__len__'):
             # TODO: instead of using self.metric, it should use all metrics given by key.
             # But now this throws error...
-
-            err = {key: metric._optimum - score[key] for key, metric in
-                   CLASSIFICATION_METRICS.items() if key in score}
+            if self.task_type in CLASSIFICATION_TASKS:
+                err = {key: metric._optimum - score[key] for key, metric in
+                       CLASSIFICATION_METRICS.items() if key in score}
+            else:
+                err = {key: metric._optimum - score[key] for key, metric in
+                       REGRESSION_METRICS.items() if key in score}
         else:
             err = self.metric._optimum - score
 

--- a/autosklearn/evaluation/test_evaluator.py
+++ b/autosklearn/evaluation/test_evaluator.py
@@ -5,7 +5,7 @@ from autosklearn.evaluation.abstract_evaluator import (
     AbstractEvaluator,
     _fit_and_suppress_warnings,
 )
-from autosklearn.metrics import calculate_score
+from autosklearn.metrics import calculate_score, CLASSIFICATION_METRICS
 
 
 __all__ = [
@@ -85,9 +85,10 @@ class TestEvaluator(AbstractEvaluator):
                 all_scoring_functions=self.all_scoring_functions)
 
         if hasattr(score, '__len__'):
-            err = {key: 1 - score[key] for key in score}
+            err = {key: metric._optimum - score[key] for key, metric in
+                   CLASSIFICATION_METRICS.items() if key in score}
         else:
-            err = 1 - score
+            err = self.metric._optimum - score
 
         return err, Y_pred, None, None
 

--- a/autosklearn/evaluation/test_evaluator.py
+++ b/autosklearn/evaluation/test_evaluator.py
@@ -5,7 +5,8 @@ from autosklearn.evaluation.abstract_evaluator import (
     AbstractEvaluator,
     _fit_and_suppress_warnings,
 )
-from autosklearn.metrics import calculate_score, CLASSIFICATION_METRICS
+from autosklearn.metrics import calculate_score, CLASSIFICATION_METRICS, REGRESSION_METRICS
+from autosklearn.constants import CLASSIFICATION_TASKS
 
 
 __all__ = [
@@ -85,8 +86,12 @@ class TestEvaluator(AbstractEvaluator):
                 all_scoring_functions=self.all_scoring_functions)
 
         if hasattr(score, '__len__'):
-            err = {key: metric._optimum - score[key] for key, metric in
-                   CLASSIFICATION_METRICS.items() if key in score}
+            if self.task_type in CLASSIFICATION_TASKS:
+                err = {key: metric._optimum - score[key] for key, metric in
+                       CLASSIFICATION_METRICS.items() if key in score}
+            else:
+                err = {key: metric._optimum - score[key] for key, metric in
+                       REGRESSION_METRICS.items() if key in score}
         else:
             err = self.metric._optimum - score
 

--- a/autosklearn/metalearning/input/aslib_simple.py
+++ b/autosklearn/metalearning/input/aslib_simple.py
@@ -94,7 +94,10 @@ class AlgorithmSelectionProblem(object):
             # repetition = data[1]
             algorithm = str(data[2])
             perf_list = data[3:-1]
-            # status = data[-1]
+            status = data[-1]
+
+            if status != 'ok':
+                continue
 
             for i, performance_measure in enumerate(performance_measures):
                 measure_instance_algorithm_triples[performance_measure][

--- a/autosklearn/pipeline/components/classification/gradient_boosting.py
+++ b/autosklearn/pipeline/components/classification/gradient_boosting.py
@@ -174,8 +174,10 @@ class GradientBoostingClassifier(
         max_bins = Constant("max_bins", 255)
         l2_regularization = UniformFloatHyperparameter(
             name="l2_regularization", lower=1E-10, upper=1, default_value=1E-10, log=True)
+        # Train temporarily disabled to avoid error with scikit-learn 0.22
+        # TODO re-enable with later scikit-learn version
         early_stop = CategoricalHyperparameter(
-            name="early_stop", choices=["off", "train", "valid"], default_value="off")
+            name="early_stop", choices=["off", "valid"], default_value="off")
         tol = UnParametrizedHyperparameter(
             name="tol", value=1e-7)
         scoring = UnParametrizedHyperparameter(
@@ -191,7 +193,7 @@ class GradientBoostingClassifier(
                                 validation_fraction])
 
         n_iter_no_change_cond = InCondition(
-            n_iter_no_change, early_stop, ["valid", "train"])
+            n_iter_no_change, early_stop, ["valid"])  # , "train"])
         validation_fraction_cond = EqualsCondition(
             validation_fraction, early_stop, "valid")
 

--- a/autosklearn/pipeline/components/regression/gradient_boosting.py
+++ b/autosklearn/pipeline/components/regression/gradient_boosting.py
@@ -164,8 +164,10 @@ class GradientBoosting(
         max_bins = Constant("max_bins", 255)
         l2_regularization = UniformFloatHyperparameter(
             name="l2_regularization", lower=1E-10, upper=1, default_value=1E-10, log=True)
+        # Train temporarily disabled to avoid error with scikit-learn 0.22
+        # TODO re-enable with later scikit-learn version
         early_stop = CategoricalHyperparameter(
-            name="early_stop", choices=["off", "train", "valid"], default_value="off")
+            name="early_stop", choices=["off", "valid"], default_value="off")
         tol = UnParametrizedHyperparameter(
             name="tol", value=1e-7)
         scoring = UnParametrizedHyperparameter(
@@ -181,7 +183,7 @@ class GradientBoosting(
                                 validation_fraction])
 
         n_iter_no_change_cond = InCondition(
-            n_iter_no_change, early_stop, ["valid", "train"])
+            n_iter_no_change, early_stop, ["valid"])  # , "train"])
         validation_fraction_cond = EqualsCondition(
             validation_fraction, early_stop, "valid")
 

--- a/test/test_evaluation/test_test_evaluator.py
+++ b/test/test_evaluation/test_test_evaluator.py
@@ -131,7 +131,7 @@ class FunctionsTest(unittest.TestCase):
                    'f1_macro': 0.0341005967604433,
                    'f1_micro': 0.040000000000000036,
                    'f1_weighted': 0.039693094629155934,
-                   'log_loss': 1.148586485311389,
+                   'log_loss': 0.148586485311389,
                    'precision_macro': 0.03703703703703709,
                    'precision_micro': 0.040000000000000036,
                    'precision_weighted': 0.03555555555555556,

--- a/test/test_metalearning/pyMetaLearn/test_meta_base.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_base.py
@@ -28,12 +28,12 @@ class MetaBaseTest(unittest.TestCase):
         runs = self.base.get_all_runs()
         self.assertIsInstance(runs, pd.DataFrame)
         # TODO update this ASAP
-        self.assertEqual((128, 128), runs.shape)
+        self.assertEqual((125, 125), runs.shape)
 
     def test_get_runs(self):
         runs = self.base.get_runs('233')
         # TODO update this ASAP
-        self.assertEqual(128, len(runs))
+        self.assertEqual(125, len(runs))
         self.assertIsInstance(runs, pd.Series)
 
     def test_get_metafeatures_single_dataset(self):

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -409,13 +409,6 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                     print(traceback.format_exc())
                     print(config)
                     raise e
-            except UnboundLocalError as e:
-                if "local variable 'raw_predictions_val' referenced before assignment" in e.args[0]:
-                    continue
-                else:
-                    print(traceback.format_exc())
-                    print(config)
-                    raise e
 
     def test_get_hyperparameter_search_space(self):
         cs = SimpleClassificationPipeline().get_hyperparameter_search_space()

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -234,13 +234,6 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                     print(config)
                     traceback.print_tb(sys.exc_info()[2])
                     raise e
-            except UnboundLocalError as e:
-                if "local variable 'raw_predictions_val' referenced before assignment" in e.args[0]:
-                    continue
-                else:
-                    print(traceback.format_exc())
-                    print(config)
-                    raise e
             except Exception as e:
                 if "Multiple input features cannot have the same target value" in e.args[0]:
                     continue

--- a/test/test_scripts/test_metadata_generation.py
+++ b/test/test_scripts/test_metadata_generation.py
@@ -319,10 +319,10 @@ class TestMetadataGeneration(unittest.TestCase):
                               ('runstatus',
                                ['ok', 'timeout', 'memout', 'not_applicable',
                                 'crash', 'other'])])
-            self.assertEqual(len(algorithm_runs['data']), 1)
-            self.assertEqual(len(algorithm_runs['data'][0]), 5)
-            self.assertLess(algorithm_runs['data'][0][3], 0.9)
-            self.assertEqual(algorithm_runs['data'][0][4], 'ok')
+            self.assertEqual(len(algorithm_runs['data']), 1, algorithm_runs)
+            self.assertEqual(len(algorithm_runs['data'][0]), 5, algorithm_runs)
+            self.assertLess(algorithm_runs['data'][0][3], 0.9, algorithm_runs)
+            self.assertEqual(algorithm_runs['data'][0][4], 'ok', algorithm_runs)
 
     def tearDown(self):
         for i in range(5):


### PR DESCRIPTION
1. work around a bug in scikit-learn's HistGradientBoosting that causes a lot of the search space to crash
2. when doing meta-learning, only load valid runs on meta-datasets
3. subtract metric from correct value in TestEvaluator when computing the loss