### PR TITLE
#660 Enable Power Transformations Update

### DIFF
--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
@@ -1,0 +1,38 @@
+from scipy import sparse
+from autosklearn.pipeline.constants import *
+from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
+    import Rescaling
+from autosklearn.pipeline.components.base import \
+    AutoSklearnPreprocessingAlgorithm
+
+class PowerTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
+    def __init__(self, random_state):
+        from sklearn.preprocessing import PowerTransformer
+        self.preprocessor = PowerTransformer(copy=False)
+
+    @staticmethod
+    def get_properties(dataset_properties=None):
+        return {'shortname': 'PowerTransformer',
+                'name': 'PowerTransformer',
+                'handles_missing_values': False,
+                'handles_nominal_values': False,
+                'handles_numerical_features': True,
+                'prefers_data_scaled': False,
+                'prefers_data_normalized': False,
+                'handles_regression': True,
+                'handles_classification': True,
+                'handles_multiclass': True,
+                'handles_multilabel': True,
+                'is_deterministic': True,
+                # TODO find out of this is right!
+                'handles_sparse': True,
+                'handles_dense': True,
+                'input': (SPARSE, DENSE, UNSIGNED_DATA),
+                'output': (INPUT,),
+                'preferred_dtype': None}
+
+    def fit(self, X, y=None):
+        if sparse.isspmatrix(X):
+            self.preprocessor.set_params(standardize=False)
+
+        return super(PowerTransfomerComponent, self).fit(X, y)

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
@@ -1,7 +1,8 @@
-from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, INPUT, SPARSE
+from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, INPUT
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
+
 
 class PowerTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
     def __init__(self, random_state):

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
@@ -35,4 +35,4 @@ class PowerTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
         if sparse.isspmatrix(X):
             self.preprocessor.set_params(standardize=False)
 
-        return super(PowerTransfomerComponent, self).fit(X, y)
+        return super(PowerTransformerComponent, self).fit(X, y)

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
@@ -1,9 +1,7 @@
-from scipy import sparse
-from autosklearn.pipeline.constants import *
+from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, INPUT, SPARSE
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
-from autosklearn.pipeline.components.base import \
-    AutoSklearnPreprocessingAlgorithm
+from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 
 class PowerTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
     def __init__(self, random_state):
@@ -23,16 +21,11 @@ class PowerTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
                 'handles_classification': True,
                 'handles_multiclass': True,
                 'handles_multilabel': True,
+                'handles_multioutput': False,
                 'is_deterministic': True,
                 # TODO find out of this is right!
-                'handles_sparse': True,
+                'handles_sparse': False,
                 'handles_dense': True,
-                'input': (SPARSE, DENSE, UNSIGNED_DATA),
+                'input': (DENSE, UNSIGNED_DATA),
                 'output': (INPUT,),
                 'preferred_dtype': None}
-
-    def fit(self, X, y=None):
-        if sparse.isspmatrix(X):
-            self.preprocessor.set_params(standardize=False)
-
-        return super(PowerTransformerComponent, self).fit(X, y)

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
@@ -22,7 +22,7 @@ class PowerTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
                 'handles_classification': True,
                 'handles_multiclass': True,
                 'handles_multilabel': True,
-                'handles_multioutput': False,
+                'handles_multioutput': True,
                 'is_deterministic': True,
                 # TODO find out of this is right!
                 'handles_sparse': False,

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -421,7 +421,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         forbiddens = cs.get_forbiddens()
 
         self.assertEqual(len(cs.get_hyperparameter(
-            'data_preprocessing:numerical_transformer:rescaling:__choice__').choices), 6)
+            'data_preprocessing:numerical_transformer:rescaling:__choice__').choices), 7)
         self.assertEqual(len(cs.get_hyperparameter(
             'classifier:__choice__').choices), 16)
         self.assertEqual(len(cs.get_hyperparameter(


### PR DESCRIPTION
Enhances #660 so that testing is fixed and sparse component is removed (sparse is not supported in power transformer, due to check array ensuring dense data)