### PR TITLE
Threads and forkserver

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -301,6 +301,14 @@ class AutoML(BaseEstimator):
         # are treated under the logger_name ROOT logger setting
         context = multiprocessing.get_context(
             self._multiprocessing_context)
+        all_loaded_modules = sys.modules.keys()
+        preload = [
+            loaded_module for loaded_module in all_loaded_modules
+            if loaded_module.split('.')[0] in (
+                'smac', 'autosklearn', 'numpy', 'scipy', 'pandas', 'pynisher', 'sklearn',
+            ) and 'logging' not in loaded_module
+        ]
+        context.set_forkserver_preload(preload)
         self.stop_logging_server = context.Event()
         port = context.Value('l')  # be safe by using a long
         port.value = -1

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -228,7 +228,7 @@ class AutoML(BaseEstimator):
         # examples. Nevertheless, multi-process runs
         # have spawn as requirement to reduce the
         # possibility of a deadlock
-        self._multiprocessing_context = 'spawn'
+        self._multiprocessing_context = 'forkserver'
         if self._n_jobs == 1 and self._dask_client is None:
             self._multiprocessing_context = 'fork'
             self._dask_client = SingleThreadedClient()

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -248,7 +248,6 @@ class AutoML(BaseEstimator):
 
     def _create_dask_client(self):
         self._is_dask_client_internally_created = True
-        dask.config.set({'distributed.worker.daemon': False})
         self._dask_client = dask.distributed.Client(
             dask.distributed.LocalCluster(
                 n_workers=self._n_jobs,

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -252,7 +252,7 @@ class AutoML(BaseEstimator):
         self._dask_client = dask.distributed.Client(
             dask.distributed.LocalCluster(
                 n_workers=self._n_jobs,
-                processes=True if self._n_jobs != 1 else False,
+                processes=False,
                 threads_per_worker=1,
                 # We use the temporal directory to save the
                 # dask workers, because deleting workers

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -49,6 +49,7 @@ from autosklearn.util.logging_ import (
     get_named_client_logger,
 )
 from autosklearn.util import pipeline, RE_PATTERN
+from autosklearn.util.parallel import preload_modules
 from autosklearn.ensemble_builder import EnsembleBuilderManager
 from autosklearn.ensembles.singlebest_ensemble import SingleBest
 from autosklearn.smbo import AutoMLSMBO
@@ -298,16 +299,8 @@ class AutoML(BaseEstimator):
         # under the above logging configuration setting
         # We need to specify the logger_name so that received records
         # are treated under the logger_name ROOT logger setting
-        context = multiprocessing.get_context(
-            self._multiprocessing_context)
-        all_loaded_modules = sys.modules.keys()
-        preload = [
-            loaded_module for loaded_module in all_loaded_modules
-            if loaded_module.split('.')[0] in (
-                'smac', 'autosklearn', 'numpy', 'scipy', 'pandas', 'pynisher', 'sklearn',
-            ) and 'logging' not in loaded_module
-        ]
-        context.set_forkserver_preload(preload)
+        context = multiprocessing.get_context(self._multiprocessing_context)
+        preload_modules(context)
         self.stop_logging_server = context.Event()
         port = context.Value('l')  # be safe by using a long
         port.value = -1

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -576,7 +576,7 @@ class EnsembleBuilder(object):
         end_at: Optional[float] = None,
         time_buffer=5,
         return_predictions: bool = False,
-        pynisher_context: str = 'spawn',
+        pynisher_context: str = 'forkserver',
     ):
 
         if time_left is None and end_at is None:

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -573,11 +573,11 @@ class EnsembleBuilder(object):
     def run(
         self,
         iteration: int,
+        pynisher_context: str,
         time_left: Optional[float] = None,
         end_at: Optional[float] = None,
         time_buffer=5,
         return_predictions: bool = False,
-        pynisher_context: str = 'forkserver',
     ):
 
         if time_left is None and end_at is None:

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -9,6 +9,7 @@ import os
 import pickle
 import re
 import shutil
+import sys
 import time
 import traceback
 from typing import List, Optional, Tuple, Union
@@ -606,6 +607,14 @@ class EnsembleBuilder(object):
             if wall_time_in_s < 1:
                 break
             context = multiprocessing.get_context(pynisher_context)
+            all_loaded_modules = sys.modules.keys()
+            preload = [
+                loaded_module for loaded_module in all_loaded_modules
+                if loaded_module.split('.')[0] in (
+                    'smac', 'autosklearn', 'numpy', 'scipy', 'pandas', 'pynisher', 'sklearn',
+                ) and 'logging' not in loaded_module
+            ]
+            context.set_forkserver_preload(preload)
 
             safe_ensemble_script = pynisher.enforce_limits(
                 wall_time_in_s=wall_time_in_s,

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -9,7 +9,6 @@ import os
 import pickle
 import re
 import shutil
-import sys
 import time
 import traceback
 from typing import List, Optional, Tuple, Union
@@ -32,6 +31,7 @@ from autosklearn.metrics import calculate_score, Scorer
 from autosklearn.ensembles.ensemble_selection import EnsembleSelection
 from autosklearn.ensembles.abstract_ensemble import AbstractEnsemble
 from autosklearn.util.logging_ import get_named_client_logger
+from autosklearn.util.parallel import preload_modules
 
 Y_ENSEMBLE = 0
 Y_VALID = 1
@@ -607,14 +607,7 @@ class EnsembleBuilder(object):
             if wall_time_in_s < 1:
                 break
             context = multiprocessing.get_context(pynisher_context)
-            all_loaded_modules = sys.modules.keys()
-            preload = [
-                loaded_module for loaded_module in all_loaded_modules
-                if loaded_module.split('.')[0] in (
-                    'smac', 'autosklearn', 'numpy', 'scipy', 'pandas', 'pynisher', 'sklearn',
-                ) and 'logging' not in loaded_module
-            ]
-            context.set_forkserver_preload(preload)
+            preload_modules(context)
 
             safe_ensemble_script = pynisher.enforce_limits(
                 wall_time_in_s=wall_time_in_s,

--- a/autosklearn/evaluation/__init__.py
+++ b/autosklearn/evaluation/__init__.py
@@ -102,7 +102,8 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
                  run_obj='quality', par_factor=1, scoring_functions=None,
                  output_y_hat_optimization=True, include=None, exclude=None,
                  memory_limit=None, disable_file_output=False, init_params=None,
-                 budget_type=None, ta=False, pynisher_context='spawn', **resampling_strategy_args):
+                 budget_type=None, ta=False, pynisher_context='forkserver',
+                 **resampling_strategy_args):
 
         if resampling_strategy == 'holdout':
             eval_function = autosklearn.evaluation.train_evaluator.eval_holdout

--- a/autosklearn/evaluation/__init__.py
+++ b/autosklearn/evaluation/__init__.py
@@ -5,6 +5,7 @@ import json
 import math
 import multiprocessing
 from queue import Empty
+import sys
 import time
 import traceback
 from typing import Dict, List, Optional, Tuple, Union
@@ -262,6 +263,14 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
     ) -> Tuple[StatusType, float, float, Dict[str, Union[int, float, str, Dict, List, Tuple]]]:
 
         context = multiprocessing.get_context(self.pynisher_context)
+        all_loaded_modules = sys.modules.keys()
+        preload = [
+            loaded_module for loaded_module in all_loaded_modules
+            if loaded_module.split('.')[0] in (
+                'smac', 'autosklearn', 'numpy', 'scipy', 'pandas', 'pynisher', 'sklearn',
+            ) and 'logging' not in loaded_module
+        ]
+        context.set_forkserver_preload(preload)
         queue = context.Queue()
 
         if not (instance_specific is None or instance_specific == '0'):

--- a/autosklearn/evaluation/__init__.py
+++ b/autosklearn/evaluation/__init__.py
@@ -5,7 +5,6 @@ import json
 import math
 import multiprocessing
 from queue import Empty
-import sys
 import time
 import traceback
 from typing import Dict, List, Optional, Tuple, Union
@@ -25,6 +24,7 @@ import autosklearn.evaluation.train_evaluator
 import autosklearn.evaluation.test_evaluator
 import autosklearn.evaluation.util
 from autosklearn.util.logging_ import get_named_client_logger
+from autosklearn.util.parallel import preload_modules
 
 
 def fit_predict_try_except_decorator(ta, queue, cost_for_crash, **kwargs):
@@ -262,14 +262,7 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
     ) -> Tuple[StatusType, float, float, Dict[str, Union[int, float, str, Dict, List, Tuple]]]:
 
         context = multiprocessing.get_context(self.pynisher_context)
-        all_loaded_modules = sys.modules.keys()
-        preload = [
-            loaded_module for loaded_module in all_loaded_modules
-            if loaded_module.split('.')[0] in (
-                'smac', 'autosklearn', 'numpy', 'scipy', 'pandas', 'pynisher', 'sklearn',
-            ) and 'logging' not in loaded_module
-        ]
-        context.set_forkserver_preload(preload)
+        preload_modules(context)
         queue = context.Queue()
 
         if not (instance_specific is None or instance_specific == '0'):

--- a/autosklearn/evaluation/__init__.py
+++ b/autosklearn/evaluation/__init__.py
@@ -98,13 +98,12 @@ def _encode_exit_status(exit_status):
 class ExecuteTaFuncWithQueue(AbstractTAFunc):
 
     def __init__(self, backend, autosklearn_seed, resampling_strategy, metric,
-                 cost_for_crash, abort_on_first_run_crash, port,
+                 cost_for_crash, abort_on_first_run_crash, port, pynisher_context,
                  initial_num_run=1, stats=None,
                  run_obj='quality', par_factor=1, scoring_functions=None,
                  output_y_hat_optimization=True, include=None, exclude=None,
                  memory_limit=None, disable_file_output=False, init_params=None,
-                 budget_type=None, ta=False, pynisher_context='forkserver',
-                 **resampling_strategy_args):
+                 budget_type=None, ta=False, **resampling_strategy_args):
 
         if resampling_strategy == 'holdout':
             eval_function = autosklearn.evaluation.train_evaluator.eval_holdout

--- a/autosklearn/util/parallel.py
+++ b/autosklearn/util/parallel.py
@@ -7,12 +7,12 @@ def preload_modules(context: multiprocessing.context.BaseContext) -> None:
     preload = [
         loaded_module for loaded_module in all_loaded_modules
         if loaded_module.split('.')[0] in (
-            'smac', 
-            'autosklearn', 
-            'numpy', 
-            'scipy', 
-            'pandas', 
-            'pynisher', 
+            'smac',
+            'autosklearn',
+            'numpy',
+            'scipy',
+            'pandas',
+            'pynisher',
             'sklearn',
             'ConfigSpace',
         ) and 'logging' not in loaded_module

--- a/autosklearn/util/parallel.py
+++ b/autosklearn/util/parallel.py
@@ -7,7 +7,14 @@ def preload_modules(context: multiprocessing.context.BaseContext) -> None:
     preload = [
         loaded_module for loaded_module in all_loaded_modules
         if loaded_module.split('.')[0] in (
-            'smac', 'autosklearn', 'numpy', 'scipy', 'pandas', 'pynisher', 'sklearn',
+            'smac', 
+            'autosklearn', 
+            'numpy', 
+            'scipy', 
+            'pandas', 
+            'pynisher', 
+            'sklearn',
+            'ConfigSpace',
         ) and 'logging' not in loaded_module
     ]
     context.set_forkserver_preload(preload)

--- a/autosklearn/util/parallel.py
+++ b/autosklearn/util/parallel.py
@@ -1,0 +1,13 @@
+import multiprocessing
+import sys
+
+
+def preload_modules(context: multiprocessing.context.BaseContext) -> None:
+    all_loaded_modules = sys.modules.keys()
+    preload = [
+        loaded_module for loaded_module in all_loaded_modules
+        if loaded_module.split('.')[0] in (
+            'smac', 'autosklearn', 'numpy', 'scipy', 'pandas', 'pynisher', 'sklearn',
+        ) and 'logging' not in loaded_module
+    ]
+    context.set_forkserver_preload(preload)

--- a/scripts/run_auto-sklearn_for_metadata_generation.py
+++ b/scripts/run_auto-sklearn_for_metadata_generation.py
@@ -151,7 +151,8 @@ if __name__ == '__main__':
                                         include=include,
                                         metric=automl_arguments['metric'],
                                         cost_for_crash=get_cost_of_crash(automl_arguments['metric']),
-                                        abort_on_first_run_crash=False,)
+                                        abort_on_first_run_crash=False,
+                                        pynisher_context='fork')
             run_info, run_value = ta.run_wrapper(
                 RunInfo(
                     config=config,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,6 @@ import shutil
 import time
 import unittest.mock
 
-import dask
 from dask.distributed import Client, get_client
 import psutil
 import pytest
@@ -125,8 +124,7 @@ def dask_client(request):
     Workers are in subprocesses to not create deadlocks with the pynisher and logging.
     """
 
-    dask.config.set({'distributed.worker.daemon': False})
-    client = Client(n_workers=2, threads_per_worker=1, processes=True)
+    client = Client(n_workers=2, threads_per_worker=1, processes=False)
     print("Started Dask client={}\n".format(client))
 
     def get_finalizer(address):
@@ -151,7 +149,6 @@ def dask_client_single_worker(request):
     it is used very rarely to avoid this issue as much as possible.
     """
 
-    dask.config.set({'distributed.worker.daemon': False})
     client = Client(n_workers=1, threads_per_worker=1, processes=False)
     print("Started Dask client={}\n".format(client))
 

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -504,7 +504,7 @@ def test_run_end_at(ensemble_backend):
 
         current_time = time.time()
 
-        ensbuilder.run(end_at=current_time + 10, iteration=1)
+        ensbuilder.run(end_at=current_time + 10, iteration=1, pynisher_context='forkserver')
         # 4 seconds left because: 10 seconds - 5 seconds overhead - very little overhead,
         # but then rounded to an integer
         assert pynisher_mock.call_args_list[0][1]["wall_time_in_s"], 4
@@ -579,7 +579,7 @@ def testLimit(ensemble_backend):
 
         # And then it still runs, but basically won't do anything any more except for raising error
         # messages via the logger
-        ensbuilder.run(time_left=1000, iteration=0)
+        ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
         assert os.path.exists(read_scores_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 4

--- a/test/test_evaluation/test_evaluation.py
+++ b/test/test_evaluation/test_evaluation.py
@@ -112,6 +112,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
+                                    pynisher_context='forkserver',
                                     )
         self.scenario.wallclock_limit = 5
         self.stats.submitted_ta_runs += 1
@@ -130,6 +131,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
+                                    pynisher_context='forkserver',
                                     )
         self.stats.ta_runs = 1
         ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None, instance_specific=None,
@@ -224,6 +226,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
+                                    pynisher_context='forkserver',
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -259,6 +262,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
+                                    pynisher_context='forkserver',
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -282,6 +286,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
+                                    pynisher_context='forkserver',
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))


### PR DESCRIPTION
* move from processes to threads for dask (less overhead)
* move from the spawn context to the forkserver context for the processes we create (less overhead)
* streamline code - the context arguments to functions no longer have default values and the context is determined only once