### PR TITLE
[Fix] stale only-labels

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,5 +18,5 @@ jobs:
           close-issue-message: >
             This issue has been automatically closed due to inactivity.
           stale-issue-label: 'stale'
-          only-issue-labels: 'Answered,Feedback-Required,invalid,wontfix'
+          exempt-issue-labels: 'bug,document-this,enhancement,help-wanted,Need-contributor'
           exempt-all-milestones: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,5 +18,7 @@ jobs:
           close-issue-message: >
             This issue has been automatically closed due to inactivity.
           stale-issue-label: 'stale'
-          exempt-issue-labels: 'bug,document-this,enhancement,help-wanted,Need-contributor'
+          # Only issues with ANY of these labels are checked.
+          # Separate multiple labels with commas (eg. "incomplete,waiting-feedback").
+          any-of-issue-labels: 'Answered,Feedback-Required,invalid,wontfix'
           exempt-all-milestones: true

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import sklearn.datasets
-from sklearn.base import clone
 from smac.scenario.scenario import Scenario
 from smac.facade.roar_facade import ROAR
 
@@ -426,16 +425,6 @@ def test_do_dummy_prediction(backend, dask_client, datasets):
         backend.temporary_directory, '.auto-sklearn', 'runs', '1_1_0.0',
         'predictions_ensemble_1_1_0.0.npy')
     )
-
-    model_path = os.path.join(backend.temporary_directory, '.auto-sklearn',
-                              'runs', '1_1_0.0',
-                              '1.1.0.0.model')
-
-    # Make sure the dummy model complies with scikit learn
-    # get/set params
-    assert os.path.exists(model_path)
-    with open(model_path, 'rb') as model_handler:
-        clone(pickle.load(model_handler))
 
     auto._clean_logger()
 

--- a/test/test_evaluation/test_dummy_pipelines.py
+++ b/test/test_evaluation/test_dummy_pipelines.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+import pytest
+
+from sklearn.base import clone
+from sklearn.datasets import make_classification, make_regression
+from sklearn.utils.validation import check_is_fitted
+
+from autosklearn.evaluation.abstract_evaluator import MyDummyClassifier, MyDummyRegressor
+
+
+@pytest.mark.parametrize("task_type", ['classification', 'regression'])
+def test_dummy_pipeline(task_type):
+    if task_type == 'classification':
+        estimator_class = MyDummyClassifier
+        data_maker = make_classification
+    elif task_type == 'regression':
+        estimator_class = MyDummyRegressor
+        data_maker = make_regression
+    else:
+        pytest.fail(task_type)
+
+    estimator = estimator_class(config=1, random_state=np.random.RandomState(42))
+    X, y = data_maker()
+    estimator.fit(X, y)
+    check_is_fitted(estimator)
+
+    assert np.shape(X)[0] == np.shape(estimator.predict(X))[0]
+
+    # make sure we comply with scikit-learn estimator API
+    clone(estimator)


### PR DESCRIPTION
Only labels was misunderstood on my part:
```
# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
```

All the labels have to be present. There is support to except labels [here](https://github.com/probot/stale).

This works as showed here:
- Unlabeled: https://github.com/franchuterivera/auto-sklearn/issues/9#issuecomment-824492286
- Labeled (ignored as it has bug): https://github.com/franchuterivera/auto-sklearn/issues/11