### PR TITLE
handling logging error

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -427,7 +427,7 @@ class AutoML(BaseEstimator):
         self._logger.debug('  max_models_on_disc: %s', str(self._max_models_on_disc))
         self._logger.debug('  ensemble_memory_limit: %d', self._ensemble_memory_limit)
         self._logger.debug('  seed: %d', self._seed)
-        self._logger.debug('  ml_memory_limit: %d', self._ml_memory_limit)
+        self._logger.debug('  ml_memory_limit: %s', str(self._ml_memory_limit))
         self._logger.debug('  metadata_directory: %s', self._metadata_directory)
         self._logger.debug('  debug_mode: %s', self._debug_mode)
         self._logger.debug('  include_estimators: %s', str(self._include_estimators))


### PR DESCRIPTION
There is a logging error when `ml_memory_limit` is set to `None`. The logger argument expects integer value for formatting string, but it gets `None`.  The PR is to fix this issue.