### PR TITLE
Fix 1072

### DIFF
--- a/autosklearn/experimental/askl2.py
+++ b/autosklearn/experimental/askl2.py
@@ -25,15 +25,16 @@ with open(training_data_file) as fh:
     m = hashlib.md5()
     m.update(fh.read().encode('utf8'))
 training_data_hash = m.hexdigest()[:10]
-sklearn_version = sklearn.__version__
-autosklearn_version = autosklearn.__version__
-selector_file = pathlib.Path(
-    os.environ.get(
-        'XDG_CACHE_HOME',
-        '~/.cache/auto-sklearn/askl2_selector_%s_%s_%s.pkl'
-        % (autosklearn_version, sklearn_version, training_data_hash),
-    )
-).expanduser()
+selector_filename = "askl2_selector_%s_%s_%s.pkl" % (
+    autosklearn.__version__,
+    sklearn.__version__,
+    training_data_hash
+)
+selector_directory = os.environ.get('XDG_CACHE_HOME')
+if selector_directory is None or not os.access(selector_directory, os.W_OK):
+    selector_directory = pathlib.Path.home() / '.cache'
+selector_directory = pathlib.Path(selector_directory).joinpath('auto-sklearn').expanduser()
+selector_file = selector_directory / selector_filename
 metafeatures = pd.DataFrame(training_data['metafeatures'])
 y_values = np.array(training_data['y_values'])
 strategies = training_data['strategies']
@@ -255,7 +256,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
 
         smac_scenario_args : dict, optional (None)
             Additional arguments inserted into the scenario of SMAC. See the
-            `SMAC documentation 
+            `SMAC documentation
             <https://automl.github.io/SMAC3/master/options.html?highlight=scenario
             #scenario>`_
             for a list of available arguments.
@@ -272,7 +273,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
             If None is provided, a default metric is selected depending on the task.
 
         scoring_functions : List[Scorer], optional (None)
-            List of scorers which will be calculated for each pipeline and results will be 
+            List of scorers which will be calculated for each pipeline and results will be
             available via ``cv_results``
 
         load_models : bool, optional (True)

--- a/autosklearn/experimental/askl2.py
+++ b/autosklearn/experimental/askl2.py
@@ -31,8 +31,8 @@ selector_filename = "askl2_selector_%s_%s_%s.pkl" % (
     training_data_hash
 )
 selector_directory = os.environ.get('XDG_CACHE_HOME')
-if selector_directory is None or not os.access(selector_directory, os.W_OK):
-    selector_directory = pathlib.Path.home() / '.cache'
+if selector_directory is None:
+    selector_directory = pathlib.Path.home()
 selector_directory = pathlib.Path(selector_directory).joinpath('auto-sklearn').expanduser()
 selector_file = selector_directory / selector_filename
 metafeatures = pd.DataFrame(training_data['metafeatures'])
@@ -54,8 +54,14 @@ if not selector_file.exists():
         maxima=maxima_for_methods,
     )
     selector_file.parent.mkdir(exist_ok=True, parents=True)
-    with open(selector_file, 'wb') as fh:
-        pickle.dump(selector, fh)
+    try:
+        with open(selector_file, 'wb') as fh:
+            pickle.dump(selector, fh)
+    except Exception as e:
+        print("AutoSklearn2Classifier needs to create a selector file under "
+              "the user's home directory or XDG_CACHE_HOME. Nevertheless "
+              "the path {} is not writable.".format(selector_file))
+        raise e
 
 
 class SmacObjectCallback:

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -653,17 +653,6 @@ def test_autosklearn2_classification_methods_returns_self(dask_client):
     pickle.dumps(automl_fitted)
 
 
-@pytest.mark.parametrize("class_", [AutoSklearnClassifier, AutoSklearnRegressor,
-                                    AutoSklearn2Classifier])
-def test_check_estimator_signature(class_):
-    # Make sure signature is store in self
-    expected_subclass = ClassifierMixin if 'Classifier' in str(class_) else RegressorMixin
-    assert issubclass(class_, expected_subclass)
-    estimator = class_()
-    for expected in list(inspect.signature(class_).parameters):
-        assert hasattr(estimator, expected)
-
-
 @pytest.mark.parametrize("selector_path", [None,  # No XDG_CACHE_HOME provided
                                            '/',  # XDG_CACHE_HOME has no permission
                                            tempfile.gettempdir(),  # in the user cache

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -671,13 +671,17 @@ def test_check_estimator_signature(class_):
 def test_selector_file_askl2_can_be_created(selector_path):
     with unittest.mock.patch('os.environ.get') as mock_foo:
         mock_foo.return_value = selector_path
-        importlib.reload(autosklearn.experimental.askl2)
-        assert os.path.exists(autosklearn.experimental.askl2.selector_file)
-        if selector_path is None or not os.access(selector_path, os.W_OK):
-            # We default to home in worst case
-            assert os.path.expanduser("~") in str(autosklearn.experimental.askl2.selector_file)
+        if selector_path is not None and not os.access(selector_path, os.W_OK):
+            with pytest.raises(PermissionError):
+                importlib.reload(autosklearn.experimental.askl2)
         else:
-            # a dir provided via XDG_CACHE_HOME
-            assert selector_path in str(autosklearn.experimental.askl2.selector_file)
+            importlib.reload(autosklearn.experimental.askl2)
+            assert os.path.exists(autosklearn.experimental.askl2.selector_file)
+            if selector_path is None or not os.access(selector_path, os.W_OK):
+                # We default to home in worst case
+                assert os.path.expanduser("~") in str(autosklearn.experimental.askl2.selector_file)
+            else:
+                # a dir provided via XDG_CACHE_HOME
+                assert selector_path in str(autosklearn.experimental.askl2.selector_file)
     # Re import it at the end so we do not affect other test
     importlib.reload(autosklearn.experimental.askl2)

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -653,6 +653,17 @@ def test_autosklearn2_classification_methods_returns_self(dask_client):
     pickle.dumps(automl_fitted)
 
 
+@pytest.mark.parametrize("class_", [AutoSklearnClassifier, AutoSklearnRegressor,
+                                    AutoSklearn2Classifier])
+def test_check_estimator_signature(class_):
+    # Make sure signature is store in self
+    expected_subclass = ClassifierMixin if 'Classifier' in str(class_) else RegressorMixin
+    assert issubclass(class_, expected_subclass)
+    estimator = class_()
+    for expected in list(inspect.signature(class_).parameters):
+        assert hasattr(estimator, expected)
+
+
 @pytest.mark.parametrize("selector_path", [None,  # No XDG_CACHE_HOME provided
                                            '/',  # XDG_CACHE_HOME has no permission
                                            tempfile.gettempdir(),  # in the user cache

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -1,10 +1,12 @@
 import copy
 import glob
+import importlib
 import os
 import inspect
 import pickle
 import re
 import sys
+import tempfile
 import unittest
 import unittest.mock
 import pytest
@@ -660,3 +662,22 @@ def test_check_estimator_signature(class_):
     estimator = class_()
     for expected in list(inspect.signature(class_).parameters):
         assert hasattr(estimator, expected)
+
+
+@pytest.mark.parametrize("selector_path", [None,  # No XDG_CACHE_HOME provided
+                                           '/',  # XDG_CACHE_HOME has no permission
+                                           tempfile.gettempdir(),  # in the user cache
+                                           ])
+def test_selector_file_askl2_can_be_created(selector_path):
+    with unittest.mock.patch('os.environ.get') as mock_foo:
+        mock_foo.return_value = selector_path
+        importlib.reload(autosklearn.experimental.askl2)
+        assert os.path.exists(autosklearn.experimental.askl2.selector_file)
+        if selector_path is None or not os.access(selector_path, os.W_OK):
+            # We default to home in worst case
+            assert os.path.expanduser("~") in str(autosklearn.experimental.askl2.selector_file)
+        else:
+            # a dir provided via XDG_CACHE_HOME
+            assert selector_path in str(autosklearn.experimental.askl2.selector_file)
+    # Re import it at the end so we do not affect other test
+    importlib.reload(autosklearn.experimental.askl2)


### PR DESCRIPTION
Address #1072 

Also, to have in mind:

- I am creating auto-sklearn even when XDG_CACHE_HOME is provided, which I think make sense to have files within the given tool
- In case the XDG_CACHE_HOME is not passed or *is not writable* we default to `HOME`.
- Add checks for different combinations. 