### PR TITLE
smbo error

### DIFF
--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -666,3 +666,9 @@ class AutoMLSMBO(object):
         if meta_features is None:
             metalearning_configurations = []
         return metalearning_configurations
+
+    def __getstate__(self) -> typing.Dict[str, typing.Any]:
+        # Cannot serialize a client!
+        state_dict = {key: val for key, val in self.__dict__.items()
+                      if key not in ['dask_client', 'get_smac_object_callback']}
+        return state_dict


### PR DESCRIPTION
# What?
I am seeing the following error when running autosklearn in parallel:

```
[ERROR] [2021-04-01 23:41:49,304:Client-AutoMLSMBO(12)::breast_cancer] Error getting metafeatures: Can't pickle local object 'Client.__init__.<locals>.<lambda>'
```
I think it is coming from this [line](https://github.com/automl/auto-sklearn/blob/25d680d4e9520a661aae48ea4c7295c663b64df3/autosklearn/smbo.py#L351), when on the spawn context the smbo object is passed to dask workers.

We should not pass the dask client.

# Proposed fix

To use the get state workaround where we skip the dask client. We also skip the get_smac_object_callback because local functions cannot be pickled. Note, this only affects a copy of smbo sent to a worker to calculate metafeatures.
