### PR TITLE
Pynisher context is passed to metafeatures

### DIFF
--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import logging
+import multiprocessing
 import os
 import time
 import traceback
@@ -29,6 +30,7 @@ from autosklearn.metalearning.mismbo import suggest_via_metalearning
 from autosklearn.data.abstract_data_manager import AbstractDataManager
 from autosklearn.evaluation import ExecuteTaFuncWithQueue, get_cost_of_crash
 from autosklearn.util.logging_ import get_named_client_logger
+from autosklearn.util.parallel import preload_modules
 from autosklearn.metalearning.metalearning.meta_base import MetaBase
 from autosklearn.metalearning.metafeatures.metafeatures import \
     calculate_all_metafeatures_with_labels, calculate_all_metafeatures_encoded_labels
@@ -339,9 +341,12 @@ class AutoMLSMBO(object):
         res = None
         time_limit = max(time_limit, 1)
         try:
+            context = multiprocessing.get_context(self.pynisher_context)
+            preload_modules(context)
             safe_mf = pynisher.enforce_limits(mem_in_mb=self.memory_limit,
                                               wall_time_in_s=int(time_limit),
                                               grace_period_in_s=30,
+                                              context=context,
                                               logger=self.logger)(
                 self._calculate_metafeatures)
             res = safe_mf()

--- a/test/test_optimizer/test_smbo.py
+++ b/test/test_optimizer/test_smbo.py
@@ -1,0 +1,65 @@
+import logging.handlers
+
+from ConfigSpace.configuration_space import Configuration
+
+import pytest
+
+import autosklearn.metrics
+from autosklearn.smbo import AutoMLSMBO
+import autosklearn.pipeline.util as putil
+from autosklearn.automl import AutoML
+from autosklearn.constants import BINARY_CLASSIFICATION
+from autosklearn.data.xy_data_manager import XYDataManager
+from autosklearn.util.stopwatch import StopWatch
+
+
+@pytest.mark.parametrize("context", ['fork', 'forkserver', 'spawn'])
+def test_smbo_metalearning_configurations(backend, context, dask_client):
+
+    # Get the inputs to the optimizer
+    X_train, Y_train, X_test, Y_test = putil.get_dataset('iris')
+    config_space = AutoML(backend=backend,
+                          metric=autosklearn.metrics.accuracy,
+                          time_left_for_this_task=20,
+                          per_run_time_limit=5).fit(
+                              X_train, Y_train,
+                              task=BINARY_CLASSIFICATION,
+                              only_return_configuration_space=True)
+    watcher = StopWatch()
+
+    # Create an optimizer
+    smbo = AutoMLSMBO(
+        config_space=config_space,
+        dataset_name='iris',
+        backend=backend,
+        total_walltime_limit=10,
+        func_eval_time_limit=5,
+        memory_limit=4096,
+        metric=autosklearn.metrics.accuracy,
+        watcher=watcher,
+        n_jobs=1,
+        dask_client=dask_client,
+        port=logging.handlers.DEFAULT_TCP_LOGGING_PORT,
+        start_num_run=1,
+        data_memory_limit=None,
+        num_metalearning_cfgs=25,
+        pynisher_context=context,
+    )
+    assert smbo.pynisher_context == context
+
+    # Create the inputs to metalearning
+    datamanager = XYDataManager(
+        X_train, Y_train,
+        X_test, Y_test,
+        task=BINARY_CLASSIFICATION,
+        dataset_name='iris',
+        feat_type=None,
+    )
+    backend.save_datamanager(datamanager)
+    smbo.task = BINARY_CLASSIFICATION
+    smbo.reset_data_manager()
+    metalearning_configurations = smbo.get_metalearning_suggestions()
+
+    # We should have 25 metalearning configurations
+    assert len(metalearning_configurations) == 25
+    assert [isinstance(config, Configuration) for config in metalearning_configurations]


### PR DESCRIPTION
This enables us to pass the context we use for pynisher (defined in automl) to the metalearning calculation in SMBO.

It also creates a test to make sure that metalearning works in any context.