### PR TITLE
Store meta-data creation trajectory in differently

### DIFF
--- a/scripts/02_retrieve_metadata.py
+++ b/scripts/02_retrieve_metadata.py
@@ -29,25 +29,15 @@ def retrieve_matadata(validation_directory, metric, configuration_space,
     configurations_to_ids = dict()
 
     try:
-        possible_experiment_directories = glob.glob(os.path.join(
-            validation_directory, '*', '*'
+        validation_trajectory_files = glob.glob(os.path.join(
+            validation_directory, '*', '*', 'validation_trajectory_*.json'
         ))
     except FileNotFoundError:
         return {}, {}
 
-    for ped in possible_experiment_directories:
+    for validation_trajectory_file in validation_trajectory_files:
         task_name = None
 
-        ped = os.path.join(validation_directory, ped)
-        if not os.path.exists(ped) or not os.path.isdir(ped):
-            continue
-        print("Going through directory %s" % ped)
-
-        validation_trajectory_file = os.path.join(ped, 'smac3-output', 'run_1',
-                                                  'validation_trajectory.json')
-        if not os.path.exists(validation_trajectory_file):
-            print('Could not find output file', validation_trajectory_file)
-            continue
         with open(validation_trajectory_file) as fh:
             validation_trajectory = json.load(fh)
 

--- a/scripts/run_auto-sklearn_for_metadata_generation.py
+++ b/scripts/run_auto-sklearn_for_metadata_generation.py
@@ -43,11 +43,9 @@ X_train, y_train, X_test, y_test, cat, task_type = load_task(task_id)
 
 configuration_output_dir = os.path.join(working_directory, 'configuration',
                                         task_type)
-try:
-    os.makedirs(configuration_output_dir)
-except:
-    pass
+os.makedirs(configuration_output_dir, exist_ok=True)
 tmp_dir = os.path.join(configuration_output_dir, str(task_id), metric)
+os.makedirs(tmp_dir, exist_ok=True)
 
 tempdir = tempfile.mkdtemp()
 autosklearn_directory = os.path.join(tempdir, "dir")
@@ -164,14 +162,12 @@ for i, entry in enumerate(trajectory):
         validated_trajectory.append(list(entry) + [task_id] +
                                     [run_value.additional_info])
     print('Finished validating configuration %d/%d' % (i + 1, len(trajectory)))
+print('Finished to validate configurations')
 
-print('Starting to copy data to configuration directory')
+print('Starting to copy data to configuration directory', flush=True)
 validated_trajectory = [entry[:2] + [entry[2].get_dictionary()] + entry[3:]
                         for entry in validated_trajectory]
-validated_trajectory_file = os.path.join(autosklearn_directory,
-                                         'smac3-output',
-                                         'run_%d' % seed,
-                                         'validation_trajectory.json')
+validated_trajectory_file = os.path.join(tmp_dir, 'validation_trajectory_%d.json' % seed)
 with open(validated_trajectory_file, 'w') as fh:
     json.dump(validated_trajectory, fh, indent=4)
 
@@ -189,7 +185,7 @@ for dirpath, dirnames, filenames in os.walk(autosklearn_directory, topdown=False
 
 
 print('Going to copy the configuration directory')
-shutil.copytree(autosklearn_directory, tmp_dir)
+shutil.copytree(autosklearn_directory, os.path.join(tmp_dir, 'auto-sklearn-output'))
 print('Finished copying the configuration directory')
 try:
     shutil.rmtree(tempdir)

--- a/test/test_scripts/test_metadata_generation.py
+++ b/test/test_scripts/test_metadata_generation.py
@@ -84,17 +84,16 @@ class TestMetadataGeneration(unittest.TestCase):
             expected_output_directory = os.path.join(self.working_directory,
                                                      'configuration',
                                                      task_type,
-                                                     str(task_id), metric)
+                                                     str(task_id), metric,
+                                                     'auto-sklearn-output')
             self.assertTrue(os.path.exists(expected_output_directory),
                             msg=expected_output_directory)
             smac_log = os.path.join(expected_output_directory, 'AutoML(1):%d.log' % task_id)
             with open(smac_log) as fh:
                 smac_output = fh.read()
             self.assertEqual(rval.returncode, 0, msg=str(rval) + '\n' + smac_output)
-            expected_validation_output = os.path.join(expected_output_directory,
-                                                      'smac3-output',
-                                                      'run_1',
-                                                      'validation_trajectory.json')
+            expected_validation_output = os.path.join(expected_output_directory, '..',
+                                                      'validation_trajectory_1.json')
             self.assertTrue(os.path.exists(expected_validation_output))
             trajectory = os.path.join(expected_output_directory,
                                       'smac3-output', 'run_1', 'trajectory.json')
@@ -105,8 +104,8 @@ class TestMetadataGeneration(unittest.TestCase):
                     valid_traj = json.load(fh_validation)
                     print('Validation trajectory:')
                     print(valid_traj)
-                    self.assertGreater(len(traj), 2)
-                    self.assertEqual(len(traj), len(valid_traj))
+                    self.assertGreater(len(traj), 2, msg=str(valid_traj))
+                    self.assertEqual(len(traj), len(valid_traj), msg=str(valid_traj))
                     for entry in valid_traj:
                         if task_type == 'classification':
                             for metric in CLASSIFICATION_METRICS:


### PR DESCRIPTION
On our cluster the meta-data creation fails currently due to the
job freezing when initiating shutil.copytree. This PR changes
the behavior to make meta-data creation also work in case of this
failing as the necessary files are now stored directly in the real
working directory.