### PR TITLE
FIX: iterative CV

### DIFF
--- a/autosklearn/evaluation/train_evaluator.py
+++ b/autosklearn/evaluation/train_evaluator.py
@@ -386,10 +386,12 @@ class TrainEvaluator(AbstractEvaluator):
 
                     # Compute weights of each fold based on the number of samples in each
                     # fold.
-                    train_fold_weights = [w / sum(train_fold_weights)
-                                          for w in train_fold_weights]
-                    opt_fold_weights = [w / sum(opt_fold_weights)
-                                        for w in opt_fold_weights]
+                    train_fold_weights_percentage = [
+                        w / sum(train_fold_weights) for w in train_fold_weights
+                    ]
+                    opt_fold_weights_percentage = [
+                        w / sum(opt_fold_weights) for w in opt_fold_weights
+                    ]
 
                     # train_losses is a list of either scalars or dicts. If it contains
                     # dicts, then train_loss is computed using the target metric
@@ -397,10 +399,10 @@ class TrainEvaluator(AbstractEvaluator):
                     if all(isinstance(elem, dict) for elem in train_losses):
                         train_loss = np.average([train_losses[i][str(self.metric)]
                                                  for i in range(self.num_cv_folds)],
-                                                weights=train_fold_weights,
+                                                weights=train_fold_weights_percentage,
                                                 )
                     else:
-                        train_loss = np.average(train_losses, weights=train_fold_weights)
+                        train_loss = np.average(train_losses, weights=train_fold_weights_percentage)
 
                     # if all_scoring_function is true, return a dict of opt_loss.
                     # Otherwise, return a scalar.
@@ -412,10 +414,10 @@ class TrainEvaluator(AbstractEvaluator):
                                     opt_losses[i][metric]
                                     for i in range(self.num_cv_folds)
                                 ],
-                                weights=opt_fold_weights,
+                                weights=opt_fold_weights_percentage,
                             )
                     else:
-                        opt_loss = np.average(opt_losses, weights=opt_fold_weights)
+                        opt_loss = np.average(opt_losses, weights=opt_fold_weights_percentage)
 
                     Y_targets = self.Y_targets
                     Y_train_targets = self.Y_train_targets


### PR DESCRIPTION
This PR fixes a weird edge case in iterative CV: Assume we have 3 folds. Two folds converge early on to a bad score and are terminated via early stopping, while the 3rd fold goes on and reaches a really good score. Due to a bug, Auto-sklearn would ignore the bad scores and report this unstable configuration as a really good one. This PR correctly computes the average of the scores.

Can be approximately reproduced via:
```
if __name__ == '__main__':

    import sys
    import autosklearn.metrics
    from autosklearn.classification import AutoSklearnClassifier

    sys.path.append('../scripts')
    from update_metadata_util import load_task

    X_train, y_train, X_test, y_test, cat, task_type, dataset_name = load_task(189905)

    automl = AutoSklearnClassifier(
        per_run_time_limit=360,
        metric=autosklearn.metrics.balanced_accuracy,
    )

    # config = {
    #   "balancing:strategy": "weighting",
    #   "classifier:__choice__": "gradient_boosting",
    #   "data_preprocessing:categorical_transformer:categorical_encoding:__choice__": "no_encoding",
    #   "data_preprocessing:categorical_transformer:category_coalescence:__choice__": "minority_coalescer",
    #   "data_preprocessing:numerical_transformer:imputation:strategy": "most_frequent",
    #   "data_preprocessing:numerical_transformer:rescaling:__choice__": "robust_scaler",
    #   "feature_preprocessor:__choice__": "no_preprocessing",
    #   "classifier:gradient_boosting:early_stop": "train",
    #   "classifier:gradient_boosting:l2_regularization": 5.205915999429948e-09,
    #   "classifier:gradient_boosting:learning_rate": 0.861159596651958,
    #   "classifier:gradient_boosting:loss": "auto",
    #   "classifier:gradient_boosting:max_bins": 255,
    #   "classifier:gradient_boosting:max_depth": "None",
    #   "classifier:gradient_boosting:max_leaf_nodes": 195,
    #   "classifier:gradient_boosting:min_samples_leaf": 16,
    #   "classifier:gradient_boosting:scoring": "loss",
    #   "classifier:gradient_boosting:tol": 1e-07,
    #   "data_preprocessing:categorical_transformer:category_coalescence:minority_coalescer:minimum_fraction": 0.06191658766042969,
    #   "data_preprocessing:numerical_transformer:rescaling:robust_scaler:q_max": 0.7493495185188641,
    #   "data_preprocessing:numerical_transformer:rescaling:robust_scaler:q_min": 0.2995969400106461,
    #   "classifier:gradient_boosting:n_iter_no_change": 19
    # }
    config = {
      "balancing:strategy": "weighting",
      "classifier:__choice__": "gradient_boosting",
      "data_preprocessing:categorical_transformer:categorical_encoding:__choice__": "no_encoding",
      "data_preprocessing:categorical_transformer:category_coalescence:__choice__": "minority_coalescer",
      "data_preprocessing:numerical_transformer:imputation:strategy": "median",
      "data_preprocessing:numerical_transformer:rescaling:__choice__": "robust_scaler",
      "feature_preprocessor:__choice__": "no_preprocessing",
      "classifier:gradient_boosting:early_stop": "train",
      "classifier:gradient_boosting:l2_regularization": 5.205915999429948e-09,
      "classifier:gradient_boosting:learning_rate": 0.861159596651958,
      "classifier:gradient_boosting:loss": "auto",
      "classifier:gradient_boosting:max_bins": 255,
      "classifier:gradient_boosting:max_depth": "None",
      "classifier:gradient_boosting:max_leaf_nodes": 204,
      "classifier:gradient_boosting:min_samples_leaf": 16,
      "classifier:gradient_boosting:scoring": "loss",
      "classifier:gradient_boosting:tol": 1e-07,
      "data_preprocessing:categorical_transformer:category_coalescence:minority_coalescer:minimum_fraction": 0.0668155830580962,
      "data_preprocessing:numerical_transformer:rescaling:robust_scaler:q_max": 0.7495444113816928,
      "data_preprocessing:numerical_transformer:rescaling:robust_scaler:q_min": 0.2995969400106461,
      "classifier:gradient_boosting:n_iter_no_change": 20
    }

    pipeline, run_info, run_value = automl.fit_pipeline(
        X=X_train,
        y=y_train,
        dataset_name=dataset_name,
        resampling_strategy='cv-iterative-fit',
        folds=3,
        feat_type=cat,
        X_test=X_test,
        y_test=y_test,
        pynisher_context='spawn',
        cutoff=3600,
        config=config,
        disable_file_output=True,
    )
    print(pipeline)
    print(run_info)
    print(run_value)
```