### PR TITLE
No daemonic with threads

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -230,8 +230,6 @@ class AutoML(BaseEstimator):
 
     def _create_dask_client(self):
         self._is_dask_client_internally_created = True
-        if self._n_jobs is not None and self._n_jobs > 1:
-            dask.config.set({'distributed.worker.daemon': False})
         self._dask_client = dask.distributed.Client(
             dask.distributed.LocalCluster(
                 n_workers=self._n_jobs,

--- a/examples/60_search/example_parallel_manual_spawning.py
+++ b/examples/60_search/example_parallel_manual_spawning.py
@@ -36,7 +36,14 @@ output_folder = '/tmp/autosklearn_parallel_2_example_out'
 # Dask configuration
 # ==================
 #
-# Auto-sklearn requires dask workers to not run in the daemon setting
+# Auto-sklearn uses threads in Dask to launch memory constrained jobs.
+# This number of threads can be provided directly via the n_jobs argument
+# when creating the AutoSklearnClassifier. Additionally, the user can provide
+# a dask_client argument which can have processes=True.
+# When using processes to True, we need to specify the below setting
+# to allow internally generated processes.
+# Optionally, you can choose to provide a dask client with processes=False
+# and remove the following line.
 dask.config.set({'distributed.worker.daemon': False})
 
 
@@ -76,6 +83,9 @@ def start_python_worker(scheduler_address):
 # one can also start a dask scheduler from the command line), see the
 # `dask cli docs <https://docs.dask.org/en/latest/setup/cli.html>`_ for
 # further information.
+# Please not, that DASK_DISTRIBUTED__WORKER__DAEMON=False is required in this
+# case as dask-worker creates a new process. That is, it is equivalent to the
+# setting described above with dask.distributed.Client with processes=True
 #
 # Again, we need to make sure that we do not start the workers in a daemon
 # mode.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,6 @@ import shutil
 import time
 import unittest.mock
 
-import dask
 from dask.distributed import Client, get_client
 import psutil
 import pytest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -124,9 +124,8 @@ def dask_client(request):
 
     Workers are in subprocesses to not create deadlocks with the pynisher and logging.
     """
-    dask.config.set({'distributed.worker.daemon': False})
 
-    client = Client(n_workers=2, threads_per_worker=1, processes=True)
+    client = Client(n_workers=2, threads_per_worker=1, processes=False)
     print("Started Dask client={}\n".format(client))
 
     def get_finalizer(address):
@@ -150,7 +149,6 @@ def dask_client_single_worker(request):
     Using this might cause deadlocks with the pynisher and the logging module. However,
     it is used very rarely to avoid this issue as much as possible.
     """
-    dask.config.set({'distributed.worker.daemon': False})
 
     client = Client(n_workers=1, threads_per_worker=1, processes=False)
     print("Started Dask client={}\n".format(client))


### PR DESCRIPTION
If moving to thread based dask workers, we do not need to concern ourselves with daemonic workers.

Below line can be removed. Nevertheless, the question remains if for our testing we should keep this, and for this I am talking about:

https://github.com/automl/auto-sklearn/blob/13d1c060d87f83d9ddad6c7a363df5c221995f50/test/conftest.py#L167

Does it makes sense to still test with process==true for the user that wants to provide a process=true dask client?