### PR TITLE
Calculate loss support

### DIFF
--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -27,7 +27,7 @@ from smac.tae.base import StatusType
 
 from autosklearn.util.backend import Backend
 from autosklearn.constants import BINARY_CLASSIFICATION
-from autosklearn.metrics import calculate_score, Scorer
+from autosklearn.metrics import calculate_score, calculate_loss, Scorer
 from autosklearn.ensembles.ensemble_selection import EnsembleSelection
 from autosklearn.ensembles.abstract_ensemble import AbstractEnsemble
 from autosklearn.util.logging_ import get_named_client_logger
@@ -498,14 +498,14 @@ class EnsembleBuilder(object):
 
         # already read prediction files
         # {"file name": {
-        #    "ens_score": float
+        #    "ens_loss": float
         #    "mtime_ens": str,
         #    "mtime_valid": str,
         #    "mtime_test": str,
         #    "seed": int,
         #    "num_run": int,
         # }}
-        self.read_scores = {}
+        self.read_losses = {}
         # {"file_name": {
         #    Y_ENSEMBLE: np.ndarray
         #    Y_VALID: np.ndarray
@@ -516,7 +516,7 @@ class EnsembleBuilder(object):
 
         # Depending on the dataset dimensions,
         # regenerating every iteration, the predictions
-        # scores for self.read_preds
+        # losses for self.read_preds
         # is too computationally expensive
         # As the ensemble builder is stateless
         # (every time the ensemble builder gets resources
@@ -539,17 +539,17 @@ class EnsembleBuilder(object):
                         traceback.format_exc(),
                     )
                 )
-        self.ensemble_score_file = os.path.join(
+        self.ensemble_loss_file = os.path.join(
             self.backend.internals_directory,
-            'ensemble_read_scores.pkl'
+            'ensemble_read_losses.pkl'
         )
-        if os.path.exists(self.ensemble_score_file):
+        if os.path.exists(self.ensemble_loss_file):
             try:
-                with (open(self.ensemble_score_file, "rb")) as memory:
-                    self.read_scores = pickle.load(memory)
+                with (open(self.ensemble_loss_file, "rb")) as memory:
+                    self.read_losses = pickle.load(memory)
             except Exception as e:
                 self.logger.warning(
-                    "Could not load the previous iterations of ensemble_builder scores."
+                    "Could not load the previous iterations of ensemble_builder losses."
                     "This might impact the quality of the run. Exception={} {}".format(
                         e,
                         traceback.format_exc(),
@@ -677,7 +677,7 @@ class EnsembleBuilder(object):
             time_left - used_time,
         )
 
-        # populates self.read_preds and self.read_scores
+        # populates self.read_preds and self.read_losses
         if not self.score_ensemble_preds():
             if return_predictions:
                 return self.ensemble_history, self.ensemble_nbest, train_pred, valid_pred, test_pred
@@ -745,9 +745,9 @@ class EnsembleBuilder(object):
         if self.max_resident_models is not None:
             self._delete_excess_models(selected_keys=candidate_models)
 
-        # Save the read scores status for the next iteration
-        with open(self.ensemble_score_file, "wb") as memory:
-            pickle.dump(self.read_scores, memory)
+        # Save the read losses status for the next iteration
+        with open(self.ensemble_loss_file, "wb") as memory:
+            pickle.dump(self.read_losses, memory)
 
         if ensemble is not None:
             train_pred = self.predict(set_="train",
@@ -811,7 +811,7 @@ class EnsembleBuilder(object):
     def score_ensemble_preds(self):
         """
             score predictions on ensemble building data set;
-            populates self.read_preds and self.read_scores
+            populates self.read_preds and self.read_losses
         """
 
         self.logger.debug("Read ensemble data set predictions")
@@ -865,9 +865,9 @@ class EnsembleBuilder(object):
                 self.logger.info('Error loading file (not .npy or .npy.gz): %s', y_ens_fn)
                 continue
 
-            if not self.read_scores.get(y_ens_fn):
-                self.read_scores[y_ens_fn] = {
-                    "ens_score": -np.inf,
+            if not self.read_losses.get(y_ens_fn):
+                self.read_losses[y_ens_fn] = {
+                    "ens_loss": np.inf,
                     "mtime_ens": 0,
                     "mtime_valid": 0,
                     "mtime_test": 0,
@@ -889,37 +889,37 @@ class EnsembleBuilder(object):
                     Y_TEST: None,
                 }
 
-            if self.read_scores[y_ens_fn]["mtime_ens"] == mtime:
+            if self.read_losses[y_ens_fn]["mtime_ens"] == mtime:
                 # same time stamp; nothing changed;
                 continue
 
             # actually read the predictions and score them
             try:
                 y_ensemble = self._read_np_fn(y_ens_fn)
-                score = calculate_score(solution=self.y_true_ensemble,
-                                        prediction=y_ensemble,
-                                        task_type=self.task_type,
-                                        metric=self.metric,
-                                        scoring_functions=None)
+                loss = calculate_loss(solution=self.y_true_ensemble,
+                                      prediction=y_ensemble,
+                                      task_type=self.task_type,
+                                      metric=self.metric,
+                                      scoring_functions=None)
 
-                if np.isfinite(self.read_scores[y_ens_fn]["ens_score"]):
+                if np.isfinite(self.read_losses[y_ens_fn]["ens_loss"]):
                     self.logger.debug(
-                        'Changing ensemble score for file %s from %f to %f '
+                        'Changing ensemble loss for file %s from %f to %f '
                         'because file modification time changed? %f - %f',
                         y_ens_fn,
-                        self.read_scores[y_ens_fn]["ens_score"],
-                        score,
-                        self.read_scores[y_ens_fn]["mtime_ens"],
+                        self.read_losses[y_ens_fn]["ens_loss"],
+                        loss,
+                        self.read_losses[y_ens_fn]["mtime_ens"],
                         os.path.getmtime(y_ens_fn),
                     )
 
-                self.read_scores[y_ens_fn]["ens_score"] = score
+                self.read_losses[y_ens_fn]["ens_loss"] = loss
 
                 # It is not needed to create the object here
                 # To save memory, we just score the object.
-                self.read_scores[y_ens_fn]["mtime_ens"] = os.path.getmtime(y_ens_fn)
-                self.read_scores[y_ens_fn]["loaded"] = 2
-                self.read_scores[y_ens_fn]["disc_space_cost_mb"] = self.get_disk_consumption(
+                self.read_losses[y_ens_fn]["mtime_ens"] = os.path.getmtime(y_ens_fn)
+                self.read_losses[y_ens_fn]["loaded"] = 2
+                self.read_losses[y_ens_fn]["disc_space_cost_mb"] = self.get_disk_consumption(
                     y_ens_fn
                 )
 
@@ -931,19 +931,20 @@ class EnsembleBuilder(object):
                     y_ens_fn,
                     traceback.format_exc(),
                 )
-                self.read_scores[y_ens_fn]["ens_score"] = -np.inf
+                self.read_losses[y_ens_fn]["ens_loss"] = np.inf
 
         self.logger.debug(
             'Done reading %d new prediction files. Loaded %d predictions in '
             'total.',
             n_read_files,
-            np.sum([pred["loaded"] > 0 for pred in self.read_scores.values()])
+            np.sum([pred["loaded"] > 0 for pred in self.read_losses.values()])
         )
+        print(f"self.read_losses={self.read_losses}")
         return True
 
     def get_n_best_preds(self):
         """
-            get best n predictions (i.e., keys of self.read_scores)
+            get best n predictions (i.e., keys of self.read_losses)
             according to score on "ensemble set"
             n: self.ensemble_nbest
 
@@ -955,21 +956,28 @@ class EnsembleBuilder(object):
         """
 
         sorted_keys = self._get_list_of_sorted_preds()
+        print(f"sorted_keys={sorted_keys}")
 
         # number of models available
         num_keys = len(sorted_keys)
         # remove all that are at most as good as random
         # note: dummy model must have run_id=1 (there is no run_id=0)
-        dummy_scores = list(filter(lambda x: x[2] == 1, sorted_keys))
+        dummy_losses = list(filter(lambda x: x[2] == 1, sorted_keys))
         # number of dummy models
-        num_dummy = len(dummy_scores)
-        dummy_score = dummy_scores[0]
-        self.logger.debug("Use %f as dummy score" % dummy_score[1])
-        sorted_keys = filter(lambda x: x[1] > dummy_score[1], sorted_keys)
+        num_dummy = len(dummy_losses)
+        dummy_loss = dummy_losses[0]
+        self.logger.debug("Use %f as dummy loss" % dummy_loss[1])
+
+        # sorted_keys looks like: (k, v["ens_loss"], v["num_run"])
+        # On position 1 we have the loss of a minimization problem.
+        # keep only the predictions with a loss smaller than the dummy
+        # prediction
+        sorted_keys = filter(lambda x: x[1] < dummy_loss[1], sorted_keys)
+
         # remove Dummy Classifier
         sorted_keys = list(filter(lambda x: x[2] > 1, sorted_keys))
         if not sorted_keys:
-            # no model left; try to use dummy score (num_run==0)
+            # no model left; try to use dummy loss (num_run==0)
             # log warning when there are other models but not better than dummy model
             if num_keys > num_dummy:
                 self.logger.warning("No models better than random - using Dummy Score!"
@@ -978,10 +986,10 @@ class EnsembleBuilder(object):
                                     num_keys - 1,
                                     num_dummy)
             sorted_keys = [
-                (k, v["ens_score"], v["num_run"]) for k, v in self.read_scores.items()
+                (k, v["ens_loss"], v["num_run"]) for k, v in self.read_losses.items()
                 if v["seed"] == self.seed and v["num_run"] == 1
             ]
-        # reload predictions if scores changed over time and a model is
+        # reload predictions if losses changed over time and a model is
         # considered to be in the top models again!
         if not isinstance(self.ensemble_nbest, numbers.Integral):
             # Transform to number of models to keep. Keep at least one
@@ -1004,9 +1012,9 @@ class EnsembleBuilder(object):
             if not isinstance(self.max_models_on_disc, numbers.Integral):
                 consumption = [
                     [
-                        v["ens_score"],
+                        v["ens_loss"],
                         v["disc_space_cost_mb"],
-                    ] for v in self.read_scores.values() if v["disc_space_cost_mb"] is not None
+                    ] for v in self.read_losses.values() if v["disc_space_cost_mb"] is not None
                 ]
                 max_consumption = max(c[1] for c in consumption)
 
@@ -1015,10 +1023,10 @@ class EnsembleBuilder(object):
                 # max_consumption megabytes
                 if (sum(c[1] for c in consumption) + max_consumption) > self.max_models_on_disc:
 
-                    # just leave the best -- higher is better!
+                    # just leave the best -- smaller is better!
                     # This list is in descending order, to preserve the best models
                     sorted_cum_consumption = np.cumsum([
-                        c[1] for c in list(reversed(sorted(consumption)))
+                        c[1] for c in list(sorted(consumption))
                     ]) + max_consumption
                     max_models = np.argmax(sorted_cum_consumption > self.max_models_on_disc)
 
@@ -1048,17 +1056,17 @@ class EnsembleBuilder(object):
 
         # consider performance_range_threshold
         if self.performance_range_threshold > 0:
-            best_score = sorted_keys[0][1]
-            min_score = dummy_score[1]
-            min_score += (best_score - min_score) * self.performance_range_threshold
-            if sorted_keys[keep_nbest - 1][1] < min_score:
+            best_loss = sorted_keys[0][1]
+            worst_loss = dummy_loss[1]
+            worst_loss -= (worst_loss - best_loss) * self.performance_range_threshold
+            if sorted_keys[keep_nbest - 1][1] > worst_loss:
                 # We can further reduce number of models
                 # since worst model is worse than thresh
                 for i in range(0, keep_nbest):
                     # Look at most at keep_nbest models,
                     # but always keep at least one model
-                    current_score = sorted_keys[i][1]
-                    if current_score <= min_score:
+                    current_loss = sorted_keys[i][1]
+                    if current_loss >= worst_loss:
                         self.logger.debug("Dynamic Performance range: "
                                           "Further reduce from %d to %d models",
                                           keep_nbest, max(1, i))
@@ -1075,15 +1083,15 @@ class EnsembleBuilder(object):
                 self.read_preds[k][Y_ENSEMBLE] = None
                 self.read_preds[k][Y_VALID] = None
                 self.read_preds[k][Y_TEST] = None
-            if self.read_scores[k]['loaded'] == 1:
+            if self.read_losses[k]['loaded'] == 1:
                 self.logger.debug(
-                    'Dropping model %s (%d,%d) with score %f.',
+                    'Dropping model %s (%d,%d) with loss %f.',
                     k,
-                    self.read_scores[k]['seed'],
-                    self.read_scores[k]['num_run'],
-                    self.read_scores[k]['ens_score'],
+                    self.read_losses[k]['seed'],
+                    self.read_losses[k]['num_run'],
+                    self.read_losses[k]['ens_loss'],
                 )
-                self.read_scores[k]['loaded'] = 2
+                self.read_losses[k]['loaded'] = 2
 
         # Load the predictions for the winning
         for k in sorted_keys[:ensemble_n_best]:
@@ -1092,14 +1100,14 @@ class EnsembleBuilder(object):
                     k not in self.read_preds or
                     self.read_preds[k][Y_ENSEMBLE] is None
                 )
-                and self.read_scores[k]['loaded'] != 3
+                and self.read_losses[k]['loaded'] != 3
             ):
                 self.read_preds[k][Y_ENSEMBLE] = self._read_np_fn(k)
                 # No need to load valid and test here because they are loaded
                 #  only if the model ends up in the ensemble
-                self.read_scores[k]['loaded'] = 1
+                self.read_losses[k]['loaded'] = 1
 
-        # return best scored keys of self.read_scores
+        # return best scored keys of self.read_losses
         return sorted_keys[:ensemble_n_best]
 
     def get_valid_test_preds(self, selected_keys: List[str]) -> Tuple[List[str], List[str]]:
@@ -1126,14 +1134,14 @@ class EnsembleBuilder(object):
                 os.path.join(
                     glob.escape(self.backend.get_runs_directory()),
                     '%d_%d_%s' % (
-                        self.read_scores[k]["seed"],
-                        self.read_scores[k]["num_run"],
-                        self.read_scores[k]["budget"],
+                        self.read_losses[k]["seed"],
+                        self.read_losses[k]["num_run"],
+                        self.read_losses[k]["budget"],
                     ),
                     'predictions_valid_%d_%d_%s.npy*' % (
-                        self.read_scores[k]["seed"],
-                        self.read_scores[k]["num_run"],
-                        self.read_scores[k]["budget"],
+                        self.read_losses[k]["seed"],
+                        self.read_losses[k]["num_run"],
+                        self.read_losses[k]["budget"],
                     )
                 )
             )
@@ -1142,14 +1150,14 @@ class EnsembleBuilder(object):
                 os.path.join(
                     glob.escape(self.backend.get_runs_directory()),
                     '%d_%d_%s' % (
-                        self.read_scores[k]["seed"],
-                        self.read_scores[k]["num_run"],
-                        self.read_scores[k]["budget"],
+                        self.read_losses[k]["seed"],
+                        self.read_losses[k]["num_run"],
+                        self.read_losses[k]["budget"],
                     ),
                     'predictions_test_%d_%d_%s.npy*' % (
-                        self.read_scores[k]["seed"],
-                        self.read_scores[k]["num_run"],
-                        self.read_scores[k]["budget"]
+                        self.read_losses[k]["seed"],
+                        self.read_losses[k]["num_run"],
+                        self.read_losses[k]["budget"]
                     )
                 )
             )
@@ -1163,7 +1171,7 @@ class EnsembleBuilder(object):
             else:
                 valid_fn = valid_fn[0]
                 if (
-                    self.read_scores[k]["mtime_valid"] == os.path.getmtime(valid_fn)
+                    self.read_losses[k]["mtime_valid"] == os.path.getmtime(valid_fn)
                     and k in self.read_preds
                     and self.read_preds[k][Y_VALID] is not None
                 ):
@@ -1173,7 +1181,7 @@ class EnsembleBuilder(object):
                     y_valid = self._read_np_fn(valid_fn)
                     self.read_preds[k][Y_VALID] = y_valid
                     success_keys_valid.append(k)
-                    self.read_scores[k]["mtime_valid"] = os.path.getmtime(valid_fn)
+                    self.read_losses[k]["mtime_valid"] = os.path.getmtime(valid_fn)
                 except Exception:
                     self.logger.warning('Error loading %s: %s',
                                         valid_fn, traceback.format_exc())
@@ -1186,7 +1194,7 @@ class EnsembleBuilder(object):
             else:
                 test_fn = test_fn[0]
                 if (
-                    self.read_scores[k]["mtime_test"] == os.path.getmtime(test_fn)
+                    self.read_losses[k]["mtime_test"] == os.path.getmtime(test_fn)
                     and k in self.read_preds
                     and self.read_preds[k][Y_TEST] is not None
                 ):
@@ -1196,7 +1204,7 @@ class EnsembleBuilder(object):
                     y_test = self._read_np_fn(test_fn)
                     self.read_preds[k][Y_TEST] = y_test
                     success_keys_test.append(k)
-                    self.read_scores[k]["mtime_test"] = os.path.getmtime(test_fn)
+                    self.read_losses[k]["mtime_test"] = os.path.getmtime(test_fn)
                 except Exception:
                     self.logger.warning('Error loading %s: %s',
                                         test_fn, traceback.format_exc())
@@ -1210,7 +1218,7 @@ class EnsembleBuilder(object):
             Parameters
             ---------
             selected_keys: list
-                list of selected keys of self.read_scores
+                list of selected keys of self.read_losses
 
             Returns
             -------
@@ -1224,9 +1232,9 @@ class EnsembleBuilder(object):
         predictions_train = [self.read_preds[k][Y_ENSEMBLE] for k in selected_keys]
         include_num_runs = [
             (
-                self.read_scores[k]["seed"],
-                self.read_scores[k]["num_run"],
-                self.read_scores[k]["budget"],
+                self.read_losses[k]["seed"],
+                self.read_losses[k]["num_run"],
+                self.read_losses[k]["budget"],
             )
             for k in selected_keys]
 
@@ -1298,7 +1306,7 @@ class EnsembleBuilder(object):
             ensemble: EnsembleSelection
                 trained Ensemble
             selected_keys: list
-                list of selected keys of self.read_scores
+                list of selected keys of self.read_losses
             n_preds: int
                 number of prediction models used for ensemble building
                 same number of predictions on valid and test are necessary
@@ -1407,7 +1415,7 @@ class EnsembleBuilder(object):
     def _get_list_of_sorted_preds(self):
         """
             Returns a list of sorted predictions in descending order
-            Scores are taken from self.read_scores.
+            Scores are taken from self.read_losses.
 
             Parameters
             ----------
@@ -1417,24 +1425,26 @@ class EnsembleBuilder(object):
             ------
             sorted_keys: list
         """
-        # Sort by score - higher is better!
+        # Sort by loss - smaller is better!
         # First sort by num_run
         sorted_keys = list(reversed(sorted(
             [
-                (k, v["ens_score"], v["num_run"])
-                for k, v in self.read_scores.items()
+                (k, v["ens_loss"], v["num_run"])
+                for k, v in self.read_losses.items()
             ],
             key=lambda x: x[2],
         )))
-        # Then by score
-        sorted_keys = list(reversed(sorted(sorted_keys, key=lambda x: x[1])))
+        # We sort the loss on a ascending fashion. Smaller loss
+        # (that is better performance for the given task)
+        # will be first in the sorted_keys list
+        sorted_keys = list(sorted(sorted_keys, key=lambda x: x[1]))
         return sorted_keys
 
     def _delete_excess_models(self, selected_keys: List[str]):
         """
             Deletes models excess models on disc. self.max_models_on_disc
             defines the upper limit on how many models to keep.
-            Any additional model with a worst score than the top
+            Any additional model with a worst loss than the top
             self.max_models_on_disc is deleted.
 
         """
@@ -1463,9 +1473,9 @@ class EnsembleBuilder(object):
                 os.rename(numrun_dir, numrun_dir + '.old')
                 shutil.rmtree(numrun_dir + '.old')
                 self.logger.info("Deleted files of non-candidate model %s", pred_path)
-                self.read_scores[pred_path]["disc_space_cost_mb"] = None
-                self.read_scores[pred_path]["loaded"] = 3
-                self.read_scores[pred_path]["ens_score"] = -np.inf
+                self.read_losses[pred_path]["disc_space_cost_mb"] = None
+                self.read_losses[pred_path]["loaded"] = 3
+                self.read_losses[pred_path]["ens_loss"] = np.inf
             except Exception as e:
                 self.logger.error(
                     "Failed to delete files of non-candidate model %s due"

--- a/autosklearn/ensemble_builder.py
+++ b/autosklearn/ensemble_builder.py
@@ -76,7 +76,7 @@ class EnsembleBuilderManager(IncorporateRunResultCallback):
         task_type: int
             type of ML task
         metric: str
-            name of metric to score predictions
+            name of metric to compute the loss of the given predictions
         ensemble_size: int
             maximal size of ensemble (passed to autosklearn.ensemble.ensemble_selection)
         ensemble_nbest: int/float
@@ -294,7 +294,7 @@ def fit_and_return_ensemble(
         dataset_name: str
             name of dataset
         metric: str
-            name of metric to score predictions
+            name of metric to compute the loss of the given predictions
         task_type: int
             type of ML task
         ensemble_size: int
@@ -399,7 +399,7 @@ class EnsembleBuilder(object):
             task_type: int
                 type of ML task
             metric: str
-                name of metric to score predictions
+                name of metric to compute the loss of the given predictions
             ensemble_size: int
                 maximal size of ensemble (passed to autosklearn.ensemble.ensemble_selection)
             ensemble_nbest: int/float
@@ -810,7 +810,7 @@ class EnsembleBuilder(object):
 
     def compute_loss_per_model(self):
         """
-            score predictions on ensemble building data set;
+            Compute the loss of the predictions on ensemble building data set;
             populates self.read_preds and self.read_losses
         """
 
@@ -893,7 +893,7 @@ class EnsembleBuilder(object):
                 # same time stamp; nothing changed;
                 continue
 
-            # actually read the predictions and score them
+            # actually read the predictions and compute their respective loss
             try:
                 y_ensemble = self._read_np_fn(y_ens_fn)
                 loss = calculate_loss(solution=self.y_true_ensemble,
@@ -916,7 +916,7 @@ class EnsembleBuilder(object):
                 self.read_losses[y_ens_fn]["ens_loss"] = loss
 
                 # It is not needed to create the object here
-                # To save memory, we just score the object.
+                # To save memory, we just compute the loss.
                 self.read_losses[y_ens_fn]["mtime_ens"] = os.path.getmtime(y_ens_fn)
                 self.read_losses[y_ens_fn]["loaded"] = 2
                 self.read_losses[y_ens_fn]["disc_space_cost_mb"] = self.get_disk_consumption(
@@ -944,7 +944,7 @@ class EnsembleBuilder(object):
     def get_n_best_preds(self):
         """
             get best n predictions (i.e., keys of self.read_losses)
-            according to score on "ensemble set"
+            according to the loss on the "ensemble set"
             n: self.ensemble_nbest
 
             Side effects:
@@ -1106,6 +1106,7 @@ class EnsembleBuilder(object):
                 self.read_losses[k]['loaded'] = 1
 
         # return best scored keys of self.read_losses
+        # That is, the one with the lowest loss
         return sorted_keys[:ensemble_n_best]
 
     def get_valid_test_preds(self, selected_keys: List[str]) -> Tuple[List[str], List[str]]:
@@ -1413,7 +1414,7 @@ class EnsembleBuilder(object):
     def _get_list_of_sorted_preds(self):
         """
             Returns a list of sorted predictions in descending order
-            Scores are taken from self.read_losses.
+            Losses are taken from self.read_losses.
 
             Parameters
             ----------

--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from autosklearn.constants import TASK_TYPES
 from autosklearn.ensembles.abstract_ensemble import AbstractEnsemble
-from autosklearn.metrics import Scorer, calculate_score
+from autosklearn.metrics import Scorer, calculate_loss
 from autosklearn.pipeline.base import BasePipeline
 
 
@@ -131,9 +131,9 @@ class EnsembleSelection(AbstractEnsemble):
 
                 # Calculate score is versatile and can return a dict of score
                 # when scoring_functions=None, we know it will be a float
-                calculated_score = cast(
+                scores[j] = cast(
                     float,
-                    calculate_score(
+                    calculate_loss(
                         solution=labels,
                         prediction=fant_ensemble_prediction,
                         task_type=self.task_type,
@@ -141,7 +141,6 @@ class EnsembleSelection(AbstractEnsemble):
                         scoring_functions=None
                     )
                 )
-                scores[j] = self.metric._optimum - calculated_score
 
             all_best = np.argwhere(scores == np.nanmin(scores)).flatten()
             best = self.random_state.choice(all_best)
@@ -181,9 +180,9 @@ class EnsembleSelection(AbstractEnsemble):
                 ensemble_prediction = np.mean(np.array(ensemble), axis=0)
                 # Calculate score is versatile and can return a dict of score
                 # when scoring_functions=None, we know it will be a float
-                calculated_score = cast(
+                scores[j] = cast(
                     float,
-                    calculate_score(
+                    calculate_loss(
                         solution=labels,
                         prediction=ensemble_prediction,
                         task_type=self.task_type,
@@ -191,7 +190,6 @@ class EnsembleSelection(AbstractEnsemble):
                         scoring_functions=None
                     )
                 )
-                scores[j] = self.metric._optimum - calculated_score
                 ensemble.pop()
             best = np.nanargmin(scores)
             ensemble.append(predictions[best])

--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -100,7 +100,7 @@ class EnsembleSelection(AbstractEnsemble):
             dtype=np.float64,
         )
         for i in range(ensemble_size):
-            scores = np.zeros(
+            losses = np.zeros(
                 (len(predictions)),
                 dtype=np.float64,
             )
@@ -129,9 +129,9 @@ class EnsembleSelection(AbstractEnsemble):
                     out=fant_ensemble_prediction
                 )
 
-                # Calculate score is versatile and can return a dict of score
+                # calculate_loss is versatile and can return a dict of losses
                 # when scoring_functions=None, we know it will be a float
-                scores[j] = cast(
+                losses[j] = cast(
                     float,
                     calculate_loss(
                         solution=labels,
@@ -142,10 +142,10 @@ class EnsembleSelection(AbstractEnsemble):
                     )
                 )
 
-            all_best = np.argwhere(scores == np.nanmin(scores)).flatten()
+            all_best = np.argwhere(losses == np.nanmin(losses)).flatten()
             best = self.random_state.choice(all_best)
             ensemble.append(predictions[best])
-            trajectory.append(scores[best])
+            trajectory.append(losses[best])
             order.append(best)
 
             # Handle special case
@@ -154,7 +154,7 @@ class EnsembleSelection(AbstractEnsemble):
 
         self.indices_ = order
         self.trajectory_ = trajectory
-        self.train_score_ = trajectory[-1]
+        self.train_loss_ = trajectory[-1]
 
     def _slow(
         self,
@@ -171,16 +171,16 @@ class EnsembleSelection(AbstractEnsemble):
         ensemble_size = self.ensemble_size
 
         for i in range(ensemble_size):
-            scores = np.zeros(
+            losses = np.zeros(
                 [np.shape(predictions)[0]],
                 dtype=np.float64,
             )
             for j, pred in enumerate(predictions):
                 ensemble.append(pred)
                 ensemble_prediction = np.mean(np.array(ensemble), axis=0)
-                # Calculate score is versatile and can return a dict of score
+                # calculate_loss is versatile and can return a dict of losses
                 # when scoring_functions=None, we know it will be a float
-                scores[j] = cast(
+                losses[j] = cast(
                     float,
                     calculate_loss(
                         solution=labels,
@@ -191,9 +191,9 @@ class EnsembleSelection(AbstractEnsemble):
                     )
                 )
                 ensemble.pop()
-            best = np.nanargmin(scores)
+            best = np.nanargmin(losses)
             ensemble.append(predictions[best])
-            trajectory.append(scores[best])
+            trajectory.append(losses[best])
             order.append(best)
 
             # Handle special case
@@ -208,7 +208,7 @@ class EnsembleSelection(AbstractEnsemble):
             trajectory,
             dtype=np.float64,
         )
-        self.train_score_ = trajectory[-1]
+        self.train_loss_ = trajectory[-1]
 
     def _calculate_weights(self) -> None:
         ensemble_members = Counter(self.indices_).most_common()

--- a/autosklearn/evaluation/test_evaluator.py
+++ b/autosklearn/evaluation/test_evaluator.py
@@ -5,8 +5,7 @@ from autosklearn.evaluation.abstract_evaluator import (
     AbstractEvaluator,
     _fit_and_suppress_warnings,
 )
-from autosklearn.metrics import calculate_score, CLASSIFICATION_METRICS, REGRESSION_METRICS
-from autosklearn.constants import CLASSIFICATION_TASKS
+from autosklearn.metrics import calculate_loss
 
 
 __all__ = [
@@ -71,7 +70,7 @@ class TestEvaluator(AbstractEvaluator):
         if train:
             Y_pred = self.predict_function(self.X_train, self.model,
                                            self.task_type, self.Y_train)
-            score = calculate_score(
+            err = calculate_loss(
                 solution=self.Y_train,
                 prediction=Y_pred,
                 task_type=self.task_type,
@@ -80,22 +79,12 @@ class TestEvaluator(AbstractEvaluator):
         else:
             Y_pred = self.predict_function(self.X_test, self.model,
                                            self.task_type, self.Y_train)
-            score = calculate_score(
+            err = calculate_loss(
                 solution=self.Y_test,
                 prediction=Y_pred,
                 task_type=self.task_type,
                 metric=self.metric,
                 scoring_functions=self.scoring_functions)
-
-        if hasattr(score, '__len__'):
-            if self.task_type in CLASSIFICATION_TASKS:
-                err = {key: metric._optimum - score[key] for key, metric in
-                       CLASSIFICATION_METRICS.items() if key in score}
-            else:
-                err = {key: metric._optimum - score[key] for key, metric in
-                       REGRESSION_METRICS.items() if key in score}
-        else:
-            err = self.metric._optimum - score
 
         return err, Y_pred, None, None
 

--- a/autosklearn/metrics/__init__.py
+++ b/autosklearn/metrics/__init__.py
@@ -353,7 +353,7 @@ def calculate_score(
             for metric_ in scoring_functions:
 
                 try:
-                    score_dict[metric_.name] = metric_(solution, cprediction)
+                    score_dict[metric_.name] = metric_._sign * metric_(solution, cprediction)
                 except ValueError as e:
                     print(e, e.args[0])
                     if e.args[0] == "Mean Squared Logarithmic Error cannot be used when " \
@@ -369,7 +369,7 @@ def calculate_score(
                 # handle?
 
                 try:
-                    score_dict[metric_.name] = metric_(solution, prediction)
+                    score_dict[metric_.name] = metric_._sign * metric_(solution, prediction)
                 except ValueError as e:
                     if e.args[0] == 'multiclass format is not supported':
                         continue

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -308,7 +308,7 @@ def test_automl_outputs(backend, dask_client):
         'start_time_100',
         'datamanager.pkl',
         'ensemble_read_preds.pkl',
-        'ensemble_read_scores.pkl',
+        'ensemble_read_losses.pkl',
         'runs',
         'ensembles',
         'ensemble_history.json',
@@ -625,7 +625,8 @@ def test_load_best_individual_model(metric, backend, dask_client):
     if metric.name == 'balanced_accuracy':
         assert automl.score(X_test, Y_test) > 0.9
     elif metric.name == 'log_loss':
-        assert automl.score(X_test, Y_test) <= 0.2
+        # On average log loss is 0.38 += 0.02
+        assert automl.score(X_test, Y_test) <= 0.45
     else:
         raise ValueError(metric.name)
 

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -625,8 +625,8 @@ def test_load_best_individual_model(metric, backend, dask_client):
     if metric.name == 'balanced_accuracy':
         assert automl.score(X_test, Y_test) > 0.9
     elif metric.name == 'log_loss':
-        # On average log loss is 0.38 += 0.02
-        assert automl.score(X_test, Y_test) <= 0.45
+        # Seen values in github actions of 0.6978304740364537
+        assert automl.score(X_test, Y_test) <= 0.72
     else:
         raise ValueError(metric.name)
 

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -111,7 +111,7 @@ def testRead(ensemble_backend):
         seed=0,  # important to find the test files
     )
 
-    success = ensbuilder.score_ensemble_preds()
+    success = ensbuilder.compute_loss_per_model()
     assert success, str(ensbuilder.read_preds)
     assert len(ensbuilder.read_preds) == 3, ensbuilder.read_preds.keys()
     assert len(ensbuilder.read_losses) == 3, ensbuilder.read_losses.keys()
@@ -151,17 +151,14 @@ def testNBest(ensemble_backend, ensemble_nbest, max_models_on_disc, exp):
         max_models_on_disc=max_models_on_disc,
     )
 
-    ensbuilder.score_ensemble_preds()
+    ensbuilder.compute_loss_per_model()
     sel_keys = ensbuilder.get_n_best_preds()
 
     assert len(sel_keys) == exp
 
-    # Sort by name, then score
-    # Num_run=2 and num_run=3 have same performance.
-    # Prefer run_3 over run_2 (more budget/advanced run)
     fixture = os.path.join(
         ensemble_backend.temporary_directory,
-        ".auto-sklearn/runs/0_3_100.0/predictions_ensemble_0_3_100.0.npy"
+        ".auto-sklearn/runs/0_2_0.0/predictions_ensemble_0_2_0.0.npy"
     )
     assert sel_keys[0] == fixture
 
@@ -195,7 +192,7 @@ def testMaxModelsOnDisc(ensemble_backend, test_case, exp):
 
     with unittest.mock.patch('os.path.getsize') as mock:
         mock.return_value = 100*1024*1024
-        ensbuilder.score_ensemble_preds()
+        ensbuilder.compute_loss_per_model()
         sel_keys = ensbuilder.get_n_best_preds()
         assert len(sel_keys) == exp, test_case
 
@@ -306,7 +303,7 @@ def testFallBackNBest(ensemble_backend):
                                  ensemble_nbest=1
                                  )
 
-    ensbuilder.score_ensemble_preds()
+    ensbuilder.compute_loss_per_model()
     print()
     print(ensbuilder.read_preds.keys())
     print(ensbuilder.read_losses.keys())
@@ -350,10 +347,10 @@ def testGetValidTestPreds(ensemble_backend):
                                  ensemble_nbest=1
                                  )
 
-    ensbuilder.score_ensemble_preds()
+    ensbuilder.compute_loss_per_model()
 
     # d1 is a dummt prediction. d2 and d3 have the same prediction with
-    # different name. num_run=3 is selected when doing sorted()
+    # different name. num_run=2 is selected when doing sorted()
     d1 = os.path.join(
         ensemble_backend.temporary_directory,
         ".auto-sklearn/runs/0_1_0.0/predictions_ensemble_0_1_0.0.npy"
@@ -382,12 +379,12 @@ def testGetValidTestPreds(ensemble_backend):
     # not selected --> should still be None
     assert ensbuilder.read_preds[d1][Y_VALID] is None
     assert ensbuilder.read_preds[d1][Y_TEST] is None
-    assert ensbuilder.read_preds[d2][Y_VALID] is None
-    assert ensbuilder.read_preds[d2][Y_TEST] is None
+    assert ensbuilder.read_preds[d3][Y_VALID] is None
+    assert ensbuilder.read_preds[d3][Y_TEST] is None
 
     # selected --> read valid and test predictions
-    assert ensbuilder.read_preds[d3][Y_VALID] is not None
-    assert ensbuilder.read_preds[d3][Y_TEST] is not None
+    assert ensbuilder.read_preds[d2][Y_VALID] is not None
+    assert ensbuilder.read_preds[d2][Y_TEST] is not None
 
 
 def testEntireEnsembleBuilder(ensemble_backend):
@@ -402,7 +399,7 @@ def testEntireEnsembleBuilder(ensemble_backend):
     )
     ensbuilder.SAVE2DISC = False
 
-    ensbuilder.score_ensemble_preds()
+    ensbuilder.compute_loss_per_model()
 
     d2 = os.path.join(
         ensemble_backend.temporary_directory,

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -114,19 +114,19 @@ def testRead(ensemble_backend):
     success = ensbuilder.score_ensemble_preds()
     assert success, str(ensbuilder.read_preds)
     assert len(ensbuilder.read_preds) == 3, ensbuilder.read_preds.keys()
-    assert len(ensbuilder.read_scores) == 3, ensbuilder.read_scores.keys()
+    assert len(ensbuilder.read_losses) == 3, ensbuilder.read_losses.keys()
 
     filename = os.path.join(
         ensemble_backend.temporary_directory,
         ".auto-sklearn/runs/0_1_0.0/predictions_ensemble_0_1_0.0.npy"
     )
-    assert ensbuilder.read_scores[filename]["ens_score"] == 0.5
+    assert ensbuilder.read_losses[filename]["ens_loss"] == 0.5
 
     filename = os.path.join(
         ensemble_backend.temporary_directory,
         ".auto-sklearn/runs/0_2_0.0/predictions_ensemble_0_2_0.0.npy"
     )
-    assert ensbuilder.read_scores[filename]["ens_score"] == 1.0
+    assert ensbuilder.read_losses[filename]["ens_loss"] == 0.0
 
 
 @pytest.mark.parametrize(
@@ -156,9 +156,12 @@ def testNBest(ensemble_backend, ensemble_nbest, max_models_on_disc, exp):
 
     assert len(sel_keys) == exp
 
+    # Sort by name, then score
+    # Num_run=2 and num_run=3 have same performance.
+    # Prefer run_3 over run_2 (more budget/advanced run)
     fixture = os.path.join(
         ensemble_backend.temporary_directory,
-        ".auto-sklearn/runs/0_2_0.0/predictions_ensemble_0_2_0.0.npy"
+        ".auto-sklearn/runs/0_3_100.0/predictions_ensemble_0_3_100.0.npy"
     )
     assert sel_keys[0] == fixture
 
@@ -211,8 +214,8 @@ def testMaxModelsOnDisc2(ensemble_backend):
     )
     ensbuilder.read_preds = {}
     for i in range(50):
-        ensbuilder.read_scores['pred'+str(i)] = {
-            'ens_score': i*10,
+        ensbuilder.read_losses['pred'+str(i)] = {
+            'ens_loss': -i*10,
             'num_run': i,
             'loaded': 1,
             "seed": 1,
@@ -242,16 +245,16 @@ def testPerformanceRangeThreshold(ensemble_backend, performance_range_threshold,
         ensemble_nbest=100,
         performance_range_threshold=performance_range_threshold
     )
-    ensbuilder.read_scores = {
-        'A': {'ens_score': 1, 'num_run': 1, 'loaded': -1, "seed": 1},
-        'B': {'ens_score': 2, 'num_run': 2, 'loaded': -1, "seed": 1},
-        'C': {'ens_score': 3, 'num_run': 3, 'loaded': -1, "seed": 1},
-        'D': {'ens_score': 4, 'num_run': 4, 'loaded': -1, "seed": 1},
-        'E': {'ens_score': 5, 'num_run': 5, 'loaded': -1, "seed": 1},
+    ensbuilder.read_losses = {
+        'A': {'ens_loss': -1, 'num_run': 1, 'loaded': -1, "seed": 1},
+        'B': {'ens_loss': -2, 'num_run': 2, 'loaded': -1, "seed": 1},
+        'C': {'ens_loss': -3, 'num_run': 3, 'loaded': -1, "seed": 1},
+        'D': {'ens_loss': -4, 'num_run': 4, 'loaded': -1, "seed": 1},
+        'E': {'ens_loss': -5, 'num_run': 5, 'loaded': -1, "seed": 1},
     }
     ensbuilder.read_preds = {
         key: {key_2: True for key_2 in (Y_ENSEMBLE, Y_VALID, Y_TEST)}
-        for key in ensbuilder.read_scores
+        for key in ensbuilder.read_losses
     }
     sel_keys = ensbuilder.get_n_best_preds()
 
@@ -277,16 +280,16 @@ def testPerformanceRangeThresholdMaxBest(ensemble_backend, performance_range_thr
         performance_range_threshold=performance_range_threshold,
         max_models_on_disc=None,
     )
-    ensbuilder.read_scores = {
-        'A': {'ens_score': 1, 'num_run': 1, 'loaded': -1, "seed": 1},
-        'B': {'ens_score': 2, 'num_run': 2, 'loaded': -1, "seed": 1},
-        'C': {'ens_score': 3, 'num_run': 3, 'loaded': -1, "seed": 1},
-        'D': {'ens_score': 4, 'num_run': 4, 'loaded': -1, "seed": 1},
-        'E': {'ens_score': 5, 'num_run': 5, 'loaded': -1, "seed": 1},
+    ensbuilder.read_losses = {
+        'A': {'ens_loss': -1, 'num_run': 1, 'loaded': -1, "seed": 1},
+        'B': {'ens_loss': -2, 'num_run': 2, 'loaded': -1, "seed": 1},
+        'C': {'ens_loss': -3, 'num_run': 3, 'loaded': -1, "seed": 1},
+        'D': {'ens_loss': -4, 'num_run': 4, 'loaded': -1, "seed": 1},
+        'E': {'ens_loss': -5, 'num_run': 5, 'loaded': -1, "seed": 1},
     }
     ensbuilder.read_preds = {
         key: {key_2: True for key_2 in (Y_ENSEMBLE, Y_VALID, Y_TEST)}
-        for key in ensbuilder.read_scores
+        for key in ensbuilder.read_losses
     }
     sel_keys = ensbuilder.get_n_best_preds()
 
@@ -306,26 +309,26 @@ def testFallBackNBest(ensemble_backend):
     ensbuilder.score_ensemble_preds()
     print()
     print(ensbuilder.read_preds.keys())
-    print(ensbuilder.read_scores.keys())
+    print(ensbuilder.read_losses.keys())
     print(ensemble_backend.temporary_directory)
 
     filename = os.path.join(
         ensemble_backend.temporary_directory,
         ".auto-sklearn/runs/0_2_0.0/predictions_ensemble_0_2_0.0.npy"
     )
-    ensbuilder.read_scores[filename]["ens_score"] = -1
+    ensbuilder.read_losses[filename]["ens_loss"] = -1
 
     filename = os.path.join(
         ensemble_backend.temporary_directory,
         ".auto-sklearn/runs/0_3_100.0/predictions_ensemble_0_3_100.0.npy"
     )
-    ensbuilder.read_scores[filename]["ens_score"] = -1
+    ensbuilder.read_losses[filename]["ens_loss"] = -1
 
     filename = os.path.join(
         ensemble_backend.temporary_directory,
         ".auto-sklearn/runs/0_1_0.0/predictions_ensemble_0_1_0.0.npy"
     )
-    ensbuilder.read_scores[filename]["ens_score"] = -1
+    ensbuilder.read_losses[filename]["ens_loss"] = -1
 
     sel_keys = ensbuilder.get_n_best_preds()
 
@@ -349,6 +352,8 @@ def testGetValidTestPreds(ensemble_backend):
 
     ensbuilder.score_ensemble_preds()
 
+    # d1 is a dummt prediction. d2 and d3 have the same prediction with
+    # different name. num_run=3 is selected when doing sorted()
     d1 = os.path.join(
         ensemble_backend.temporary_directory,
         ".auto-sklearn/runs/0_1_0.0/predictions_ensemble_0_1_0.0.npy"
@@ -377,12 +382,12 @@ def testGetValidTestPreds(ensemble_backend):
     # not selected --> should still be None
     assert ensbuilder.read_preds[d1][Y_VALID] is None
     assert ensbuilder.read_preds[d1][Y_TEST] is None
-    assert ensbuilder.read_preds[d3][Y_VALID] is None
-    assert ensbuilder.read_preds[d3][Y_TEST] is None
+    assert ensbuilder.read_preds[d2][Y_VALID] is None
+    assert ensbuilder.read_preds[d2][Y_TEST] is None
 
     # selected --> read valid and test predictions
-    assert ensbuilder.read_preds[d2][Y_VALID] is not None
-    assert ensbuilder.read_preds[d2][Y_TEST] is not None
+    assert ensbuilder.read_preds[d3][Y_VALID] is not None
+    assert ensbuilder.read_preds[d3][Y_TEST] is not None
 
 
 def testEntireEnsembleBuilder(ensemble_backend):
@@ -485,7 +490,7 @@ def test_main(ensemble_backend):
         os.path.join(ensemble_backend.internals_directory, 'ensemble_read_preds.pkl')
     ), os.listdir(ensemble_backend.internals_directory)
     assert os.path.exists(
-        os.path.join(ensemble_backend.internals_directory, 'ensemble_read_scores.pkl')
+        os.path.join(ensemble_backend.internals_directory, 'ensemble_read_losses.pkl')
     ), os.listdir(ensemble_backend.internals_directory)
 
 
@@ -522,9 +527,9 @@ def testLimit(ensemble_backend):
                                         )
     ensbuilder.SAVE2DISC = False
 
-    read_scores_file = os.path.join(
+    read_losses_file = os.path.join(
         ensemble_backend.internals_directory,
-        'ensemble_read_scores.pkl'
+        'ensemble_read_losses.pkl'
     )
     read_preds_file = os.path.join(
         ensemble_backend.internals_directory,
@@ -554,15 +559,15 @@ def testLimit(ensemble_backend):
         mtime.side_effect = mtime_mock
 
         ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
-        assert os.path.exists(read_scores_file)
+        assert os.path.exists(read_losses_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 1
         ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
-        assert os.path.exists(read_scores_file)
+        assert os.path.exists(read_losses_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 2
         ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
-        assert os.path.exists(read_scores_file)
+        assert os.path.exists(read_losses_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 3
 
@@ -570,7 +575,7 @@ def testLimit(ensemble_backend):
         assert ensbuilder.ensemble_nbest == 1
 
         ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
-        assert os.path.exists(read_scores_file)
+        assert os.path.exists(read_losses_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 4
 
@@ -580,7 +585,7 @@ def testLimit(ensemble_backend):
         # And then it still runs, but basically won't do anything any more except for raising error
         # messages via the logger
         ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
-        assert os.path.exists(read_scores_file)
+        assert os.path.exists(read_losses_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 4
 
@@ -629,15 +634,15 @@ def test_read_pickle_read_preds(ensemble_backend):
 
     ensemble_memory_file = os.path.join(
         ensemble_backend.internals_directory,
-        'ensemble_read_scores.pkl'
+        'ensemble_read_losses.pkl'
     )
     assert os.path.exists(ensemble_memory_file)
 
     # Make sure we pickle the correct read scores
     with (open(ensemble_memory_file, "rb")) as memory:
-        read_scores = pickle.load(memory)
+        read_losses = pickle.load(memory)
 
-    compare_read_preds(read_scores, ensbuilder.read_scores)
+    compare_read_preds(read_losses, ensbuilder.read_losses)
 
     # Then create a new instance, which should automatically read this file
     ensbuilder2 = EnsembleBuilder(
@@ -650,7 +655,7 @@ def test_read_pickle_read_preds(ensemble_backend):
         max_models_on_disc=None,
         )
     compare_read_preds(ensbuilder2.read_preds, ensbuilder.read_preds)
-    compare_read_preds(ensbuilder2.read_scores, ensbuilder.read_scores)
+    compare_read_preds(ensbuilder2.read_losses, ensbuilder.read_losses)
     assert ensbuilder2.last_hash == ensbuilder.last_hash
 
 

--- a/test/test_metric/test_metrics.py
+++ b/test/test_metric/test_metrics.py
@@ -46,9 +46,7 @@ class TestScorer(unittest.TestCase):
 
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
         score = scorer(y_true, y_pred)
-        # The scorer has negative sign, yet that is accounted when calculating a loss
-        # Not when producing a score
-        self.assertAlmostEqual(score, 1.0)
+        self.assertAlmostEqual(score, -1.0)
 
     def test_predict_scorer_multiclass(self):
         y_true = np.array([0, 1, 2])
@@ -80,9 +78,7 @@ class TestScorer(unittest.TestCase):
 
         y_pred = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
         score = scorer(y_true, y_pred)
-        # The scorer has negative sign, yet that is accounted when calculating a loss
-        # Not when producing a score
-        self.assertAlmostEqual(score, 1.0)
+        self.assertAlmostEqual(score, -1.0)
 
     def test_predict_scorer_multilabel(self):
         y_true = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
@@ -107,9 +103,7 @@ class TestScorer(unittest.TestCase):
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)
-        # The scorer has negative sign, yet that is accounted when calculating a loss
-        # Not when producing a score
-        self.assertAlmostEqual(score, 1.0)
+        self.assertAlmostEqual(score, -1.0)
 
     def test_predict_scorer_regression(self):
         y_true = np.arange(0, 1.01, 0.1)
@@ -148,7 +142,7 @@ class TestScorer(unittest.TestCase):
 
         y_pred = [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]
         score = scorer(y_true, y_pred)
-        self.assertAlmostEqual(score, 0.69314718055994529)
+        self.assertAlmostEqual(score, -0.69314718055994529)
 
     def test_proba_scorer_multiclass(self):
         y_true = [0, 1, 2]
@@ -173,7 +167,7 @@ class TestScorer(unittest.TestCase):
 
         y_pred = [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
         score = scorer(y_true, y_pred)
-        self.assertAlmostEqual(score, 1.0986122886681096)
+        self.assertAlmostEqual(score, -1.0986122886681096)
 
     def test_proba_scorer_multilabel(self):
         y_true = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
@@ -198,7 +192,7 @@ class TestScorer(unittest.TestCase):
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)
-        self.assertAlmostEqual(score, 0.34657359027997314)
+        self.assertAlmostEqual(score, -0.34657359027997314)
 
     def test_threshold_scorer_binary(self):
         y_true = [0, 0, 1, 1]
@@ -223,7 +217,7 @@ class TestScorer(unittest.TestCase):
 
         y_pred = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
         score = scorer(y_true, y_pred)
-        self.assertAlmostEqual(score, 1.0)
+        self.assertAlmostEqual(score, -1.0)
 
     def test_threshold_scorer_multilabel(self):
         y_true = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
@@ -248,7 +242,7 @@ class TestScorer(unittest.TestCase):
 
         y_pred = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
         score = scorer(y_true, y_pred)
-        self.assertAlmostEqual(score, 1.0)
+        self.assertAlmostEqual(score, -1.0)
 
     def test_sign_flip(self):
         y_true = np.arange(0, 1.01, 0.1)
@@ -257,62 +251,26 @@ class TestScorer(unittest.TestCase):
         scorer = autosklearn.metrics.make_scorer(
             'r2', sklearn.metrics.r2_score, greater_is_better=True)
 
-        loss = calculate_loss(
-            solution=y_true,
-            prediction=y_pred + 1.0,
-            task_type=REGRESSION,
-            metric=scorer,
-        )
-        # Optimum - sign * score = 1.0 - (1) * (-9)
-        self.assertAlmostEqual(loss, 10.0)
+        score = scorer(y_true, y_pred + 1.0)
+        self.assertAlmostEqual(score, -9.0)
 
-        loss = calculate_loss(
-            solution=y_true,
-            prediction=y_pred + 0.5,
-            task_type=REGRESSION,
-            metric=scorer,
-        )
-        # Optimum - sign * score = 1.0 - (1) * (-1.5)
-        self.assertAlmostEqual(loss, 2.5)
+        score = scorer(y_true, y_pred + 0.5)
+        self.assertAlmostEqual(score, -1.5)
 
-        loss = calculate_loss(
-            solution=y_true,
-            prediction=y_pred,
-            task_type=REGRESSION,
-            metric=scorer,
-        )
-        # Optimum - sign * score = 1.0 - (1) * (1.0)
-        self.assertAlmostEqual(loss, 0.0)
+        score = scorer(y_true, y_pred)
+        self.assertAlmostEqual(score, 1.0)
 
         scorer = autosklearn.metrics.make_scorer(
             'r2', sklearn.metrics.r2_score, greater_is_better=False)
 
-        loss = calculate_loss(
-            solution=y_true,
-            prediction=y_pred + 1.0,
-            task_type=REGRESSION,
-            metric=scorer,
-        )
-        # Optimum - sign * score = 1.0 - (-1) * (-9)
-        self.assertAlmostEqual(loss, -8.0)
+        score = scorer(y_true, y_pred + 1.0)
+        self.assertAlmostEqual(score, 9.0)
 
-        loss = calculate_loss(
-            solution=y_true,
-            prediction=y_pred + 0.5,
-            task_type=REGRESSION,
-            metric=scorer,
-        )
-        # Optimum - sign * score = 1.0 - (-1) * (-1.5)
-        self.assertAlmostEqual(loss, -0.5)
+        score = scorer(y_true, y_pred + 0.5)
+        self.assertAlmostEqual(score, 1.5)
 
-        loss = calculate_loss(
-            solution=y_true,
-            prediction=y_pred,
-            task_type=REGRESSION,
-            metric=scorer,
-        )
-        # Optimum - sign * score = 1.0 - (-1) * (1.0)
-        self.assertAlmostEqual(loss, 2.0)
+        score = scorer(y_true, y_pred)
+        self.assertAlmostEqual(score, -1.0)
 
 
 class TestMetricsDoNotAlterInput(unittest.TestCase):
@@ -365,60 +323,25 @@ class TestMetric(unittest.TestCase):
             y_true = np.array([1, 2, 3, 4])
             y_pred = y_true.copy()
             previous_score = scorer._optimum
-            previous_loss = scorer._optimum
             current_score = scorer(y_true, y_pred)
             self.assertAlmostEqual(current_score, previous_score)
 
             y_pred = np.array([3, 4, 5, 6])
             current_score = scorer(y_true, y_pred)
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-
-            # Loss should consistently be worst, the score is metric dependent
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
             if scorer.name == 'mean_squared_log_error':
                 continue
 
             y_pred = np.array([-1, 0, -1, 0])
             previous_score = current_score
-            previous_loss = current_loss
             current_score = scorer(y_true, y_pred)
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
             y_pred = np.array([-5, 10, 7, -3])
             previous_score = current_score
-            previous_loss = current_loss
             current_score = scorer(y_true, y_pred)
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
     def test_classification_binary(self):
 
@@ -436,70 +359,26 @@ class TestMetric(unittest.TestCase):
             y_pred = \
                 np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
             previous_score = scorer._optimum
-            previous_loss = 0  # Perfect result
             current_score = scorer(y_true, y_pred)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
             self.assertAlmostEqual(current_score, previous_score)
-            self.assertAlmostEqual(current_loss, previous_loss)
 
             y_pred = \
                 np.array([[0.0, 1.0], [1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0], [1.0, 0.0]])
             previous_score = current_score
-            previous_loss = current_loss
             current_score = scorer(y_true, y_pred)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-            # The score is metric dependent, the loss should consistently become worst
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
             y_pred = \
                 np.array([[0.0, 1.0], [1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0]])
             previous_score = current_score
-            previous_loss = current_loss
             current_score = scorer(y_true, y_pred)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-            # The score is metric dependent, the loss should consistently become worst
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
             y_pred = \
                 np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0]])
             previous_score = current_score
-            previous_loss = current_loss
             current_score = scorer(y_true, y_pred)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-            # The score is metric dependent, the loss should consistently become worst
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
     def test_classification_multiclass(self):
 
@@ -513,7 +392,6 @@ class TestMetric(unittest.TestCase):
             y_pred = np.array([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0],
                               [0.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
             previous_score = scorer._optimum
-            previous_loss = 0  # No loss as it is the perfect result
             current_score = scorer(y_true, y_pred)
             self.assertAlmostEqual(current_score, previous_score)
 
@@ -521,55 +399,19 @@ class TestMetric(unittest.TestCase):
                               [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
             previous_score = current_score
             current_score = scorer(y_true, y_pred)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-
-            # The score is metric dependent, the loss should consistently become worst
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
             y_pred = np.array([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0],
                               [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
             previous_score = current_score
-            previous_loss = current_loss
             current_score = scorer(y_true, y_pred)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-            # The score is metric dependent, the loss should consistently become worst
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
             y_pred = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0],
                               [1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
             previous_score = current_score
-            previous_loss = current_loss
             current_score = scorer(y_true, y_pred)
-            current_loss = calculate_loss(
-                solution=y_true,
-                prediction=y_pred,
-                task_type=REGRESSION,
-                metric=scorer,
-            )
-            # The score is metric dependent, the loss should consistently become worst
-            if scorer._sign > 0:
-                self.assertLess(current_score, previous_score)
-            else:
-                self.assertGreater(current_score, previous_score)
-            self.assertGreater(current_loss, previous_loss)
+            self.assertLess(current_score, previous_score)
 
             # less labels in the targets than in the predictions
             y_true = np.array([0.0, 0.0, 1.0, 1.0])


### PR DESCRIPTION
Enables calculate_loss which makes sure that all optimization problems are treated as minimization.

Please notice that calculate_score made it so that any call to functions like log_loss returned the result of a negative version of scikit learn log_loss. I have made it so that we return the score of scikit learn and only modify this score for calculate_loss. This implied changes in a couple of places of the testing code.