### PR TITLE
Improve ensemble selection memory usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ matrix:
   - os: linux
     env: DISTRIB="conda" DOCPUSH="true" PYTHON="3.7" SKIP_TESTS="true"
   - os: linux
-    env: DISTRIB="conda" RUN_FLAKE8="true" SKIP_TESTS="true"
+    env: DISTRIB="conda" PYTHON="3.8" RUN_FLAKE8="true" SKIP_TESTS="true"
   - os: linux
-    env: DISTRIB="conda" RUN_MYPY="true" SKIP_TESTS="true"
+    env: DISTRIB="conda" PYTHON="3.8" RUN_MYPY="true" SKIP_TESTS="true"
   - os: linux
     env: DISTRIB="conda" COVERAGE="true" PYTHON="3.6"
   - os: linux

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -872,7 +872,7 @@ class AutoML(BaseEstimator):
         future = manager.futures.pop()
         dask.distributed.wait([future])  # wait for the ensemble process to finish
         result = future.result()
-        self.ensemble_performance_history, _ = result
+        self.ensemble_performance_history, _, _, _, _ = result
 
         self._load_models()
         self._close_dask_client()

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -872,6 +872,9 @@ class AutoML(BaseEstimator):
         future = manager.futures.pop()
         dask.distributed.wait([future])  # wait for the ensemble process to finish
         result = future.result()
+        if result is None:
+            raise ValueError("Error building the ensemble - please check the log file and command "
+                             "line output for error messages.")
         self.ensemble_performance_history, _, _, _, _ = result
 
         self._load_models()

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -606,10 +606,9 @@ class EnsembleBuilder(object):
                             "Memory Exception -- Unable to further reduce the number of ensemble "
                             "members and can no further limit the number of ensemble members "
                             "loaded per iteration -- please restart Auto-sklearn with a higher "
-                            "value for the argument `memory_limit` (current limit is {} MB). "
+                            "value for the argument `memory_limit` (current limit is %s MB). "
                             "The ensemble builder will keep running to delete files from disk in "
-                            "case this was enabled."
-                            "".format(self.memory_limit)
+                            "case this was enabled.", self.memory_limit
                         )
                         self.ensemble_nbest = 0
                     else:
@@ -618,7 +617,6 @@ class EnsembleBuilder(object):
                             "Memory Exception -- Unable to further reduce the number of ensemble "
                             "members -- Now reducing the number of predictions per call to read "
                             "at most to 1."
-                            "".format(self.memory_limit)
                         )
                 else:
                     if isinstance(self.ensemble_nbest, numbers.Integral):

--- a/autosklearn/ensembles/abstract_ensemble.py
+++ b/autosklearn/ensembles/abstract_ensemble.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 
@@ -40,7 +40,7 @@ class AbstractEnsemble(object):
         pass
 
     @abstractmethod
-    def predict(self, base_models_predictions: np.ndarray) -> np.ndarray:
+    def predict(self, base_models_predictions: Union[np.ndarray, List[np.ndarray]]) -> np.ndarray:
         """Create ensemble predictions from the base model predictions.
 
         Parameters

--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -1,6 +1,6 @@
 import random
 from collections import Counter
-from typing import Any, Dict, List, Tuple, cast, Union
+from typing import Any, Dict, List, Tuple, Union, cast
 
 import numpy as np
 

--- a/autosklearn/ensembles/singlebest_ensemble.py
+++ b/autosklearn/ensembles/singlebest_ensemble.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 import numpy as np
 
@@ -85,7 +85,7 @@ class SingleBest(AbstractEnsemble):
 
         return best_model_identifier
 
-    def predict(self, predictions: np.ndarray) -> np.ndarray:
+    def predict(self, predictions: Union[np.ndarray, List[np.ndarray]]) -> np.ndarray:
         return predictions[0]
 
     def __str__(self) -> str:

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -42,6 +42,7 @@ class AutoSklearnEstimator(BaseEstimator):
         logging_config=None,
         metadata_directory=None,
         metric=None,
+        load_models: bool = True,
     ):
         """
         Parameters
@@ -216,6 +217,9 @@ class AutoSklearnEstimator(BaseEstimator):
             :meth:`autosklearn.metrics.make_scorer`. These are the `Built-in
             Metrics`_.
             If None is provided, a default metric is selected depending on the task.
+            
+        load_models : bool, optional (True)
+            Whether to load the models after fitting Auto-sklearn.
 
         Attributes
         ----------
@@ -257,6 +261,7 @@ class AutoSklearnEstimator(BaseEstimator):
         self.logging_config = logging_config
         self.metadata_directory = metadata_directory
         self._metric = metric
+        self._load_models = load_models
 
         self.automl_ = None  # type: Optional[AutoML]
         # n_jobs after conversion to a number (b/c default is None)
@@ -340,7 +345,7 @@ class AutoSklearnEstimator(BaseEstimator):
             tmp_folder=self.tmp_folder,
             output_folder=self.output_folder,
         )
-        self.automl_.fit(load_models=True, **kwargs)
+        self.automl_.fit(load_models=self._load_models, **kwargs)
 
         return self
 

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -305,6 +305,7 @@ def test_automl_outputs(backend, dask_client):
         'start_time_100',
         'datamanager.pkl',
         'ensemble_read_preds.pkl',
+        'ensemble_read_scores.pkl',
         'runs',
         'ensembles',
     ]

--- a/test/test_ensemble_builder/ensemble_utils.py
+++ b/test/test_ensemble_builder/ensemble_utils.py
@@ -1,6 +1,6 @@
 import os
+import shutil
 import unittest
-
 
 import numpy as np
 
@@ -8,8 +8,6 @@ from autosklearn.metrics import make_scorer
 from autosklearn.ensemble_builder import (
     EnsembleBuilder,
 )
-
-this_directory = os.path.dirname(__file__)
 
 
 def scorer_function(a, b):
@@ -21,22 +19,19 @@ MockMetric = make_scorer('mock', scorer_function)
 
 class BackendMock(object):
 
-    def __init__(self):
+    def __init__(self, target_directory):
         this_directory = os.path.abspath(
             os.path.dirname(__file__)
         )
-        self.temporary_directory = os.path.join(
-            this_directory, 'data',
-        )
-        self.internals_directory = os.path.join(
-            this_directory, 'data', '.auto-sklearn',
-        )
+        shutil.copytree(os.path.join(this_directory, 'data'), os.path.join(target_directory))
+        self.temporary_directory = target_directory
+        self.internals_directory = os.path.join(self.temporary_directory, '.auto-sklearn')
 
     def load_datamanager(self):
         manager = unittest.mock.Mock()
         manager.__reduce__ = lambda self: (unittest.mock.MagicMock, ())
         array = np.load(os.path.join(
-            this_directory, 'data',
+            self.temporary_directory,
             '.auto-sklearn',
             'runs', '0_3_100.0',
             'predictions_test_0_3_100.0.npy'
@@ -60,7 +55,7 @@ class BackendMock(object):
         return
 
     def get_runs_directory(self) -> str:
-        return os.path.join(this_directory, 'data', '.auto-sklearn', 'runs')
+        return os.path.join(self.temporary_directory, '.auto-sklearn', 'runs')
 
     def get_numrun_directory(self, seed: int, num_run: int, budget: float) -> str:
         return os.path.join(self.get_runs_directory(), '%d_%d_%s' % (seed, num_run, budget))

--- a/test/test_ensemble_builder/ensemble_utils.py
+++ b/test/test_ensemble_builder/ensemble_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from autosklearn.metrics import make_scorer
 from autosklearn.ensemble_builder import (
-    EnsembleBuilder,
+    EnsembleBuilder, AbstractEnsemble
 )
 
 
@@ -92,4 +92,11 @@ def compare_read_preds(read_preds1, read_preds2):
 class EnsembleBuilderMemMock(EnsembleBuilder):
 
     def fit_ensemble(self, selected_keys):
+        return True
+
+    def predict(self, set_: str,
+                ensemble: AbstractEnsemble,
+                selected_keys: list,
+                n_preds: int,
+                index_run: int):
         np.ones([10000000, 1000000])

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -519,7 +519,7 @@ def testLimit(ensemble_backend):
                                         seed=0,  # important to find the test files
                                         ensemble_nbest=10,
                                         # small to trigger MemoryException
-                                        memory_limit=10
+                                        memory_limit=100,
                                         )
     ensbuilder.SAVE2DISC = False
 

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import sys
 import time
@@ -36,7 +35,7 @@ def ensemble_backend(request):
 
     try:
         shutil.rmtree(test_dir)
-    except:
+    except:  # noqa E722
         pass
 
     # Make sure the folders we wanna create do not already exist.
@@ -46,7 +45,7 @@ def ensemble_backend(request):
         def session_run_at_end():
             try:
                 shutil.rmtree(test_dir)
-            except:
+            except:  # noqa E722
                 pass
         return session_run_at_end
     request.addfinalizer(get_finalizer(backend))
@@ -269,30 +268,30 @@ def testPerformanceRangeThreshold(ensemble_backend, performance_range_threshold,
 )
 def testPerformanceRangeThresholdMaxBest(ensemble_backend, performance_range_threshold,
                                          ensemble_nbest, exp):
-            ensbuilder = EnsembleBuilder(
-                backend=ensemble_backend,
-                dataset_name="TEST",
-                task_type=BINARY_CLASSIFICATION,
-                metric=roc_auc,
-                seed=0,  # important to find the test files
-                ensemble_nbest=ensemble_nbest,
-                performance_range_threshold=performance_range_threshold,
-                max_models_on_disc=None,
-            )
-            ensbuilder.read_scores = {
-                'A': {'ens_score': 1, 'num_run': 1, 'loaded': -1, "seed": 1},
-                'B': {'ens_score': 2, 'num_run': 2, 'loaded': -1, "seed": 1},
-                'C': {'ens_score': 3, 'num_run': 3, 'loaded': -1, "seed": 1},
-                'D': {'ens_score': 4, 'num_run': 4, 'loaded': -1, "seed": 1},
-                'E': {'ens_score': 5, 'num_run': 5, 'loaded': -1, "seed": 1},
-            }
-            ensbuilder.read_preds = {
-                key: {key_2: True for key_2 in (Y_ENSEMBLE, Y_VALID, Y_TEST)}
-                for key in ensbuilder.read_scores
-            }
-            sel_keys = ensbuilder.get_n_best_preds()
+    ensbuilder = EnsembleBuilder(
+        backend=ensemble_backend,
+        dataset_name="TEST",
+        task_type=BINARY_CLASSIFICATION,
+        metric=roc_auc,
+        seed=0,  # important to find the test files
+        ensemble_nbest=ensemble_nbest,
+        performance_range_threshold=performance_range_threshold,
+        max_models_on_disc=None,
+    )
+    ensbuilder.read_scores = {
+        'A': {'ens_score': 1, 'num_run': 1, 'loaded': -1, "seed": 1},
+        'B': {'ens_score': 2, 'num_run': 2, 'loaded': -1, "seed": 1},
+        'C': {'ens_score': 3, 'num_run': 3, 'loaded': -1, "seed": 1},
+        'D': {'ens_score': 4, 'num_run': 4, 'loaded': -1, "seed": 1},
+        'E': {'ens_score': 5, 'num_run': 5, 'loaded': -1, "seed": 1},
+    }
+    ensbuilder.read_preds = {
+        key: {key_2: True for key_2 in (Y_ENSEMBLE, Y_VALID, Y_TEST)}
+        for key in ensbuilder.read_scores
+    }
+    sel_keys = ensbuilder.get_n_best_preds()
 
-            assert len(sel_keys) == exp
+    assert len(sel_keys) == exp
 
 
 def testFallBackNBest(ensemble_backend):
@@ -534,7 +533,7 @@ def testLimit(ensemble_backend):
     )
 
     with unittest.mock.patch('logging.getLogger') as get_logger_mock, \
-        unittest.mock.patch('logging.config.dictConfig') as _:
+            unittest.mock.patch('logging.config.dictConfig') as _:
         logger_mock = unittest.mock.Mock()
         get_logger_mock.return_value = logger_mock
 

--- a/test/test_evaluation/test_abstract_evaluator.py
+++ b/test/test_evaluation/test_abstract_evaluator.py
@@ -245,7 +245,6 @@ class AbstractEvaluatorTest(unittest.TestCase):
             load_datamanager_mock.return_value = get_multiclass_classification_datamanager()
 
             backend = Backend(context)
-            os.makedirs(backend.get_runs_directory())
 
             ae = AbstractEvaluator(
                 backend=backend,

--- a/test/test_evaluation/test_train_evaluator.py
+++ b/test/test_evaluation/test_train_evaluator.py
@@ -70,9 +70,12 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         backend_mock.get_prediction_output_path.side_effect = dummy_pred_files
         self.backend_mock = backend_mock
 
+        self.tmp_dir = os.path.join(self.ev_path, 'tmp_dir')
+        self.output_dir = os.path.join(self.ev_path, 'out_dir')
+
     def tearDown(self):
         if os.path.exists(self.ev_path):
-            os.rmdir(self.ev_path)
+            shutil.rmtree(self.ev_path)
 
     @unittest.mock.patch('autosklearn.pipeline.classification.SimpleClassificationPipeline')
     def test_holdout(self, pipeline_mock):
@@ -87,11 +90,9 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         pipeline_mock.get_additional_run_info.return_value = None
         pipeline_mock.get_max_iter.return_value = 1
         pipeline_mock.get_current_iter.return_value = 1
-        tmp_dir = os.path.join(os.getcwd(), '.out_test_holdout')
-        output_dir = os.path.join(os.getcwd(), '.tmp_test_holdout')
 
         configuration = unittest.mock.Mock(spec=Configuration)
-        backend_api = backend.create(tmp_dir, output_dir)
+        backend_api = backend.create(self.tmp_dir, self.output_dir)
         backend_api.load_datamanager = lambda: D
         queue_ = multiprocessing.Queue()
 
@@ -155,11 +156,9 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         pipeline_mock.side_effect = lambda **kwargs: pipeline_mock
         pipeline_mock.get_max_iter.return_value = 512
         pipeline_mock.get_current_iter.side_effect = (2, 4, 8, 16, 32, 64, 128, 256, 512)
-        tmp_dir = os.path.join(os.getcwd(), '.tmp_test_iterative_holdout')
-        output_dir = os.path.join(os.getcwd(), '.out_test_iterative_holdout')
 
         configuration = unittest.mock.Mock(spec=Configuration)
-        backend_api = backend.create(tmp_dir, output_dir)
+        backend_api = backend.create(self.tmp_dir, self.output_dir)
         backend_api.load_datamanager = lambda: D
         queue_ = multiprocessing.Queue()
 
@@ -254,11 +253,9 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         pipeline_mock.get_additional_run_info.return_value = None
         pipeline_mock.get_max_iter.return_value = 512
         pipeline_mock.get_current_iter.side_effect = (2, 4, 8, 16, 32, 64, 128, 256, 512)
-        tmp_dir = os.path.join(os.getcwd(), '.tmp_test_iterative_holdout_interuption')
-        output_dir = os.path.join(os.getcwd(), '.out_test_iterative_holdout_interuption')
 
         configuration = unittest.mock.Mock(spec=Configuration)
-        backend_api = backend.create(tmp_dir, output_dir)
+        backend_api = backend.create(self.tmp_dir, self.output_dir)
         backend_api.load_datamanager = lambda: D
         queue_ = multiprocessing.Queue()
 
@@ -325,11 +322,9 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
             lambda X, batch_size=None: np.tile([0.6, 0.4], (len(X), 1))
         pipeline_mock.side_effect = lambda **kwargs: pipeline_mock
         pipeline_mock.get_additional_run_info.return_value = None
-        tmp_dir = os.path.join(os.getcwd(), '.tmp_test_iterative_holdout_not_iterative')
-        output_dir = os.path.join(os.getcwd(), '.out_test_iterative_holdout_not_iterative')
 
         configuration = unittest.mock.Mock(spec=Configuration)
-        backend_api = backend.create(tmp_dir, output_dir)
+        backend_api = backend.create(self.tmp_dir, self.output_dir)
         backend_api.load_datamanager = lambda: D
         queue_ = multiprocessing.Queue()
 
@@ -368,11 +363,9 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
             lambda X, batch_size=None: np.tile([0.6, 0.4], (len(X), 1))
         pipeline_mock.side_effect = lambda **kwargs: pipeline_mock
         pipeline_mock.get_additional_run_info.return_value = None
-        tmp_dir = os.path.join(os.getcwd(), '.tmp_test_cv')
-        output_dir = os.path.join(os.getcwd(), '.out_test_cv')
 
         configuration = unittest.mock.Mock(spec=Configuration)
-        backend_api = backend.create(tmp_dir, output_dir)
+        backend_api = backend.create(self.tmp_dir, self.output_dir)
         backend_api.load_datamanager = lambda: D
         queue_ = multiprocessing.Queue()
 
@@ -421,13 +414,11 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         pipeline_mock.get_additional_run_info.return_value = None
         pipeline_mock.get_max_iter.return_value = 1
         pipeline_mock.get_current_iter.return_value = 1
-        tmp_dir = os.path.join(os.getcwd(), '.tmp_test_partial_cv')
-        output_dir = os.path.join(os.getcwd(), '.out_test_partial_cv')
         D = get_binary_classification_datamanager()
         D.name = 'test'
 
         configuration = unittest.mock.Mock(spec=Configuration)
-        backend_api = backend.create(tmp_dir, output_dir)
+        backend_api = backend.create(self.tmp_dir, self.output_dir)
         backend_api.load_datamanager = lambda: D
         queue_ = multiprocessing.Queue()
 
@@ -484,11 +475,9 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         pipeline_mock.side_effect = lambda **kwargs: pipeline_mock
         pipeline_mock.get_max_iter.return_value = 512
         pipeline_mock.get_current_iter.side_effect = (2, 4, 8, 16, 32, 64, 128, 256, 512)
-        tmp_dir = os.path.join(os.getcwd(), '.tmp_test_iterative_partial_cv')
-        output_dir = os.path.join(os.getcwd(), '.out_test_iterative_partial_cv')
 
         configuration = unittest.mock.Mock(spec=Configuration)
-        backend_api = backend.create(tmp_dir, output_dir)
+        backend_api = backend.create(self.tmp_dir, self.output_dir)
         backend_api.load_datamanager = lambda: D
         queue_ = multiprocessing.Queue()
 

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -183,7 +183,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         self.assertIsInstance(cls, SimpleClassificationPipeline)
 
     def test_multilabel(self):
-        cache = Memory(cachedir=tempfile.gettempdir())
+        cache = Memory(location=tempfile.gettempdir())
         cached_func = cache.cache(
             sklearn.datasets.make_multilabel_classification
         )

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -97,7 +97,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                                   dataset_properties=dataset_properties)
 
     def test_multioutput(self):
-        cache = Memory(cachedir=tempfile.gettempdir())
+        cache = Memory(location=tempfile.gettempdir())
         cached_func = cache.cache(
             sklearn.datasets.make_regression
         )


### PR DESCRIPTION
* separate storage of data inside the ensemble builder into two dictionaries to separately store them on disk (one for scores and one for predictions). If we run over the allocated memory, we can still make use of the stored scores
* do not stop the ensemble builder when the number of models to consider can no longer be reduced so that the ensemble builder can still delete models from the hard drive if necessary.
* avoid unnecessary memory copies during ensemble construction
* improve structure of temporary directories during unit testing