### PR TITLE
Improvement in Autosklearn Metrics

### DIFF
--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -138,8 +138,7 @@ class EnsembleSelection(AbstractEnsemble):
                         prediction=fant_ensemble_prediction,
                         task_type=self.task_type,
                         metric=self.metric,
-                        fast_mode=True,
-                        scoring_functions=None
+                        scoring_functions=None,
                     )
                 )
                 scores[j] = self.metric._optimum - calculated_score
@@ -189,7 +188,6 @@ class EnsembleSelection(AbstractEnsemble):
                         prediction=ensemble_prediction,
                         task_type=self.task_type,
                         metric=self.metric,
-                        fast_mode=True,
                         scoring_functions=None
                     )
                 )

--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -138,6 +138,7 @@ class EnsembleSelection(AbstractEnsemble):
                         prediction=fant_ensemble_prediction,
                         task_type=self.task_type,
                         metric=self.metric,
+                        fast_mode=True,
                         scoring_functions=None
                     )
                 )
@@ -188,6 +189,7 @@ class EnsembleSelection(AbstractEnsemble):
                         prediction=ensemble_prediction,
                         task_type=self.task_type,
                         metric=self.metric,
+                        fast_mode=True,
                         scoring_functions=None
                     )
                 )

--- a/autosklearn/evaluation/abstract_evaluator.py
+++ b/autosklearn/evaluation/abstract_evaluator.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import VotingClassifier, VotingRegressor
+from sklearn.utils.multiclass import type_of_target
 
 import autosklearn.pipeline.classification
 import autosklearn.pipeline.regression
@@ -422,6 +423,17 @@ class AbstractEvaluator(object):
                 models = None
         else:
             models = None
+
+        # Clean up the predictions via the scorer, so that future
+        # ensemble iterations do not have the need to do so
+        # This include operations like argmax and type change
+        task_type = type_of_target(self.Y_optimization)
+        if 'y_optimization' not in self.disable_file_output and Y_optimization_pred is not None:
+            Y_optimization_pred = self.metric.clean_predictions(Y_optimization_pred, task_type)
+        if 'y_valid' not in self.disable_file_output and Y_valid_pred is not None:
+            Y_valid_pred = self.metric.clean_predictions(Y_valid_pred, task_type)
+        if 'y_test' not in self.disable_file_output and Y_test_pred is not None:
+            Y_test_pred = self.metric.clean_predictions(Y_test_pred, task_type)
 
         self.backend.save_numrun_to_dir(
             seed=self.seed,

--- a/autosklearn/evaluation/abstract_evaluator.py
+++ b/autosklearn/evaluation/abstract_evaluator.py
@@ -20,7 +20,10 @@ from autosklearn.constants import (
 from autosklearn.pipeline.implementations.util import (
     convert_multioutput_multiclass_to_multilabel
 )
-from autosklearn.metrics import calculate_score
+from autosklearn.metrics import (
+    calculate_score,
+    clean_predictions,
+)
 from autosklearn.util.logging_ import get_named_client_logger
 
 from ConfigSpace import Configuration
@@ -429,11 +432,11 @@ class AbstractEvaluator(object):
         # This include operations like argmax and type change
         task_type = type_of_target(self.Y_optimization)
         if 'y_optimization' not in self.disable_file_output and Y_optimization_pred is not None:
-            Y_optimization_pred = self.metric.clean_predictions(Y_optimization_pred, task_type)
+            Y_optimization_pred = clean_predictions(self.metric, Y_optimization_pred, task_type)
         if 'y_valid' not in self.disable_file_output and Y_valid_pred is not None:
-            Y_valid_pred = self.metric.clean_predictions(Y_valid_pred, task_type)
+            Y_valid_pred = clean_predictions(self.metric, Y_valid_pred, task_type)
         if 'y_test' not in self.disable_file_output and Y_test_pred is not None:
-            Y_test_pred = self.metric.clean_predictions(Y_test_pred, task_type)
+            Y_test_pred = clean_predictions(self.metric, Y_test_pred, task_type)
 
         self.backend.save_numrun_to_dir(
             seed=self.seed,

--- a/autosklearn/metrics/__init__.py
+++ b/autosklearn/metrics/__init__.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -26,33 +26,32 @@ class Scorer(object, metaclass=ABCMeta):
         self,
         name: str,
         score_func: Callable,
-        fast_score_func: Optional[Callable],
         optimum: float,
         worst_possible_result: float,
         sign: float,
+        needs_proba: bool,
+        needs_threshold: bool,
+        format_predictions: bool,
         kwargs: Any
     ) -> None:
         self.name = name
         self._kwargs = kwargs
         self._score_func = score_func
-        self._fast_score_func = fast_score_func
         self._optimum = optimum
         self._worst_possible_result = worst_possible_result
         self._sign = sign
+        self.needs_proba = needs_proba
+        self.needs_threshold = needs_threshold
+        self.format_predictions = format_predictions
 
     def __call__(
         self,
         y_true: np.ndarray,
         y_pred: np.ndarray,
         sample_weight: Optional[List[float]] = None,
-        task_type: Optional[str] = None,
-        fast_mode: bool = False,
     ) -> float:
         """Calls the scoring function to evaluate the performance of y_pred against
         y_true.
-
-        Internally, it call self.clean_predictions to format the predictions according
-        to the task at hand.
 
         Parameters
         ----------
@@ -62,73 +61,74 @@ class Scorer(object, metaclass=ABCMeta):
             The predictions of the model being evaluated
         sample_weight: Optional[List[float]]
             Sample weights
-        task_type: Optional[str]
-            The type of task. If not provided, it is computed via type_of_task. It
-            is provided to speed up calculations
-        fast_mode: bool
-            If the Scorer object has a fast implementation of self._score_func in the
-            self._fast_score_func attribute, the later is called to compute the score.
-            This self._fast_score_func assumes also that the data has an appropriate format,
-            so use it only when there is a certainty that such is the case.
         Returns
             score: float
                 The evaluation of how good y_pred is as compared to y_true
         """
-        if task_type is None:
-            task_type = type_of_target(y_true)
 
-        kwargs = self._kwargs.copy()
-        if fast_mode and self._fast_score_func is not None:
-            score_func = self._fast_score_func
-            # Provide the task type to speed up consecutive calculations
-            kwargs['task_type'] = task_type
-        else:
-            score_func = self._score_func
-            y_pred = self.clean_predictions(y_pred, task_type)
+        if self._score_func in (sklearn.metrics.log_loss, LogLoss):
+            self._kwargs.pop('labels', None)
+            n_labels_pred = np.array(y_pred).reshape((len(y_pred), -1)).shape[1]
+            n_labels_test = len(np.unique(y_true))
+            if n_labels_pred != n_labels_test and not type_of_target(y_true
+                                                                     ).startswith('multilabel'):
+                # If the task type is multilabel, the label binarizer inside log loss
+                # has to be fitted with multilabel data, else we run into error:
+                # The object was not fitted with multilabel input.
+                self._kwargs['labels'] = list(range(n_labels_pred))
+
+        if self.format_predictions:
+            y_pred = clean_predictions(self, y_pred, type_of_target(y_true))
 
         if sample_weight is not None:
-            return self._sign * score_func(y_true, y_pred, sample_weight=sample_weight,
-                                           **kwargs)
+            return self._sign * self._score_func(y_true, y_pred, sample_weight=sample_weight,
+                                                 **self._kwargs)
         else:
-            return self._sign * score_func(y_true, y_pred, **kwargs)
-
-    @abstractmethod
-    def clean_predictions(
-        self,
-        y_pred: np.ndarray,
-        task_type: str,
-    ) -> np.ndarray:
-        """Performs prediction cleanup before calling the actual scorer function
-
-        Parameters
-        ----------
-        y_pred : array-like, [n_samples x n_classes]
-            Model predictions
-        task_type: str
-            One of
-            binary
-            multiclass
-            multilable-indicator
-            continuous
-            continuous-multioutput
-
-        Returns
-        -------
-        y_pred : array-like, [n_samples x n_classes]
-            A post processed version of the y_pred
-        """
-        pass
+            return self._sign * self._score_func(y_true, y_pred, **self._kwargs)
 
     def __repr__(self) -> str:
         return self.name
 
 
-class _PredictScorer(Scorer):
-    def clean_predictions(
-        self,
-        y_pred: np.ndarray,
-        task_type: str,
-    ) -> np.ndarray:
+def clean_predictions(
+    metric: Scorer,
+    y_pred: np.ndarray,
+    task_type: str,
+) -> np.ndarray:
+    """Performs prediction cleanup before calling the actual scorer function
+
+    Parameters
+    ----------
+    metric: Scorer
+        A wrapper over a metric calculation function
+    y_pred : array-like, [n_samples x n_classes]
+        Model predictions
+    task_type: str
+        One of
+        binary
+        multiclass
+        multilable-indicator
+        continuous
+        continuous-multioutput
+
+    Returns
+    -------
+    y_pred : array-like, [n_samples x n_classes]
+        A post processed version of the y_pred
+    """
+
+    if metric.needs_threshold:
+        if 'binary' not in task_type and 'multilabel' not in task_type:
+            raise ValueError("{0} format is not supported".format(task_type))
+
+        if task_type.startswith("binary"):
+            if y_pred.ndim > 1:
+                y_pred = y_pred[:, 1]
+        elif isinstance(y_pred, list):
+            y_pred = np.vstack([p[:, -1] for p in y_pred]).T
+    elif metric.needs_proba:
+        pass
+    else:
         if task_type.startswith('binary') and type_of_target(y_pred) == 'continuous' and \
                 len(y_pred.shape) == 1:
             # For a pred scorer, no threshold, nor probability is required
@@ -149,81 +149,7 @@ class _PredictScorer(Scorer):
             pass
         else:
             raise ValueError(task_type)
-        return y_pred
-
-
-class _ProbaScorer(Scorer):
-    def clean_predictions(
-        self,
-        y_pred: np.ndarray,
-        task_type: str,
-    ) -> np.ndarray:
-        return y_pred
-
-    def __call__(
-        self,
-        y_true: np.ndarray,
-        y_pred: np.ndarray,
-        sample_weight: Optional[List[float]] = None,
-        task_type: Optional[str] = None,
-        fast_mode: bool = False,
-    ) -> float:
-        """Evaluate predicted probabilities for X relative to y_true.
-        Parameters
-        ----------
-        y_true : array-like
-            Gold standard target values for X. These must be class labels,
-            not probabilities.
-
-        y_pred : array-like, [n_samples x n_classes]
-            Model predictions
-
-        sample_weight : array-like, optional (default=None)
-            Sample weights.
-
-        task_type: Optional[str]
-            The type of task. If not provided, it is computed via type_of_task. It
-            is provided to speed up calculations
-        fast_mode: bool
-            If the Scorer object has a fast implementation of self._score_func in the
-            self._fast_score_func attribute, the later is called to compute the score.
-            This self._fast_score_func assumes also that the data has an appropriate format,
-
-        Returns
-        -------
-        score : float
-            Score function applied to prediction of estimator on X.
-        """
-        if task_type is None:
-            task_type = type_of_target(y_true)
-        if self._score_func is sklearn.metrics.log_loss:
-            self._kwargs.pop('labels', None)
-            n_labels_pred = np.array(y_pred).reshape((len(y_pred), -1)).shape[1]
-            n_labels_test = len(np.unique(y_true))
-            if n_labels_pred != n_labels_test and not task_type.startswith('multilabel'):
-                # If the task type is multilabel, the label binarizer inside log loss
-                # has to be fitted with multilabel data, else we run into error:
-                # The object was not fitted with multilabel input.
-                self._kwargs['labels'] = list(range(n_labels_pred))
-        return super().__call__(y_true, y_pred, sample_weight,
-                                task_type, fast_mode)
-
-
-class _ThresholdScorer(Scorer):
-    def clean_predictions(
-        self,
-        y_pred: np.ndarray,
-        task_type: str,
-    ) -> np.ndarray:
-        if 'binary' not in task_type and 'multilabel' not in task_type:
-            raise ValueError("{0} format is not supported".format(task_type))
-
-        if task_type.startswith("binary"):
-            if y_pred.ndim > 1:
-                y_pred = y_pred[:, 1]
-        elif isinstance(y_pred, list):
-            y_pred = np.vstack([p[:, -1] for p in y_pred]).T
-        return y_pred
+    return y_pred
 
 
 def make_scorer(
@@ -234,7 +160,7 @@ def make_scorer(
     greater_is_better: bool = True,
     needs_proba: bool = False,
     needs_threshold: bool = False,
-    fast_score_func: Optional[Callable] = None,
+    needs_format_predictions: bool = True,
     **kwargs: Any
 ) -> Scorer:
     """Make a scorer from a performance metric or loss function.
@@ -265,9 +191,12 @@ def make_scorer(
         Whether score_func takes a continuous decision certainty.
         This only works for binary classification.
 
-    score_func : Optional[Callable]
-        Fast implementation of the Score function (or loss function) with signature
-        ``score_func(y, y_pred, **kwargs)``.
+    needs_format_predictions: boolean, default = True,
+        By default, Auto-sklearn predictions require pre-processing before a score can
+        be calculated. For example, when doing binary predictions, and the later is a 2D
+        array, it likely means that argmax will provide the actual prediction. A scorer
+        can set this flag to false to accelerate calculation under the assumption that
+        the predictions have been format already
 
     **kwargs : additional arguments
         Additional parameters to be passed to score_func.
@@ -278,15 +207,9 @@ def make_scorer(
         Callable object that returns a scalar score; greater is better.
     """
     sign = 1 if greater_is_better else -1
-    if needs_proba:
-        return _ProbaScorer(
-            name, score_func, fast_score_func, optimum, worst_possible_result, sign, kwargs)
-    elif needs_threshold:
-        return _ThresholdScorer(
-            name, score_func, fast_score_func, optimum, worst_possible_result, sign, kwargs)
-    else:
-        return _PredictScorer(
-            name, score_func, fast_score_func, optimum, worst_possible_result, sign, kwargs)
+    return Scorer(
+        name, score_func, optimum, worst_possible_result, sign,
+        needs_proba, needs_threshold, needs_format_predictions, kwargs)
 
 
 # Standard regression scores
@@ -323,17 +246,16 @@ r2 = make_scorer('r2',
 # Standard Classification Scores
 accuracy = make_scorer('accuracy',
                        sklearn.metrics.accuracy_score,
-                       fast_score_func=Accuracy)
+                       )
 balanced_accuracy = make_scorer('balanced_accuracy',
                                 sklearn.metrics.balanced_accuracy_score,
-                                fast_score_func=BalancedAccuracy)
+                                )
 f1 = make_scorer('f1',
                  sklearn.metrics.f1_score)
 
 # Score functions that need decision values
 roc_auc = make_scorer('roc_auc',
                       sklearn.metrics.roc_auc_score,
-                      fast_score_func=ROCAUC,
                       greater_is_better=True,
                       needs_threshold=True,
                       )
@@ -348,13 +270,22 @@ recall = make_scorer('recall',
 # Score function for probabilistic classification
 log_loss = make_scorer('log_loss',
                        sklearn.metrics.log_loss,
-                       fast_score_func=LogLoss,
                        optimum=0,
                        worst_possible_result=MAXINT,
                        greater_is_better=False,
                        needs_proba=True)
 # TODO what about mathews correlation coefficient etc?
 
+CUSTOM_METRICS = {
+    'accuracy': make_scorer('accuracy', Accuracy, needs_format_predictions=False),
+    'balanced_accuracy': make_scorer('balanced_accuracy', BalancedAccuracy,
+                                     needs_format_predictions=False),
+    'roc_auc': make_scorer('roc_auc', ROCAUC, needs_threshold=True,
+                           needs_format_predictions=False),
+    'log_loss': make_scorer('log_loss', LogLoss, optimum=0, worst_possible_result=MAXINT,
+                            greater_is_better=False, needs_proba=True,
+                            needs_format_predictions=False)
+}
 
 REGRESSION_METRICS = dict()
 for scorer in [mean_absolute_error, mean_squared_error, root_mean_squared_error,
@@ -387,37 +318,27 @@ def calculate_score(
     task_type: int,
     metric: Scorer,
     scoring_functions: Optional[List[Scorer]] = None,
-    fast_mode: bool = False,
 ) -> Union[float, Dict[str, float]]:
     if task_type not in TASK_TYPES:
         raise NotImplementedError(task_type)
 
     if scoring_functions:
         score_dict = dict()
-        if task_type in REGRESSION_TASKS:
-            # TODO put this into the regression metric itself
-            cprediction = sanitize_array(prediction)
-            for metric_ in scoring_functions:
+        # TODO put this into the regression metric itself
+        # TODO maybe annotate metrics to define which cases they can
+        # handle?
+        for metric_ in scoring_functions:
 
-                try:
-                    score_dict[metric_.name] = metric_(solution, cprediction)
-                except ValueError as e:
+            try:
+                score_dict[metric_.name] = get_metric_score(metric_, prediction, solution,
+                                                            task_type)
+            except ValueError as e:
+                if task_type in REGRESSION_TASKS:
                     print(e, e.args[0])
                     if e.args[0] == "Mean Squared Logarithmic Error cannot be used when " \
-                                    "targets contain negative values.":
+                            "targets contain negative values.":
                         continue
-                    else:
-                        raise e
-
-        else:
-            for metric_ in scoring_functions:
-
-                # TODO maybe annotate metrics to define which cases they can
-                # handle?
-
-                try:
-                    score_dict[metric_.name] = metric_(solution, prediction)
-                except ValueError as e:
+                else:
                     if e.args[0] == 'multiclass format is not supported':
                         continue
                     elif e.args[0] == "Samplewise metrics are not available "\
@@ -431,12 +352,11 @@ def calculate_score(
                         raise e
 
         if metric.name not in score_dict.keys():
-            score_dict[metric.name] = get_metric_score(metric, prediction, solution, task_type,
-                                                       fast_mode)
+            score_dict[metric.name] = get_metric_score(metric, prediction, solution, task_type)
         return score_dict
 
     else:
-        return get_metric_score(metric, prediction, solution, task_type, fast_mode)
+        return get_metric_score(metric, prediction, solution, task_type)
 
 
 def get_metric_score(
@@ -444,14 +364,17 @@ def get_metric_score(
         prediction: np.ndarray,
         solution: np.ndarray,
         task_type: int,
-        fast_mode: bool,
 ) -> float:
+    if metric_._score_func in CUSTOM_METRICS:
+        # Calculating type of target has a noticeable duration
+        # due to internal castings. Custom metrics support taking the pre-computed
+        # type
+        metric_._kwargs['task_type'] = TASK_TYPES_TO_STRING[task_type]
+
     if task_type in REGRESSION_TASKS:
         # TODO put this into the regression metric itself
         cprediction = sanitize_array(prediction)
-        score = metric_(solution, cprediction, fast_mode=fast_mode,
-                        task_type=TASK_TYPES_TO_STRING[task_type])
+        score = metric_(solution, cprediction)
     else:
-        score = metric_(solution, prediction, fast_mode=fast_mode,
-                        task_type=TASK_TYPES_TO_STRING[task_type])
+        score = metric_(solution, prediction)
     return score

--- a/autosklearn/metrics/__init__.py
+++ b/autosklearn/metrics/__init__.py
@@ -9,7 +9,13 @@ from sklearn.utils.multiclass import type_of_target
 
 from smac.utils.constants import MAXINT
 
-from autosklearn.constants import REGRESSION_TASKS, TASK_TYPES
+from autosklearn.constants import REGRESSION_TASKS, TASK_TYPES, TASK_TYPES_TO_STRING
+from autosklearn.metrics.custom_metrics import (
+    Accuracy,
+    BalancedAccuracy,
+    LogLoss,
+    ROCAUC,
+)
 
 
 from .util import sanitize_array
@@ -20,6 +26,7 @@ class Scorer(object, metaclass=ABCMeta):
         self,
         name: str,
         score_func: Callable,
+        fast_score_func: Optional[Callable],
         optimum: float,
         worst_possible_result: float,
         sign: float,
@@ -28,17 +35,88 @@ class Scorer(object, metaclass=ABCMeta):
         self.name = name
         self._kwargs = kwargs
         self._score_func = score_func
+        self._fast_score_func = fast_score_func
         self._optimum = optimum
         self._worst_possible_result = worst_possible_result
         self._sign = sign
 
-    @abstractmethod
     def __call__(
         self,
         y_true: np.ndarray,
         y_pred: np.ndarray,
-        sample_weight: Optional[List[float]] = None
+        sample_weight: Optional[List[float]] = None,
+        task_type: Optional[str] = None,
+        fast_mode: bool = False,
     ) -> float:
+        """Calls the scoring function to evaluate the performance of y_pred against
+        y_true.
+
+        Internally, it call self.clean_predictions to format the predictions according
+        to the task at hand.
+
+        Parameters
+        ----------
+        y_true: np.ndarray
+            The golden truth used to evaluate the predictions
+        y_pred: np.ndarray
+            The predictions of the model being evaluated
+        sample_weight: Optional[List[float]]
+            Sample weights
+        task_type: Optional[str]
+            The type of task. If not provided, it is computed via type_of_task. It
+            is provided to speed up calculations
+        fast_mode: bool
+            If the Scorer object has a fast implementation of self._score_func in the
+            self._fast_score_func attribute, the later is called to compute the score.
+            This self._fast_score_func assumes also that the data has an appropriate format,
+            so use it only when there is a certainty that such is the case.
+        Returns
+            score: float
+                The evaluation of how good y_pred is as compared to y_true
+        """
+        if task_type is None:
+            task_type = type_of_target(y_true)
+
+        kwargs = self._kwargs.copy()
+        if fast_mode and self._fast_score_func is not None:
+            score_func = self._fast_score_func
+            # Provide the task type to speed up consecutive calculations
+            kwargs['task_type'] = task_type
+        else:
+            score_func = self._score_func
+            y_pred = self.clean_predictions(y_pred, task_type)
+
+        if sample_weight is not None:
+            return self._sign * score_func(y_true, y_pred, sample_weight=sample_weight,
+                                           **kwargs)
+        else:
+            return self._sign * score_func(y_true, y_pred, **kwargs)
+
+    @abstractmethod
+    def clean_predictions(
+        self,
+        y_pred: np.ndarray,
+        task_type: str,
+    ) -> np.ndarray:
+        """Performs prediction cleanup before calling the actual scorer function
+
+        Parameters
+        ----------
+        y_pred : array-like, [n_samples x n_classes]
+            Model predictions
+        task_type: str
+            One of
+            binary
+            multiclass
+            multilable-indicator
+            continuous
+            continuous-multioutput
+
+        Returns
+        -------
+        y_pred : array-like, [n_samples x n_classes]
+            A post processed version of the y_pred
+        """
         pass
 
     def __repr__(self) -> str:
@@ -46,67 +124,49 @@ class Scorer(object, metaclass=ABCMeta):
 
 
 class _PredictScorer(Scorer):
-    def __call__(
+    def clean_predictions(
         self,
-        y_true: np.ndarray,
         y_pred: np.ndarray,
-        sample_weight: Optional[List[float]] = None
-    ) -> float:
-        """Evaluate predicted target values for X relative to y_true.
-
-        Parameters
-        ----------
-        y_true : array-like
-            Gold standard target values for X.
-
-        y_pred : array-like, [n_samples x n_classes]
-            Model predictions
-
-        sample_weight : array-like, optional (default=None)
-            Sample weights.
-
-        Returns
-        -------
-        score : float
-            Score function applied to prediction of estimator on X.
-        """
-        type_true = type_of_target(y_true)
-        if type_true == 'binary' and type_of_target(y_pred) == 'continuous' and \
+        task_type: str,
+    ) -> np.ndarray:
+        if task_type.startswith('binary') and type_of_target(y_pred) == 'continuous' and \
                 len(y_pred.shape) == 1:
             # For a pred scorer, no threshold, nor probability is required
             # If y_true is binary, and y_pred is continuous
             # it means that a rounding is necessary to obtain the binary class
             y_pred = np.around(y_pred, decimals=0)
         elif len(y_pred.shape) == 1 or y_pred.shape[1] == 1 or \
-                type_true == 'continuous':
+                task_type.startswith('continuous'):
             # must be regression, all other task types would return at least
             # two probabilities
             pass
-        elif type_true in ['binary', 'multiclass']:
+        elif task_type.startswith('binary') or task_type.startswith('multiclass'):
             y_pred = np.argmax(y_pred, axis=1)
-        elif type_true == 'multilabel-indicator':
+        elif task_type.startswith('multilabel'):
             y_pred[y_pred > 0.5] = 1.0
             y_pred[y_pred <= 0.5] = 0.0
-        elif type_true == 'continuous-multioutput':
+        elif task_type.startswith('continuous-multioutput'):
             pass
         else:
-            raise ValueError(type_true)
-
-        if sample_weight is not None:
-            return self._sign * self._score_func(y_true, y_pred,
-                                                 sample_weight=sample_weight,
-                                                 **self._kwargs)
-        else:
-            return self._sign * self._score_func(y_true, y_pred,
-                                                 **self._kwargs)
+            raise ValueError(task_type)
+        return y_pred
 
 
 class _ProbaScorer(Scorer):
+    def clean_predictions(
+        self,
+        y_pred: np.ndarray,
+        task_type: str,
+    ) -> np.ndarray:
+        return y_pred
+
     def __call__(
         self,
         y_true: np.ndarray,
         y_pred: np.ndarray,
-        sample_weight: Optional[List[float]] = None
+        sample_weight: Optional[List[float]] = None,
+        task_type: Optional[str] = None,
+        fast_mode: bool = False,
     ) -> float:
         """Evaluate predicted probabilities for X relative to y_true.
         Parameters
@@ -121,76 +181,49 @@ class _ProbaScorer(Scorer):
         sample_weight : array-like, optional (default=None)
             Sample weights.
 
+        task_type: Optional[str]
+            The type of task. If not provided, it is computed via type_of_task. It
+            is provided to speed up calculations
+        fast_mode: bool
+            If the Scorer object has a fast implementation of self._score_func in the
+            self._fast_score_func attribute, the later is called to compute the score.
+            This self._fast_score_func assumes also that the data has an appropriate format,
+
         Returns
         -------
         score : float
             Score function applied to prediction of estimator on X.
         """
-
+        if task_type is None:
+            task_type = type_of_target(y_true)
         if self._score_func is sklearn.metrics.log_loss:
+            self._kwargs.pop('labels', None)
             n_labels_pred = np.array(y_pred).reshape((len(y_pred), -1)).shape[1]
             n_labels_test = len(np.unique(y_true))
-            if n_labels_pred != n_labels_test:
-                labels = list(range(n_labels_pred))
-                if sample_weight is not None:
-                    return self._sign * self._score_func(y_true, y_pred,
-                                                         sample_weight=sample_weight,
-                                                         labels=labels,
-                                                         **self._kwargs)
-                else:
-                    return self._sign * self._score_func(y_true, y_pred,
-                                                         labels=labels, **self._kwargs)
-
-        if sample_weight is not None:
-            return self._sign * self._score_func(y_true, y_pred,
-                                                 sample_weight=sample_weight,
-                                                 **self._kwargs)
-        else:
-            return self._sign * self._score_func(y_true, y_pred,
-                                                 **self._kwargs)
+            if n_labels_pred != n_labels_test and not task_type.startswith('multilabel'):
+                # If the task type is multilabel, the label binarizer inside log loss
+                # has to be fitted with multilabel data, else we run into error:
+                # The object was not fitted with multilabel input.
+                self._kwargs['labels'] = list(range(n_labels_pred))
+        return super().__call__(y_true, y_pred, sample_weight,
+                                task_type, fast_mode)
 
 
 class _ThresholdScorer(Scorer):
-    def __call__(
+    def clean_predictions(
         self,
-        y_true: np.ndarray,
         y_pred: np.ndarray,
-        sample_weight: Optional[List[float]] = None
-    ) -> float:
-        """Evaluate decision function output for X relative to y_true.
-        Parameters
-        ----------
-        y_true : array-like
-            Gold standard target values for X. These must be class labels,
-            not probabilities.
+        task_type: str,
+    ) -> np.ndarray:
+        if 'binary' not in task_type and 'multilabel' not in task_type:
+            raise ValueError("{0} format is not supported".format(task_type))
 
-        y_pred : array-like, [n_samples x n_classes]
-            Model predictions
-
-        sample_weight : array-like, optional (default=None)
-            Sample weights.
-
-        Returns
-        -------
-        score : float
-            Score function applied to prediction of estimator on X.
-        """
-        y_type = type_of_target(y_true)
-        if y_type not in ("binary", "multilabel-indicator"):
-            raise ValueError("{0} format is not supported".format(y_type))
-
-        if y_type == "binary":
+        if task_type.startswith("binary"):
             if y_pred.ndim > 1:
                 y_pred = y_pred[:, 1]
         elif isinstance(y_pred, list):
             y_pred = np.vstack([p[:, -1] for p in y_pred]).T
-
-        if sample_weight is not None:
-            return self._sign * self._score_func(y_true, y_pred,
-                                                 sample_weight=sample_weight,
-                                                 **self._kwargs)
-        else:
-            return self._sign * self._score_func(y_true, y_pred, **self._kwargs)
+        return y_pred
 
 
 def make_scorer(
@@ -201,6 +234,7 @@ def make_scorer(
     greater_is_better: bool = True,
     needs_proba: bool = False,
     needs_threshold: bool = False,
+    fast_score_func: Optional[Callable] = None,
     **kwargs: Any
 ) -> Scorer:
     """Make a scorer from a performance metric or loss function.
@@ -231,6 +265,10 @@ def make_scorer(
         Whether score_func takes a continuous decision certainty.
         This only works for binary classification.
 
+    score_func : Optional[Callable]
+        Fast implementation of the Score function (or loss function) with signature
+        ``score_func(y, y_pred, **kwargs)``.
+
     **kwargs : additional arguments
         Additional parameters to be passed to score_func.
 
@@ -241,11 +279,14 @@ def make_scorer(
     """
     sign = 1 if greater_is_better else -1
     if needs_proba:
-        return _ProbaScorer(name, score_func, optimum, worst_possible_result, sign, kwargs)
+        return _ProbaScorer(
+            name, score_func, fast_score_func, optimum, worst_possible_result, sign, kwargs)
     elif needs_threshold:
-        return _ThresholdScorer(name, score_func, optimum, worst_possible_result, sign, kwargs)
+        return _ThresholdScorer(
+            name, score_func, fast_score_func, optimum, worst_possible_result, sign, kwargs)
     else:
-        return _PredictScorer(name, score_func, optimum, worst_possible_result, sign, kwargs)
+        return _PredictScorer(
+            name, score_func, fast_score_func, optimum, worst_possible_result, sign, kwargs)
 
 
 # Standard regression scores
@@ -281,17 +322,21 @@ r2 = make_scorer('r2',
 
 # Standard Classification Scores
 accuracy = make_scorer('accuracy',
-                       sklearn.metrics.accuracy_score)
+                       sklearn.metrics.accuracy_score,
+                       fast_score_func=Accuracy)
 balanced_accuracy = make_scorer('balanced_accuracy',
-                                sklearn.metrics.balanced_accuracy_score)
+                                sklearn.metrics.balanced_accuracy_score,
+                                fast_score_func=BalancedAccuracy)
 f1 = make_scorer('f1',
                  sklearn.metrics.f1_score)
 
 # Score functions that need decision values
 roc_auc = make_scorer('roc_auc',
                       sklearn.metrics.roc_auc_score,
+                      fast_score_func=ROCAUC,
                       greater_is_better=True,
-                      needs_threshold=True)
+                      needs_threshold=True,
+                      )
 average_precision = make_scorer('average_precision',
                                 sklearn.metrics.average_precision_score,
                                 needs_threshold=True)
@@ -303,6 +348,7 @@ recall = make_scorer('recall',
 # Score function for probabilistic classification
 log_loss = make_scorer('log_loss',
                        sklearn.metrics.log_loss,
+                       fast_score_func=LogLoss,
                        optimum=0,
                        worst_possible_result=MAXINT,
                        greater_is_better=False,
@@ -340,7 +386,8 @@ def calculate_score(
     prediction: np.ndarray,
     task_type: int,
     metric: Scorer,
-    scoring_functions: Optional[List[Scorer]] = None
+    scoring_functions: Optional[List[Scorer]] = None,
+    fast_mode: bool = False,
 ) -> Union[float, Dict[str, float]]:
     if task_type not in TASK_TYPES:
         raise NotImplementedError(task_type)
@@ -384,23 +431,27 @@ def calculate_score(
                         raise e
 
         if metric.name not in score_dict.keys():
-            score_dict[metric.name] = get_metric_score(metric, prediction, solution, task_type)
+            score_dict[metric.name] = get_metric_score(metric, prediction, solution, task_type,
+                                                       fast_mode)
         return score_dict
 
     else:
-        return get_metric_score(metric, prediction, solution, task_type)
+        return get_metric_score(metric, prediction, solution, task_type, fast_mode)
 
 
 def get_metric_score(
         metric_: Scorer,
         prediction: np.ndarray,
         solution: np.ndarray,
-        task_type: int
+        task_type: int,
+        fast_mode: bool,
 ) -> float:
     if task_type in REGRESSION_TASKS:
         # TODO put this into the regression metric itself
         cprediction = sanitize_array(prediction)
-        score = metric_(solution, cprediction)
+        score = metric_(solution, cprediction, fast_mode=fast_mode,
+                        task_type=TASK_TYPES_TO_STRING[task_type])
     else:
-        score = metric_(solution, prediction)
+        score = metric_(solution, prediction, fast_mode=fast_mode,
+                        task_type=TASK_TYPES_TO_STRING[task_type])
     return score

--- a/autosklearn/metrics/custom_metrics.py
+++ b/autosklearn/metrics/custom_metrics.py
@@ -1,0 +1,435 @@
+import typing
+import warnings
+
+import numpy as np
+
+import scipy.sparse as sp
+from scipy.sparse import coo_matrix
+
+from sklearn.metrics import auc, roc_curve
+from sklearn.utils.multiclass import type_of_target, unique_labels
+from sklearn.utils.validation import column_or_1d
+
+
+def confusion_matrix(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    labels: typing.Optional[typing.List] = None,
+    sample_weight: typing.Optional[typing.List] = None,
+    normalize: typing.Optional[str] = None
+) -> np.ndarray:
+    """
+    Compute confusion matrix to evaluate the accuracy of a classification
+
+    Parameters
+    ----------
+    y_true: np.ndarray
+        An array-like list of ground truth values
+    y_pred: np.ndarray,
+        An array-like list of model predictions
+    labels: typing.Optional[typing.List]
+        List of labels to index the matrix
+    sample_weight: typing.Optional[typing.List]
+        Sample weights to change the score weight while reducing via average
+    normalize: typing.Optional[str]
+        Normalizes confusion matrix over the true (rows)
+
+    Returns
+    -------
+    Confusion Matrix
+    """
+
+    if labels is None:
+        n_labels = unique_labels(y_true, y_pred).size
+    else:
+        if np.all([label not in y_true for label in labels]):
+            raise ValueError("At least one label specified must be in y_true")
+        n_labels = np.asarray(labels).size
+
+    if sample_weight is None:
+        local_sample_weight = np.ones(y_true.shape[0], dtype=np.int64)
+    elif np.shape(sample_weight)[0] != np.shape(y_true)[0]:
+        local_sample_weight = np.ones(y_true.shape[0], dtype=np.int64)
+    else:
+        local_sample_weight = sample_weight
+
+    # # intersect y_pred, y_true with labels, eliminate items not in labels
+    ind = np.logical_and(y_pred < n_labels, y_true < n_labels)
+    y_pred = y_pred[ind]
+    y_true = y_true[ind]
+    # also eliminate weights of eliminated items
+    local_sample_weight = local_sample_weight[ind]
+
+    cm = coo_matrix((local_sample_weight, (y_true, y_pred)),
+                    shape=(n_labels, n_labels), dtype=np.int64,
+                    ).toarray()
+
+    with np.errstate(all='ignore'):
+        if normalize == 'true':
+            cm = cm / cm.sum(axis=1, keepdims=True)
+        elif normalize == 'pred':
+            cm = cm / cm.sum(axis=0, keepdims=True)
+        elif normalize == 'all':
+            cm = cm / cm.sum()
+        cm = np.nan_to_num(cm)
+
+    return cm
+
+
+def BalancedAccuracy(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    sample_weight: typing.Optional[typing.List] = None,
+    adjusted: bool = False,
+    task_type: typing.Optional[str] = None,
+) -> float:
+    """
+    Computes the balanced accuracy
+    This version honors the sklearn implementation without formatting checks to
+    speed up computations.
+
+    Parameters
+    ----------
+    y_true: np.ndarray
+        An array-like list of ground truth values
+    y_pred: np.ndarray,
+        An array-like list of model predictions
+    sample_weight: typing.Optional[typing.List]
+        Sample weights to change the score weight while reducing via average
+    adjusted: bool
+        When true, the result is adjusted for chance, so that random performance
+        would score 0, and perfect performance scores 1.
+    task_type: str
+        The task type at hand, as defined by type_of_target on the ground truth.
+        It should be one of binary, multiclass or multilabel-indicator
+
+    Returns
+    -------
+    The evaluation of the predictions against the ground truth
+    """
+    y_true = y_true.astype(np.int64)
+    C = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        per_class = np.diag(C) / C.sum(axis=1)
+    if np.any(np.isnan(per_class)):
+        warnings.warn('y_pred contains classes not in y_true')
+        per_class = per_class[~np.isnan(per_class)]
+    score = np.mean(per_class)
+    if adjusted:
+        n_classes = len(per_class)
+        chance = 1 / n_classes
+        score -= chance
+        score /= 1 - chance
+    return score
+
+
+def Accuracy(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    normalize: bool = True,
+    sample_weight: typing.Optional[typing.List] = None,
+    task_type: typing.Optional[str] = None,
+) -> float:
+    """
+    Computes the accuracy score
+    This version honors the sklearn implementation without formatting checks to
+    speed up computations.
+
+    Parameters
+    ----------
+    y_true: np.ndarray
+        An array-like list of ground truth values
+    y_pred: np.ndarray,
+        An array-like list of model predictions
+    sample_weight: typing.Optional[typing.List]
+        Sample weights to change the score weight while reducing via average
+    normalize: bool
+        If False, return the number of correctly classified samples.
+        Otherwise, return the fraction of correctly classified samples.
+    task_type: str
+        The task type at hand, as defined by type_of_target on the ground truth.
+        It should be one of binary, multiclass or multilabel-indicator
+
+    Returns
+    -------
+    The evaluation of the predictions against the ground truth
+    """
+    if task_type is None:
+        task_type = type_of_target(y_true)
+
+    if task_type.startswith('multilabel'):
+        differing_labels = np.count_nonzero(y_true - y_pred, axis=1)
+        score = differing_labels == 0
+    else:
+        score = y_true == y_pred
+
+    if normalize:
+        return np.average(score, weights=sample_weight)
+    elif sample_weight is not None:
+        return np.dot(score, sample_weight)
+    else:
+        return score.sum()
+
+
+def label_binarize(
+    y: np.ndarray,
+    classes: np.ndarray,
+    task_type: str,
+    neg_label: int = 0,
+    pos_label: int = 1
+) -> np.ndarray:
+    """
+    Binarize labels in a one-vs-all fashion
+
+    Parameters
+    ----------
+    y: np.ndarray
+        An array-like list of elements to encode
+    classes: np.ndarray
+        A sequence of unique labels for each class
+    task_type: str
+        The task type at hand, as defined by type_of_target on the ground truth.
+        It should be one of binary, multiclass or multilabel-indicator
+    neg_label: int
+        Value with which negative labels must be encoded.
+    pos_label: int
+        Value with which positive labels must be encoded.
+
+    Returns
+    -------
+        An encoded version of y
+    """
+    if neg_label >= pos_label:
+        raise ValueError("neg_label={0} must be strictly less than "
+                         "pos_label={1}.".format(neg_label, pos_label))
+
+    # To account for pos_label == 0 in the dense case
+    pos_switch = pos_label == 0
+    if pos_switch:
+        pos_label = -neg_label
+
+    if 'multioutput' in task_type:
+        raise ValueError("Multioutput target data is not supported with label "
+                         "binarization")
+    if task_type == 'unknown':
+        raise ValueError("The type of target data is not known")
+
+    n_samples = y.shape[0] if sp.issparse(y) else len(y)
+    n_classes = len(classes)
+    classes = np.asarray(classes)
+
+    if task_type.startswith('binary'):
+        if n_classes == 1:
+            Y = np.zeros((len(y), 1), dtype=np.int)
+            Y += neg_label
+            return Y
+        elif len(classes) >= 3:
+            task_type = "multiclass"
+
+    sorted_class = np.sort(classes)
+    if task_type.startswith('multilabel'):
+        y_n_classes = y.shape[1] if hasattr(y, 'shape') else len(y[0])
+        if classes.size != y_n_classes:
+            raise ValueError("classes {0} mismatch with the labels {1}"
+                             " found in the data"
+                             .format(classes, unique_labels(y)))
+
+    if task_type.startswith('binary') or task_type.startswith('multiclass'):
+        y = column_or_1d(y)
+
+        # pick out the known labels from y
+        y_in_classes = np.in1d(y, classes)
+        y_seen = y[y_in_classes]
+        indices = np.searchsorted(sorted_class, y_seen)
+        indptr = np.hstack((0, np.cumsum(y_in_classes)))
+
+        data = np.empty_like(indices)
+        data.fill(pos_label)
+        Y = sp.csr_matrix((data, indices, indptr),
+                          shape=(n_samples, n_classes))
+    elif task_type.startswith('multilabel'):
+        Y = sp.csr_matrix(y)
+        if pos_label != 1:
+            data = np.empty_like(Y.data)
+            data.fill(pos_label)
+            Y.data = data
+    else:
+        raise ValueError("%s target data is not supported with label "
+                         "binarization" % task_type)
+
+    Y = Y.toarray()
+    Y = Y.astype(int, copy=False)
+
+    if neg_label != 0:
+        Y[Y == 0] = neg_label
+
+    if pos_switch:
+        Y[Y == pos_label] = 0
+
+    # preserve label ordering
+    if np.any(classes != sorted_class):
+        indices = np.searchsorted(sorted_class, classes)
+        Y = Y[:, indices]
+
+    if task_type.startswith('binary'):
+        Y = Y[:, -1].reshape((-1, 1))
+
+    return Y
+
+
+def LogLoss(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    eps: float = 1e-15,
+    normalize: bool = True,
+    sample_weight: typing.Optional[typing.List] = None,
+    labels: typing.Optional[typing.List] = None,
+    task_type: typing.Optional[str] = None,
+) -> float:
+    """
+    Computes the logistic loss
+    This version honors the sklearn implementation without formatting checks to
+    speed up computations.
+
+    Parameters
+    ----------
+    y_true: np.ndarray
+        An array-like list of ground truth values
+    y_pred: np.ndarray,
+        An array-like list of model predictions
+    eps: float
+        Log loss is undefined for p=0 or p=1, so probabilities
+        are clipped to max(eps, min(1 - eps, p)).
+    sample_weight: typing.Optional[typing.List]
+        Sample weights to change the score weight while reducing via average
+    normalize: bool
+        If False, return the number of correctly classified samples.
+        Otherwise, return the fraction of correctly classified samples.
+    labels: np.ndarray
+        If not provided, labels will be inferred from y_true. Else labels are computed via
+        label binarizer
+    task_type: str
+        The task type at hand, as defined by type_of_target on the ground truth.
+        It should be one of binary, multiclass or multilabel-indicator
+
+    Returns
+    -------
+    The evaluation of the predictions against the ground truth
+    """
+
+    if task_type is None:
+        task_type = type_of_target(y_true)
+
+    classes = unique_labels(labels if labels is not None else y_true)
+    if len(classes) == 1:
+        raise ValueError("The number of classes for log loss should be at least 2")
+
+    transformed_labels = label_binarize(y=y_true, classes=classes, task_type=task_type)
+
+    if transformed_labels.shape[1] == 1:
+        transformed_labels = np.append(1 - transformed_labels,
+                                       transformed_labels, axis=1)
+
+    # Clipping
+    y_pred = np.clip(y_pred, eps, 1 - eps)
+
+    # If y_pred is of single dimension, assume y_true to be binary
+    # and then check.
+    if y_pred.ndim == 1:
+        y_pred = y_pred[:, np.newaxis]
+    if y_pred.shape[1] == 1:
+        y_pred = np.append(1 - y_pred, y_pred, axis=1)
+
+    # Check if dimensions are consistent.
+    if len(classes) != y_pred.shape[1]:
+        raise ValueError('The number of classes in labels is different '
+                         'from that in y_pred. Classes found in '
+                         'labels: {} predictions= {}'.format(classes, y_pred.shape))
+
+    # Renormalize
+    y_pred /= y_pred.sum(axis=1)[:, np.newaxis]
+    loss = -(transformed_labels * np.log(y_pred)).sum(axis=1)
+
+    if normalize:
+        return np.average(loss, weights=sample_weight)
+    elif sample_weight is not None:
+        return np.dot(loss, sample_weight)
+    else:
+        return loss.sum()
+
+
+def ROCAUC(
+    y_true: np.ndarray,
+    y_score: np.ndarray,
+    average: str = "macro",
+    sample_weight: typing.Optional[typing.List] = None,
+    task_type: typing.Optional[str] = None,
+    max_fpr: typing.Optional[float] = None,
+    multi_class: str = "raise",
+    labels: typing.Optional[typing.List] = None
+) -> float:
+    """Compute Area Under the Receiver Operating Characteristic Curve (ROC AUC)
+    from prediction scores.
+
+    It does so by calculating metrics for each label, and find their unweighted
+    mean. This version honors the sklearn implementation  (with the defaults average='macro')
+    without formatting checks to speed up computations.
+
+    Parameters
+    ----------
+    y_true: np.ndarray
+        An array-like list of ground truth values
+    y_pred: np.ndarray,
+        An array-like list of model predictions
+    average: str
+        'macro' average is the only supported implementation, which is the default of
+        sklearn. It is an argument to comply with roc auc api.
+    sample_weight: typing.Optional[typing.List]
+        Sample weights to change the score weight while reducing via average
+    max_fpr: float
+        None is the only supported value. Left here to comply with ROC AUC API.
+    multi_class: raise
+        Multiclass is not a supported implementation. As with the default sklearn implementation,
+        which this method follows, passing a y_true for multiclass classification raises an error.
+    task_type: str
+        The task type at hand, as defined by type_of_target on the ground truth.
+        It should be one of binary, multiclass or multilabel-indicator
+
+    Returns
+    -------
+    The evaluation of the predictions against the ground truth
+    """
+    if task_type is None:
+        task_type = type_of_target(y_true)
+
+    if task_type.startswith('multiclass') or (task_type.startswith('binary') and
+                                              y_score.ndim == 2 and
+                                              y_score.shape[1] > 2):
+        raise ValueError("Using ROC AUC for multiclass requires the user to "
+                         "select a multiclass strategy as detailed in "
+                         "https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html ."  # noqa: E501
+                         "If you still want to use this metric, kindly create "
+                         "a scorer object as detailed in "
+                         "https://automl.github.io/auto-sklearn/master/examples/40_advanced/example_metrics.html#sphx-glr-examples-40-advanced-example-metrics-py"  # noqa: E501
+                         )
+    elif task_type.startswith('binary'):
+        labels = np.unique(y_true)
+        y_true = label_binarize(y_true, classes=labels, task_type=task_type)[:, 0]
+        fpr, tpr, _ = roc_curve(y_true, y_score, sample_weight=sample_weight)
+        return auc(fpr, tpr)
+    elif task_type.startswith('multilabel'):
+        # Calculate the metric per class, which for multilabel indicator is axis==1
+        n_classes = y_score.shape[1]
+        score = np.zeros((n_classes,))
+        for c in range(n_classes):
+            y_true_c = y_true.take([c], axis=1).ravel()
+            y_score_c = y_score.take([c], axis=1).ravel()
+
+            fpr, tpr, _ = roc_curve(y_true_c, y_score_c, sample_weight=sample_weight)
+            score[c] = auc(fpr, tpr)
+        return np.average(score)
+    else:
+        raise ValueError("Unsupported task type {} provided".format(task_type))
+
+    if len(np.unique(y_true)) != 2:
+        raise ValueError("ROC AUC not defined when the number of labels is less than 2")

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -112,9 +112,6 @@ def testRead(ensemble_backend):
         task_type=MULTILABEL_CLASSIFICATION,
         metric=roc_auc,
         seed=0,  # important to find the test files
-        # Do not assume predictions in disc have been pre-processed for
-        # the metric at hand. We test multiple metrics in unit testing
-        enable_fast_predictions=False,
     )
 
     success = ensbuilder.score_ensemble_preds()
@@ -409,7 +406,6 @@ def testEntireEnsembleBuilder(ensemble_backend):
         metric=roc_auc,
         seed=0,  # important to find the test files
         ensemble_nbest=2,
-        enable_fast_predictions=False,
     )
     ensbuilder.SAVE2DISC = False
 

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -106,9 +106,15 @@ def testRead(ensemble_backend):
     ensbuilder = EnsembleBuilder(
         backend=ensemble_backend,
         dataset_name="TEST",
-        task_type=BINARY_CLASSIFICATION,
+        # With roc_auc, task cannot be binary as the test predictions coming
+        # from the ensemble_backend are [0., 1., 1., 1., 1.], a 1D array not supported
+        # by ROC AUC
+        task_type=MULTILABEL_CLASSIFICATION,
         metric=roc_auc,
         seed=0,  # important to find the test files
+        # Do not assume predictions in disc have been pre-processed for
+        # the metric at hand. We test multiple metrics in unit testing
+        enable_fast_predictions=False,
     )
 
     success = ensbuilder.score_ensemble_preds()
@@ -144,7 +150,10 @@ def testNBest(ensemble_backend, ensemble_nbest, max_models_on_disc, exp):
     ensbuilder = EnsembleBuilder(
         backend=ensemble_backend,
         dataset_name="TEST",
-        task_type=BINARY_CLASSIFICATION,
+        # With roc_auc, task cannot be binary as the test predictions coming
+        # from the ensemble_backend are [0., 1., 1., 1., 1.], a 1D array not supported
+        # by ROC AUC
+        task_type=MULTILABEL_CLASSIFICATION,
         metric=roc_auc,
         seed=0,  # important to find the test files
         ensemble_nbest=ensemble_nbest,
@@ -183,7 +192,10 @@ def testMaxModelsOnDisc(ensemble_backend, test_case, exp):
     ensbuilder = EnsembleBuilder(
         backend=ensemble_backend,
         dataset_name="TEST",
-        task_type=BINARY_CLASSIFICATION,
+        # With roc_auc, task cannot be binary as the test predictions coming
+        # from the ensemble_backend are [0., 1., 1., 1., 1.], a 1D array not supported
+        # by ROC AUC
+        task_type=MULTILABEL_CLASSIFICATION,
         metric=roc_auc,
         seed=0,  # important to find the test files
         ensemble_nbest=ensemble_nbest,
@@ -203,7 +215,10 @@ def testMaxModelsOnDisc2(ensemble_backend):
     ensbuilder = EnsembleBuilder(
         backend=ensemble_backend,
         dataset_name="TEST",
-        task_type=BINARY_CLASSIFICATION,
+        # With roc_auc, task cannot be binary as the test predictions coming
+        # from the ensemble_backend are [0., 1., 1., 1., 1.], a 1D array not supported
+        # by ROC AUC
+        task_type=MULTILABEL_CLASSIFICATION,
         metric=roc_auc,
         seed=0,  # important to find the test files
         ensemble_nbest=50,
@@ -236,7 +251,7 @@ def testPerformanceRangeThreshold(ensemble_backend, performance_range_threshold,
     ensbuilder = EnsembleBuilder(
         backend=ensemble_backend,
         dataset_name="TEST",
-        task_type=BINARY_CLASSIFICATION,
+        task_type=MULTILABEL_CLASSIFICATION,
         metric=roc_auc,
         seed=0,  # important to find the test files
         ensemble_nbest=100,
@@ -270,7 +285,7 @@ def testPerformanceRangeThresholdMaxBest(ensemble_backend, performance_range_thr
     ensbuilder = EnsembleBuilder(
         backend=ensemble_backend,
         dataset_name="TEST",
-        task_type=BINARY_CLASSIFICATION,
+        task_type=MULTILABEL_CLASSIFICATION,
         metric=roc_auc,
         seed=0,  # important to find the test files
         ensemble_nbest=ensemble_nbest,
@@ -297,7 +312,7 @@ def testFallBackNBest(ensemble_backend):
 
     ensbuilder = EnsembleBuilder(backend=ensemble_backend,
                                  dataset_name="TEST",
-                                 task_type=BINARY_CLASSIFICATION,
+                                 task_type=MULTILABEL_CLASSIFICATION,
                                  metric=roc_auc,
                                  seed=0,  # important to find the test files
                                  ensemble_nbest=1
@@ -341,7 +356,7 @@ def testGetValidTestPreds(ensemble_backend):
 
     ensbuilder = EnsembleBuilder(backend=ensemble_backend,
                                  dataset_name="TEST",
-                                 task_type=BINARY_CLASSIFICATION,
+                                 task_type=MULTILABEL_CLASSIFICATION,
                                  metric=roc_auc,
                                  seed=0,  # important to find the test files
                                  ensemble_nbest=1
@@ -390,10 +405,11 @@ def testEntireEnsembleBuilder(ensemble_backend):
     ensbuilder = EnsembleBuilder(
         backend=ensemble_backend,
         dataset_name="TEST",
-        task_type=BINARY_CLASSIFICATION,
+        task_type=MULTILABEL_CLASSIFICATION,
         metric=roc_auc,
         seed=0,  # important to find the test files
         ensemble_nbest=2,
+        enable_fast_predictions=False,
     )
     ensbuilder.SAVE2DISC = False
 
@@ -438,7 +454,7 @@ def testEntireEnsembleBuilder(ensemble_backend):
     # since d2 provides perfect predictions
     # it should get a higher weight
     # so that y_valid should be exactly y_valid_d2
-    y_valid_d2 = ensbuilder.read_preds[d2][Y_VALID][:, 1]
+    y_valid_d2 = ensbuilder.read_preds[d2][Y_VALID]
     np.testing.assert_array_almost_equal(y_valid, y_valid_d2)
 
 
@@ -513,7 +529,7 @@ def test_run_end_at(ensemble_backend):
 def testLimit(ensemble_backend):
     ensbuilder = EnsembleBuilderMemMock(backend=ensemble_backend,
                                         dataset_name="TEST",
-                                        task_type=BINARY_CLASSIFICATION,
+                                        task_type=MULTILABEL_CLASSIFICATION,
                                         metric=roc_auc,
                                         seed=0,  # important to find the test files
                                         ensemble_nbest=10,

--- a/test/test_evaluation/test_train_evaluator.py
+++ b/test/test_evaluation/test_train_evaluator.py
@@ -746,7 +746,9 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
             'ensemble_predictions']
 
         for i in range(7):
-            self.assertEqual(0.9, Y_optimization_pred[i][1])
+            # Ensemble predictions correspond the automl.predict, not to
+            # automl.predict_proba
+            self.assertEqual(1.0, Y_optimization_pred[i])
 
     @unittest.mock.patch.object(TrainEvaluator, 'file_output')
     @unittest.mock.patch.object(TrainEvaluator, '_partial_fit_and_predict_standard')

--- a/test/test_metric/test_custom_metrics.py
+++ b/test/test_metric/test_custom_metrics.py
@@ -1,0 +1,167 @@
+import random
+
+import numpy as np
+
+import pytest
+
+from sklearn.utils.multiclass import type_of_target
+from sklearn.metrics import (
+    accuracy_score,
+    balanced_accuracy_score,
+    log_loss,
+    roc_auc_score,
+)
+
+from autosklearn.constants import (
+    MULTILABEL_CLASSIFICATION,
+    MULTICLASS_CLASSIFICATION,
+    BINARY_CLASSIFICATION,
+)
+from autosklearn.metrics.custom_metrics import (
+    BalancedAccuracy,
+    Accuracy,
+    LogLoss,
+    ROCAUC,
+)
+import autosklearn.metrics
+
+
+@pytest.fixture
+def str_to_score_funct_dict():
+    return {
+        'balanced_accuracy': (balanced_accuracy_score, BalancedAccuracy),
+        'accuracy': (accuracy_score, Accuracy),
+        'log_loss': (log_loss, LogLoss),
+        'roc_auc': (roc_auc_score, ROCAUC),
+    }
+
+
+@pytest.fixture
+def str_to_scorer():
+    return {
+        'balanced_accuracy': autosklearn.metrics.balanced_accuracy,
+        'accuracy': autosklearn.metrics.accuracy,
+        'log_loss': autosklearn.metrics.log_loss,
+        'roc_auc': autosklearn.metrics.roc_auc,
+    }
+
+
+@pytest.fixture
+def custom_metric_y_true_pred(request):
+    if request.param == 'binary_same_dim':
+        y_true = np.array([0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0])
+        y_pred = np.array([0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0])
+        return y_true, y_pred
+    elif request.param == 'binary_diff_dim':
+        y_true = np.array([0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0])
+        y_pred = np.array([0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0])
+        y_pred = np.eye(2)[y_pred]
+        return y_true, y_pred
+    elif request.param == 'binary_randomized':
+        y_true = np.random.choice([0, 1], size=100)
+        y_pred = np.random.choice([0, 1], size=100)
+        return y_true, y_pred
+    elif request.param == 'multiclass_same_dim':
+        y_true = np.array([0, 1, 1, 0, 2, 0, 0, 4, 1, 3, 1, 0])
+        y_pred = np.array([0, 1, 0, 0, 2, 1, 0, 0, 1, 3, 1, 4])
+        return y_true, y_pred
+    elif request.param == 'multiclass_diff_dim':
+        y_true = np.array([0, 1, 1, 0, 2, 0, 0, 4, 1, 3, 1, 0])
+        y_pred = np.array([0, 1, 0, 0, 2, 1, 0, 0, 1, 3, 1, 4])
+        y_pred = np.eye(5)[y_pred]
+        return y_true, y_pred
+    elif request.param == 'multiclass_randomized':
+        y_true = np.random.choice([0, 1, 2], size=100)
+        y_pred = np.random.choice([0, 1, 2], size=100)
+        return y_true, y_pred
+    elif request.param == 'multilabel':
+        y_true = np.array([[1, 0, 1], [0, 1, 1], [0, 0, 0], [0, 1, 1],
+                           [0, 1, 1], [0, 0, 0], [0, 0, 0], [1, 0, 1]
+                           ])
+        y_pred = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 0], [0, 0, 1],
+                           [0, 1, 1], [0, 0, 0], [0, 0, 0], [1, 0, 1]
+                           ])
+        return y_true, y_pred
+    elif request.param == 'multilabel_randomized':
+        a_list = [[1, 0, 1], [0, 1, 1], [0, 0, 0]]
+        y_true = np.array(list(map(lambda x: random.choice(a_list), range(100))))
+        y_pred = np.array(list(map(lambda x: random.choice(a_list), range(100))))
+        return y_true, y_pred
+    else:
+        raise ValueError(f"Unsupported fixture request {request.param}")
+
+
+@pytest.mark.parametrize("custom_metric_y_true_pred",
+                         ['binary_same_dim', 'binary_randomized', 'multiclass_same_dim',
+                          'multiclass_randomized', 'multilabel', 'multilabel_randomized',
+                          # Do a couple of randomizations
+                          'binary_randomized', 'multiclass_randomized', 'multilabel_randomized',
+                          'binary_randomized', 'multiclass_randomized', 'multilabel_randomized',
+                          ],
+                         indirect=True)
+@pytest.mark.parametrize("metric", ['accuracy', 'balanced_accuracy', 'log_loss', 'roc_auc'])
+def test_custom_metric_score(metric, custom_metric_y_true_pred, str_to_score_funct_dict):
+
+    sklearn_score_func, custom_implementation = str_to_score_funct_dict[metric]
+    y_true, y_pred = custom_metric_y_true_pred
+
+    if type_of_target(y_true) == 'multilabel-indicator' and metric == 'balanced_accuracy':
+        pytest.skip('Balanced accuracy not supported for multilabel')
+    if type_of_target(y_true) == 'multiclass' and metric == 'roc_auc':
+        pytest.skip('ROC AUC not supported for multiclass')
+
+    # In case of log loss, we need probabilities
+    if metric == 'log_loss':
+        num_classes = len(np.unique(y_true))
+        if len(y_pred.shape) == 1 or y_pred.shape[1] < num_classes:
+            y_pred = np.eye(num_classes)[y_pred]
+
+    expected = sklearn_score_func(y_true, y_pred)
+    score = custom_implementation(y_true, y_pred)
+    assert expected == pytest.approx(score)
+
+
+@pytest.mark.parametrize("custom_metric_y_true_pred",
+                         ['binary_same_dim', 'binary_randomized', 'multiclass_same_dim',
+                          'multiclass_randomized', 'multilabel', 'multilabel_randomized',
+                          # Add different dimension scenarios that clean-prediction solves
+                          'binary_diff_dim', 'multiclass_diff_dim',
+                          # Do a couple of randomizations
+                          'binary_randomized', 'multiclass_randomized', 'multilabel_randomized',
+                          'binary_randomized', 'multiclass_randomized', 'multilabel_randomized',
+                          ],
+                         indirect=True)
+@pytest.mark.parametrize("metric", ['accuracy', 'balanced_accuracy', 'log_loss', 'roc_auc'])
+def test_custom_metric_in_scorer(metric, custom_metric_y_true_pred, str_to_scorer):
+    y_true, y_pred = custom_metric_y_true_pred
+    if metric == 'log_loss':
+        # In case of log loss, we need probabilities
+        num_classes = len(np.unique(y_true))
+        if len(y_pred.shape) == 1 or y_pred.shape[1] < num_classes:
+            y_pred = np.eye(num_classes)[y_pred]
+    task_type = type_of_target(y_true)
+    task_mapping = {'multilabel-indicator': MULTILABEL_CLASSIFICATION,
+                    'multiclass': MULTICLASS_CLASSIFICATION,
+                    'binary': BINARY_CLASSIFICATION}
+
+    if type_of_target(y_true) == 'multilabel-indicator' and metric == 'balanced_accuracy':
+        pytest.skip('Balanced accuracy not supported for multilabel')
+    if type_of_target(y_true) == 'multiclass' and metric == 'roc_auc':
+        pytest.skip('ROC AUC not supported for multiclass')
+
+    sklearn_score = autosklearn.metrics.calculate_score(
+        solution=y_true,
+        prediction=y_pred,
+        task_type=task_mapping[task_type],
+        metric=str_to_scorer[metric],
+        fast_mode=False,
+    )
+    predictions = str_to_scorer[metric].clean_predictions(y_pred, task_type)
+    fast_score = autosklearn.metrics.calculate_score(
+        solution=y_true,
+        prediction=predictions,
+        task_type=task_mapping[task_type],
+        metric=str_to_scorer[metric],
+        fast_mode=True,
+    )
+    assert sklearn_score == fast_score

--- a/test/test_metric/test_metrics.py
+++ b/test/test_metric/test_metrics.py
@@ -17,8 +17,8 @@ class TestScorer(unittest.TestCase):
         y_true = np.array([0, 0, 1, 1])
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'accuracy', sklearn.metrics.accuracy_score, 1, 0, 1, False, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -31,15 +31,15 @@ class TestScorer(unittest.TestCase):
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.5)
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'bac', sklearn.metrics.balanced_accuracy_score, None,
-            1, 0, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'bac', sklearn.metrics.balanced_accuracy_score,
+            1, 0, 1, False, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.5)
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, -1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'accuracy', sklearn.metrics.accuracy_score, 1, 0, -1, False, False, True, {})
 
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -49,8 +49,8 @@ class TestScorer(unittest.TestCase):
         y_true = np.array([0, 1, 2])
         y_pred = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'accuracy', sklearn.metrics.accuracy_score, 1, 0, 1, False, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -63,15 +63,15 @@ class TestScorer(unittest.TestCase):
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.333333333)
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'bac', sklearn.metrics.balanced_accuracy_score, None,
-            1, 0, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'bac', sklearn.metrics.balanced_accuracy_score,
+            1, 0, 1, False, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.333333333)
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, -1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'accuracy', sklearn.metrics.accuracy_score, 1, 0, -1, False, False, True, {})
 
         y_pred = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -81,8 +81,8 @@ class TestScorer(unittest.TestCase):
         y_true = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'accuracy', sklearn.metrics.accuracy_score, 1, 0, 1, False, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -95,8 +95,8 @@ class TestScorer(unittest.TestCase):
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.25)
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, -1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'accuracy', sklearn.metrics.accuracy_score, 1, 0, -1, False, False, True, {})
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -106,8 +106,8 @@ class TestScorer(unittest.TestCase):
         y_true = np.arange(0, 1.01, 0.1)
         y_pred = y_true.copy()
 
-        scorer = autosklearn.metrics._PredictScorer(
-            'r2', sklearn.metrics.r2_score, None, 1, 0, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'r2', sklearn.metrics.r2_score, 1, 0, 1, False, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -120,8 +120,8 @@ class TestScorer(unittest.TestCase):
         y_true = [0, 0, 1, 1]
         y_pred = [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]
 
-        scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, 1, True, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.0)
@@ -134,8 +134,8 @@ class TestScorer(unittest.TestCase):
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.69314718055994529)
 
-        scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, -1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, -1, True, False, True, {})
 
         y_pred = [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]
         score = scorer(y_true, y_pred)
@@ -145,8 +145,8 @@ class TestScorer(unittest.TestCase):
         y_true = [0, 1, 2]
         y_pred = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 
-        scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, 1, True, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.0)
@@ -159,8 +159,8 @@ class TestScorer(unittest.TestCase):
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0986122886681096)
 
-        scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, -1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, -1, True, False, True, {})
 
         y_pred = [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
         score = scorer(y_true, y_pred)
@@ -170,8 +170,8 @@ class TestScorer(unittest.TestCase):
         y_true = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
 
-        scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, 1, True, False, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.34657359027997314)
@@ -184,8 +184,8 @@ class TestScorer(unittest.TestCase):
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.69314718055994529)
 
-        scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, -1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, -1, True, False, True, {})
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -195,8 +195,8 @@ class TestScorer(unittest.TestCase):
         y_true = [0, 0, 1, 1]
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
 
-        scorer = autosklearn.metrics._ThresholdScorer(
-            'roc_auc', sklearn.metrics.roc_auc_score, None, 1, 0, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'roc_auc', sklearn.metrics.roc_auc_score, 1, 0, 1, False, True, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -209,8 +209,8 @@ class TestScorer(unittest.TestCase):
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.5)
 
-        scorer = autosklearn.metrics._ThresholdScorer(
-            'roc_auc', sklearn.metrics.roc_auc_score, None, 1, 0, -1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'roc_auc', sklearn.metrics.roc_auc_score, 1, 0, -1, False, True, True, {})
 
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -220,8 +220,8 @@ class TestScorer(unittest.TestCase):
         y_true = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
 
-        scorer = autosklearn.metrics._ThresholdScorer(
-            'roc_auc', sklearn.metrics.roc_auc_score, None, 1, 0, 1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'roc_auc', sklearn.metrics.roc_auc_score, 1, 0, 1, False, True, True, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -234,8 +234,8 @@ class TestScorer(unittest.TestCase):
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.5)
 
-        scorer = autosklearn.metrics._ThresholdScorer(
-            'roc_auc', sklearn.metrics.roc_auc_score, None, 1, 0, -1, {})
+        scorer = autosklearn.metrics.Scorer(
+            'roc_auc', sklearn.metrics.roc_auc_score, 1, 0, -1, False, True, True, {})
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)

--- a/test/test_metric/test_metrics.py
+++ b/test/test_metric/test_metrics.py
@@ -18,7 +18,7 @@ class TestScorer(unittest.TestCase):
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
 
         scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, 1, 0, 1, {})
+            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -32,14 +32,14 @@ class TestScorer(unittest.TestCase):
         self.assertAlmostEqual(score, 0.5)
 
         scorer = autosklearn.metrics._PredictScorer(
-            'bac', sklearn.metrics.balanced_accuracy_score,
+            'bac', sklearn.metrics.balanced_accuracy_score, None,
             1, 0, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.5)
 
         scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, 1, 0, -1, {})
+            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, -1, {})
 
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -50,7 +50,7 @@ class TestScorer(unittest.TestCase):
         y_pred = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
         scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, 1, 0, 1, {})
+            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -64,14 +64,14 @@ class TestScorer(unittest.TestCase):
         self.assertAlmostEqual(score, 0.333333333)
 
         scorer = autosklearn.metrics._PredictScorer(
-            'bac', sklearn.metrics.balanced_accuracy_score,
+            'bac', sklearn.metrics.balanced_accuracy_score, None,
             1, 0, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.333333333)
 
         scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, 1, 0, -1, {})
+            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, -1, {})
 
         y_pred = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -82,7 +82,7 @@ class TestScorer(unittest.TestCase):
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
 
         scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, 1, 0, 1, {})
+            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -96,7 +96,7 @@ class TestScorer(unittest.TestCase):
         self.assertAlmostEqual(score, 0.25)
 
         scorer = autosklearn.metrics._PredictScorer(
-            'accuracy', sklearn.metrics.accuracy_score, 1, 0, -1, {})
+            'accuracy', sklearn.metrics.accuracy_score, None, 1, 0, -1, {})
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -107,7 +107,7 @@ class TestScorer(unittest.TestCase):
         y_pred = y_true.copy()
 
         scorer = autosklearn.metrics._PredictScorer(
-            'r2', sklearn.metrics.r2_score, 1, 0, 1, {})
+            'r2', sklearn.metrics.r2_score, None, 1, 0, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -121,7 +121,7 @@ class TestScorer(unittest.TestCase):
         y_pred = [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]
 
         scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, 1, {})
+            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.0)
@@ -135,7 +135,7 @@ class TestScorer(unittest.TestCase):
         self.assertAlmostEqual(score, 0.69314718055994529)
 
         scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, -1, {})
+            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, -1, {})
 
         y_pred = [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]
         score = scorer(y_true, y_pred)
@@ -146,7 +146,7 @@ class TestScorer(unittest.TestCase):
         y_pred = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 
         scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, 1, {})
+            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.0)
@@ -160,7 +160,7 @@ class TestScorer(unittest.TestCase):
         self.assertAlmostEqual(score, 1.0986122886681096)
 
         scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, -1, {})
+            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, -1, {})
 
         y_pred = [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
         score = scorer(y_true, y_pred)
@@ -171,7 +171,7 @@ class TestScorer(unittest.TestCase):
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
 
         scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, 1, {})
+            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 0.34657359027997314)
@@ -185,7 +185,7 @@ class TestScorer(unittest.TestCase):
         self.assertAlmostEqual(score, 0.69314718055994529)
 
         scorer = autosklearn.metrics._ProbaScorer(
-            'log_loss', sklearn.metrics.log_loss, 0, MAXINT, -1, {})
+            'log_loss', sklearn.metrics.log_loss, None, 0, MAXINT, -1, {})
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -196,7 +196,7 @@ class TestScorer(unittest.TestCase):
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
 
         scorer = autosklearn.metrics._ThresholdScorer(
-            'roc_auc', sklearn.metrics.roc_auc_score, 1, 0, 1, {})
+            'roc_auc', sklearn.metrics.roc_auc_score, None, 1, 0, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -210,7 +210,7 @@ class TestScorer(unittest.TestCase):
         self.assertAlmostEqual(score, 0.5)
 
         scorer = autosklearn.metrics._ThresholdScorer(
-            'roc_auc', sklearn.metrics.roc_auc_score, 1, 0, -1, {})
+            'roc_auc', sklearn.metrics.roc_auc_score, None, 1, 0, -1, {})
 
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
         score = scorer(y_true, y_pred)
@@ -221,7 +221,7 @@ class TestScorer(unittest.TestCase):
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
 
         scorer = autosklearn.metrics._ThresholdScorer(
-            'roc_auc', sklearn.metrics.roc_auc_score, 1, 0, 1, {})
+            'roc_auc', sklearn.metrics.roc_auc_score, None, 1, 0, 1, {})
 
         score = scorer(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0)
@@ -235,7 +235,7 @@ class TestScorer(unittest.TestCase):
         self.assertAlmostEqual(score, 0.5)
 
         scorer = autosklearn.metrics._ThresholdScorer(
-            'roc_auc', sklearn.metrics.roc_auc_score, 1, 0, -1, {})
+            'roc_auc', sklearn.metrics.roc_auc_score, None, 1, 0, -1, {})
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)


### PR DESCRIPTION
This PR improves ensemble construction speed as follows:

- Enable each metric to pre-process predictions with a method called clean_predictions. With this method, the prediction of each individual model can be cleaned up once when they are written to disk, instead of doing so in every iteration of the ensemble selection.
- Custom metrics are added to improve the calculate score time. They are called if a fast mode switch in calculate score is provided.
- Added proper checking for custom metrics

With these changes, I am seeing the following improvements per metric (assuming 50 iterations on the higgs dataset):

- 124 seconds less time to fit a single ensemble with balanced accuracy
- 9.40 seconds less time to fit a single ensemble with accuracy
- 1.86 seconds less time to fit a single ensemble with accuracy
- 4.3 seconds less time to fit a single ensemble with accuracy

The time savings with balanced accuracy are quite high. 