### PR TITLE
Improve logging and remove deadlock

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -292,11 +292,12 @@ class AutoML(BaseEstimator):
         # under the above logging configuration setting
         # We need to specify the logger_name so that received records
         # are treated under the logger_name ROOT logger setting
-        self.stop_logging_server = multiprocessing.Event()
+        context = multiprocessing.get_context('fork')
+        self.stop_logging_server = context.Event()
         self.logger_tcpserver = LogRecordSocketReceiver(logname=logger_name,
                                                         port=self._logger_port,
                                                         event=self.stop_logging_server)
-        self.logging_server = multiprocessing.Process(
+        self.logging_server = context.Process(
             target=self.logger_tcpserver.serve_until_stopped)
         self.logging_server.daemon = False
         self.logging_server.start()
@@ -362,7 +363,6 @@ class AutoML(BaseEstimator):
                                     autosklearn_seed=self._seed,
                                     resampling_strategy=self._resampling_strategy,
                                     initial_num_run=num_run,
-                                    logger=self._logger,
                                     stats=stats,
                                     metric=self._metric,
                                     memory_limit=memory_limit,

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -247,7 +247,11 @@ class AutoML(BaseEstimator):
                 # file was deleted, so the client could not close
                 # the worker properly
                 local_directory=tempfile.gettempdir(),
-            )
+                # Memory is handled by the pynisher, not by the dask worker/nanny
+                memory_limit=0,
+            ),
+            # Heartbeat every 10s
+            heartbeat_interval=10000,
         )
 
     def _close_dask_client(self):
@@ -269,14 +273,18 @@ class AutoML(BaseEstimator):
         # Setup the configuration for the logger
         # This is gonna be honored by the server
         # Which is created below
-        setup_logger(os.path.join(self._backend.temporary_directory,
-                                  '%s.log' % str(logger_name)),
-                     self.logging_config,
-                     )
+        setup_logger(
+            output_file=os.path.join(
+                self._backend.temporary_directory, '%s.log' % str(logger_name)
+            ),
+            logging_config=self.logging_config,
+            output_dir=self._backend.temporary_directory,
+        )
 
         # The desired port might be used, so check this
+        self._logger_port = np.random.randint(10000, 65535)
         while is_port_in_use(self._logger_port):
-            self._logger_port += 1
+            self._logger_port = np.random.randint(10000, 65535)
 
         # As Auto-sklearn works with distributed process,
         # we implement a logger server that can receive tcp
@@ -409,6 +417,9 @@ class AutoML(BaseEstimator):
         only_return_configuration_space: Optional[bool] = False,
         load_models: bool = True,
     ):
+        self._backend.save_start_time(self._seed)
+        self._stopwatch = StopWatch()
+
         # Make sure that input is valid
         # Performs Ordinal one hot encoding to the target
         # both for train and test data
@@ -434,6 +445,12 @@ class AutoML(BaseEstimator):
             raise ValueError('Metric must be instance of '
                              'autosklearn.metrics.Scorer.')
 
+        if dataset_name is None:
+            dataset_name = hash_array_or_matrix(X)
+        # By default try to use the TCP logging port or get a new port
+        self._logger_port = logging.handlers.DEFAULT_TCP_LOGGING_PORT
+        self._logger = self._get_logger(dataset_name)
+
         # If no dask client was provided, we create one, so that we can
         # start a ensemble process in parallel to smbo optimize
         if (
@@ -444,17 +461,8 @@ class AutoML(BaseEstimator):
         else:
             self._is_dask_client_internally_created = False
 
-        if dataset_name is None:
-            dataset_name = hash_array_or_matrix(X)
-
-        self._backend.save_start_time(self._seed)
-        self._stopwatch = StopWatch()
         self._dataset_name = dataset_name
         self._stopwatch.start_task(self._dataset_name)
-
-        # By default try to use the TCP logging port or get a new port
-        self._logger_port = logging.handlers.DEFAULT_TCP_LOGGING_PORT
-        self._logger = self._get_logger(dataset_name)
 
         if feat_type is not None and len(feat_type) != X.shape[1]:
             raise ValueError('Array feat_type does not have same number of '

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -1394,24 +1394,11 @@ class EnsembleBuilder(object):
 
         """
 
-        # Obtain a list of sorted pred keys
-        sorted_keys = self._get_list_of_sorted_preds()
-        sorted_keys = list(map(lambda x: x[0], sorted_keys))
-
-        if len(sorted_keys) <= self.max_resident_models:
-            # Don't waste time if not enough models to delete
-            return
-
-        # The top self.max_resident_models models would be the candidates
-        # Any other low performance model will be deleted
-        # The list is in ascending order of score
-        candidates = sorted_keys[:self.max_resident_models]
-
         # Loop through the files currently in the directory
         for pred_path in self.y_ens_files:
 
             # Do not delete candidates
-            if pred_path in candidates:
+            if pred_path in selected_keys:
                 continue
 
             if pred_path in self._has_been_candidate:

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -567,7 +567,9 @@ class EnsembleBuilder(object):
             context = multiprocessing.get_context('forkserver')
             # Try to copy as many modules into the new context to reduce startup time
             # http://www.bnikolic.co.uk/blog/python/parallelism/2019/11/13/python-forkserver-preload.html
-            context.set_forkserver_preload(list(sys.modules.keys()))
+            # do not copy the logging module as it causes deadlocks!
+            preload_modules = list(filter(lambda key: 'logging' not in key, sys.modules.keys()))
+            context.set_forkserver_preload(preload_modules)
             safe_ensemble_script = pynisher.enforce_limits(
                 wall_time_in_s=int(time_left - time_buffer),
                 mem_in_mb=self.memory_limit,

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -177,6 +177,10 @@ class AutoSklearnEstimator(BaseEstimator):
         dask_client : dask.distributed.Client, optional
             User-created dask client, can be used to start a dask cluster and then
             attach auto-sklearn to it.
+            
+            Auto-sklearn can run into a deadlock if the dask client uses threads for
+            parallelization, it is therefore highly recommended to use dask workers
+            using a single process.
 
         disable_evaluator_output: bool or list, optional (False)
             If True, disable model and prediction output. Cannot be used

--- a/autosklearn/evaluation/__init__.py
+++ b/autosklearn/evaluation/__init__.py
@@ -97,7 +97,7 @@ def _encode_exit_status(exit_status):
 class ExecuteTaFuncWithQueue(AbstractTAFunc):
 
     def __init__(self, backend, autosklearn_seed, resampling_strategy, metric,
-                 logger, cost_for_crash, abort_on_first_run_crash,
+                 cost_for_crash, abort_on_first_run_crash,
                  initial_num_run=1, stats=None,
                  run_obj='quality', par_factor=1, all_scoring_functions=False,
                  output_y_hat_optimization=True, include=None, exclude=None,
@@ -161,7 +161,6 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
         self.disable_file_output = disable_file_output
         self.init_params = init_params
         self.budget_type = budget_type
-        self.logger = logger
 
         if memory_limit is not None:
             memory_limit = int(math.ceil(memory_limit))
@@ -248,7 +247,9 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
         context = multiprocessing.get_context('forkserver')
         # Try to copy as many modules into the new context to reduce startup time
         # http://www.bnikolic.co.uk/blog/python/parallelism/2019/11/13/python-forkserver-preload.html
-        context.set_forkserver_preload(list(sys.modules.keys()))
+        # do not copy the logging module as it causes deadlocks!
+        preload_modules = list(filter(lambda key: 'logging' not in key, sys.modules.keys()))
+        context.set_forkserver_preload(preload_modules)
         queue = context.Queue()
 
         if not (instance_specific is None or instance_specific == '0'):
@@ -442,8 +443,4 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
         runtime = float(obj.wall_clock_time)
 
         autosklearn.evaluation.util.empty_queue(queue)
-        self.logger.debug(
-            'Finished function evaluation. Status: %s, Cost: %f, Runtime: %f, Additional %s',
-            status, cost, runtime, additional_run_info,
-        )
         return status, cost, runtime, additional_run_info

--- a/autosklearn/metalearning/input/aslib_simple.py
+++ b/autosklearn/metalearning/input/aslib_simple.py
@@ -57,8 +57,9 @@ class AlgorithmSelectionProblem(object):
         for expected_file in optional:
             full_path = os.path.join(self.dir_, expected_file)
             if not os.path.isfile(full_path):
-                self.logger.warning(
-                    "Not found: %s (maybe you want to add it)" % (full_path))
+                # self.logger.warning(
+                #     "Not found: %s (maybe you want to add it)" % (full_path))
+                pass
             else:
                 self.found_files.append(full_path)
 

--- a/autosklearn/metalearning/mismbo.py
+++ b/autosklearn/metalearning/mismbo.py
@@ -19,7 +19,7 @@ def suggest_via_metalearning(
 
     task = TASK_TYPES_TO_STRING[task]
 
-    logger.warning(task)
+    logger.info(task)
 
     start = time.time()
     ml = MetaLearningOptimizer(

--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -430,7 +430,6 @@ class AutoMLSMBO(object):
             autosklearn_seed=seed,
             resampling_strategy=self.resampling_strategy,
             initial_num_run=num_run,
-            logger=self.logger,
             include=include,
             exclude=exclude,
             metric=self.metric,

--- a/autosklearn/util/logging.yaml
+++ b/autosklearn/util/logging.yaml
@@ -18,6 +18,12 @@ handlers:
     formatter: simple
     filename: autosklearn.log
 
+  distributed_logfile:
+    class: logging.FileHandler
+    level: DEBUG
+    formatter: simple
+    filename: distributed.log
+
 root:
   level: DEBUG
   handlers: [console, file_handler]
@@ -26,7 +32,6 @@ loggers:
   autosklearn.metalearning:
     level: DEBUG
     handlers: [file_handler]
-    propagate: no
 
   autosklearn.util.backend:
     level: DEBUG
@@ -48,3 +53,7 @@ loggers:
   EnsembleBuilder:
     level: DEBUG
     propagate: no
+
+  distributed:
+    level: DEBUG
+    handlers: [distributed_logfile]

--- a/autosklearn/util/logging_.py
+++ b/autosklearn/util/logging_.py
@@ -5,7 +5,6 @@ import logging.handlers
 import os
 import pickle
 import select
-import socket
 import socketserver
 import struct
 import threading
@@ -48,11 +47,6 @@ def _create_logger(name: str) -> logging.Logger:
 def get_logger(name: str) -> 'PickableLoggerAdapter':
     logger = PickableLoggerAdapter(name)
     return logger
-
-
-def is_port_in_use(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(('localhost', port)) == 0
 
 
 def get_named_client_logger(name: str, host: str = 'localhost',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ pandas>=1.0
 liac-arff
 
 ConfigSpace>=0.4.14,<0.5
-pynisher>=0.6.1
+pynisher>=0.6.2
 pyrfr>=0.7,<0.9
 smac>=0.13.1,<0.14

--- a/scripts/02_retrieve_metadata.py
+++ b/scripts/02_retrieve_metadata.py
@@ -68,7 +68,7 @@ def retrieve_matadata(validation_directory, metric, configuration_space,
                     best_configuration = Configuration(
                         configuration_space=configuration_space, values=config)
                     best_value = score
-                    best_configuration_dir = ped
+                    best_configuration_dir = validation_trajectory_file
                 except Exception as e:
                     print(e)
                     n_broken += 1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -120,30 +120,13 @@ def _dir_fixture(dir_type, request):
 @pytest.fixture(scope="function")
 def dask_client(request):
     """
-    This fixture is meant to be called one per pytest session.
+    Create a dask client with two workers.
 
-    The goal of this function is to create a global client at the start
-    of the testing phase. We can create clients at the start of the
-    session (this case, as above scope is session), module, class or function
-    level.
-
-    The overhead of creating a dask client per class/module/session is something
-    that travis cannot handle, so we rely on the following execution flow:
-
-    1- At the start of the pytest session, session_run_at_beginning fixture is called
-    to create a global client on port 4567.
-    2- Any test that needs a client, would query the global scheduler that allows
-    communication through port 4567.
-    3- At the end of the test, we shutdown any remaining work being done by any worker
-    in the client. This has a maximum 10 seconds timeout. The client object will afterwards
-    be empty and when pytest closes, it can safely delete the object without hanging.
-
-    More info on this file can be found on:
-    https://docs.pytest.org/en/stable/writing_plugins.html#conftest-py-plugins
+    Workers are in subprocesses to not create deadlocks with the pynisher and logging.
     """
     dask.config.set({'distributed.worker.daemon': False})
 
-    client = Client(n_workers=2, threads_per_worker=1, processes=False)
+    client = Client(n_workers=2, threads_per_worker=1, processes=True)
     print("Started Dask client={}\n".format(client))
 
     def get_finalizer(address):
@@ -163,6 +146,9 @@ def dask_client(request):
 def dask_client_single_worker(request):
     """
     Same as above, but only with a single worker.
+
+    Using this might cause deadlocks with the pynisher and the logging module. However,
+    it is used very rarely to avoid this issue as much as possible.
     """
     dask.config.set({'distributed.worker.daemon': False})
 

--- a/test/test_ensemble_builder/ensemble_utils.py
+++ b/test/test_ensemble_builder/ensemble_utils.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import unittest
+import unittest.mock
 
 import numpy as np
 

--- a/test/test_evaluation/test_evaluation.py
+++ b/test/test_evaluation/test_evaluation.py
@@ -87,7 +87,6 @@ class EvaluationTest(unittest.TestCase):
         config.config_id = 198
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=accuracy,
@@ -107,7 +106,6 @@ class EvaluationTest(unittest.TestCase):
         config.config_id = 198
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
@@ -125,7 +123,6 @@ class EvaluationTest(unittest.TestCase):
         config.config_id = 198
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
@@ -145,7 +142,6 @@ class EvaluationTest(unittest.TestCase):
         config.config_id = 198
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=accuracy,
@@ -186,7 +182,6 @@ class EvaluationTest(unittest.TestCase):
         config.config_id = 198
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=log_loss,
@@ -216,7 +211,6 @@ class EvaluationTest(unittest.TestCase):
         m2.wall_clock_time = 30
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=accuracy,
@@ -251,7 +245,6 @@ class EvaluationTest(unittest.TestCase):
         # Test for a succesful run
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=accuracy,
@@ -274,7 +267,6 @@ class EvaluationTest(unittest.TestCase):
         m2.side_effect = side_effect
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=accuracy,
@@ -301,7 +293,6 @@ class EvaluationTest(unittest.TestCase):
         eval_houldout_mock.side_effect = side_effect
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=accuracy,
@@ -325,7 +316,6 @@ class EvaluationTest(unittest.TestCase):
         eval_holdout_mock.side_effect = ValueError
         ta = ExecuteTaFuncWithQueue(backend=BackendMock(), autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=accuracy,
@@ -350,7 +340,6 @@ class EvaluationTest(unittest.TestCase):
         ta = ExecuteTaFuncWithQueue(backend=backend_mock,
                                     autosklearn_seed=1,
                                     resampling_strategy='holdout',
-                                    logger=self.logger,
                                     stats=self.stats,
                                     memory_limit=3072,
                                     metric=accuracy,

--- a/test/test_scripts/test_metadata_generation.py
+++ b/test/test_scripts/test_metadata_generation.py
@@ -54,7 +54,7 @@ class TestMetadataGeneration(unittest.TestCase):
         with open(commands_output_file) as fh:
             cmds = fh.read().split('\n')
             # 6 regression, 11 classification (roc_auc + task 258 is illegal), 1 empty line
-            self.assertEqual(len(cmds), 18)
+            self.assertEqual(len(cmds), 18, msg='\n'.join(cmds))
 
         for task_id, task_type, metric in (
                 (classification_task_id, 'classification', 'accuracy'),

--- a/testcommand.sh
+++ b/testcommand.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-pytest -n 8 --durations=20 --timeout=300 --dist load --timeout-method=thread -v $1
+pytest -n 3 --durations=20 --timeout=300 --dist load --timeout-method=thread -v $1

--- a/testcommand.sh
+++ b/testcommand.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-pytest -n 8 --durations=300 --timeout=300 --dist load --timeout-method=thread -v $1
+pytest -n 8 --durations=20 --timeout=300 --dist load --timeout-method=thread -v $1


### PR DESCRIPTION
* use forkserver context to start processes within the pynisher. This should remove a deadlock due to the use of logging, threading and multiprocessing. As a side-effect, we have to bump the minimal pynisher version to 0.6.2.
* log messages from dask.distributed to a separate logfile
* change a few log message severities or remove the log message alltogether
* randomly try IPs for the logging server inside try/except. Previously, the ID would be determined before starting the server, and therefore the IP could be taken by a different process in the meantime.
* Fix a bug in model deletion (if mem usage too high or max model on disk reached).
* improve output of metadata generation

Failing tests are due to https://github.com/openml/OpenML/issues/1078