### PR TITLE
Simplify InputValidator: Allows pandas frame to directly reach the pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,10 @@ repos:
         args: [--show-error-codes]
         name: mypy auto-sklearn-evaluation
         files: autosklearn/evaluation
+      - id: mypy
+        args: [--show-error-codes]
+        name: mypy auto-sklearn-datapreprocessing
+        files: autosklearn/pipeline/components/data_preprocessing/
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -537,10 +537,8 @@ class AutoML(BaseEstimator):
         self._dataset_name = dataset_name
         self._stopwatch.start_task(self._dataset_name)
 
-        if feat_type is None and self.InputValidator.feature_validator.feat_type:
-            self._feat_type = self.InputValidator.feature_validator.feat_type
-        elif feat_type is not None:
-            self._feat_type = feat_type
+        # Take the feature types from the validator
+        self._feat_type = self.InputValidator.feature_validator.feat_type
 
         # Produce debug information to the logfile
         self._logger.debug('Starting to print environment information')

--- a/autosklearn/data/abstract_data_manager.py
+++ b/autosklearn/data/abstract_data_manager.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, List
+from typing import Any, Dict, Union
 
 import numpy as np
 
@@ -31,11 +31,11 @@ class AbstractDataManager():
         return self._info
 
     @property
-    def feat_type(self) -> List[str]:
+    def feat_type(self) -> Dict[Union[str, int], str]:
         return self._feat_type
 
     @feat_type.setter
-    def feat_type(self, value: List[str]) -> None:
+    def feat_type(self, value: Dict[Union[str, int], str]) -> None:
         self._feat_type = value
 
     @property

--- a/autosklearn/data/abstract_data_manager.py
+++ b/autosklearn/data/abstract_data_manager.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import numpy as np
 
@@ -7,35 +7,6 @@ import scipy.sparse
 
 from autosklearn.pipeline.components.data_preprocessing.data_preprocessing \
     import DataPreprocessor
-from autosklearn.util.data import predict_RAM_usage
-
-
-def perform_one_hot_encoding(
-    sparse: bool,
-    categorical: List[bool],
-    data: List
-) -> Tuple[List, bool]:
-    predicted_RAM_usage = float(
-        predict_RAM_usage(data[0], categorical)) / 1024 / 1024
-
-    if predicted_RAM_usage > 1000:
-        sparse = True
-
-    rvals = []
-    if any(categorical):
-        encoder = DataPreprocessor(
-            feat_type=categorical, force_sparse_output=sparse)
-        rvals.append(encoder.fit_transform(data[0]))
-        for d in data[1:]:
-            rvals.append(encoder.transform(d))
-
-        if not sparse and scipy.sparse.issparse(rvals[0]):
-            for i in range(len(rvals)):
-                rvals[i] = rvals[i].todense()
-    else:
-        rvals = data
-
-    return rvals, sparse
 
 
 class AbstractDataManager():

--- a/autosklearn/data/abstract_data_manager.py
+++ b/autosklearn/data/abstract_data_manager.py
@@ -24,7 +24,7 @@ def perform_one_hot_encoding(
     rvals = []
     if any(categorical):
         encoder = DataPreprocessor(
-            categorical_features=categorical, force_sparse_output=sparse)
+            feat_type=categorical, force_sparse_output=sparse)
         rvals.append(encoder.fit_transform(data[0]))
         for d in data[1:]:
             rvals.append(encoder.transform(d))

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -186,9 +186,9 @@ class FeatureValidator(BaseEstimator):
         # Not all sparse format support index sorting
         if scipy.sparse.issparse(X):
             if not isinstance(X, scipy.sparse.csr_matrix):
-                self.logger.warning(f"Original features provided where of type {type(X)} "
-                                    "yet Auto-Sklearn support csr_matrix. Auto-sklearn "
-                                    "will convert the provide features to csr_matrix format.")
+                self.logger.warning(f"Sparse data provided is of type {type(X)} "
+                                    "yet Auto-Sklearn only support csr_matrix. Auto-sklearn "
+                                    "will convert the provided data to the csr_matrix format.")
                 X = X.tocsr(copy=False)
             if hasattr(X, 'sort_indices'):
                 X.sort_indices()

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -208,6 +208,12 @@ class FeatureValidator(BaseEstimator):
                 checks) and a encoder fitted in the case the data needs encoding
         """
 
+        # We consider columns that are all nan in a pandas frame as category
+        if hasattr(X, 'columns'):
+            for column in X.columns:
+                if X[column].isna().all():
+                    X[column] = X[column].astype('category')
+
         if not isinstance(X, (np.ndarray, pd.DataFrame)) and not scipy.sparse.issparse(X):
             raise ValueError("Auto-sklearn only supports Numpy arrays, Pandas DataFrames,"
                              " scipy sparse and Python Lists, yet, the provided input is"

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -37,9 +37,15 @@ class FeatureValidator(BaseEstimator):
 
     Attributes
     ----------
-        feat_type: typing.Optional[typing.Dict[Union[str, int], str]]
-            In case the data is not a pandas DataFrame, this list indicates
-            which columns should be treated as categorical
+        feat_type: typing.Optional[typing.List[str]]
+            In case the dataset is not a pandas DataFrame:
+                + If provided, this list indicates which columns should be treated as categorical
+                  it is internally transformed into a dictionary that indicates a mapping from
+                  column index to categorical/numerical
+                + If not provided, by default all columns are treated as numerical
+            If the input dataset is of type pandas dataframe, this argument
+            must be none, as the column type will be inferred from the pandas dtypes.
+
         data_type:
             Class name of the data type provided during fit.
     """

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -59,14 +59,17 @@ class FeatureValidator(BaseEstimator):
             typing.Dict[typing.Union[str, int], str]
         ] = None
         if feat_type is not None:
-            if not isinstance(feat_type, list):
+            if isinstance(feat_type, dict):
+                self.feat_type = feat_type
+            elif not isinstance(feat_type, list):
                 raise ValueError("Auto-Sklearn expects a list of categorical/"
                                  "numerical feature types, yet a"
                                  " {} was provided".format(type(feat_type)))
+            else:
 
-            # Convert to a dictionary which will be passed to the ColumnTransformer
-            # Column Transformer supports strings or integer indexes
-            self.feat_type = {i: feat for i, feat in enumerate(feat_type)}
+                # Convert to a dictionary which will be passed to the ColumnTransformer
+                # Column Transformer supports strings or integer indexes
+                self.feat_type = {i: feat for i, feat in enumerate(feat_type)}
 
         # Register types to detect unsupported data format changes
         self.data_type = None  # type: typing.Optional[type]
@@ -127,7 +130,9 @@ class FeatureValidator(BaseEstimator):
                                      'variables as X has features. %d vs %d.' %
                                      (len(self.feat_type), np.shape(X_train)[1]))
                 if not all([isinstance(f, str) for f in self.feat_type.values()]):
-                    raise ValueError('Array feat_type must only contain strings.')
+                    raise ValueError("feat_type must only contain strings: {}".format(
+                        list(self.feat_type.values()),
+                    ))
 
                 for ft in self.feat_type.values():
                     if ft.lower() not in ['categorical', 'numerical']:

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -4,7 +4,7 @@ import typing
 import numpy as np
 
 import pandas as pd
-from pandas.api.types import is_numeric_dtype
+from pandas.api.types import is_numeric_dtype, is_sparse
 
 import scipy.sparse
 
@@ -285,6 +285,9 @@ class FeatureValidator(BaseEstimator):
             if X[column].dtype.name in ['category', 'bool']:
 
                 feat_type[column] = 'categorical'
+            elif is_sparse(X[column]):
+                raise ValueError("Auto-sklearn does not yet support sparse pandas Series."
+                                 f" Please convert {column} to a dense format.")
             # Move away from np.issubdtype as it causes
             # TypeError: data type not understood in certain pandas types
             elif not is_numeric_dtype(X[column]):

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -282,12 +282,12 @@ class FeatureValidator(BaseEstimator):
 
         # Make sure each column is a valid type
         for i, column in enumerate(X.columns):
-            if X[column].dtype.name in ['category', 'bool']:
-
-                feat_type[column] = 'categorical'
-            elif is_sparse(X[column]):
+            if is_sparse(X[column]):
                 raise ValueError("Auto-sklearn does not yet support sparse pandas Series."
                                  f" Please convert {column} to a dense format.")
+            elif X[column].dtype.name in ['category', 'bool']:
+
+                feat_type[column] = 'categorical'
             # Move away from np.issubdtype as it causes
             # TypeError: data type not understood in certain pandas types
             elif not is_numeric_dtype(X[column]):

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -93,6 +93,8 @@ class FeatureValidator(BaseEstimator):
         if isinstance(X_train, list):
             X_train, X_test = self.list_to_dataframe(X_train, X_test)
 
+        self._check_data(X_train)
+
         # Handle categorical feature identification for the pipeline
         if hasattr(X_train, "iloc"):
             if self.feat_type is not None:
@@ -125,8 +127,6 @@ class FeatureValidator(BaseEstimator):
                     if ft.lower() not in ['categorical', 'numerical']:
                         raise ValueError('Only `Categorical` and `Numerical` are '
                                          'valid feature types, you passed `%s`' % ft)
-
-        self._check_data(X_train)
 
         if X_test is not None:
             self._check_data(X_test)
@@ -249,7 +249,8 @@ class FeatureValidator(BaseEstimator):
 
             if len(feat_type) > 0:
                 if np.any(pd.isnull(
-                    X[list(feat_type.keys())].dropna(  # type: ignore[call-overload]
+                    X[[key for key, value in feat_type.items() if value == 'categorical']
+                      ].dropna(  # type: ignore[call-overload]
                         axis='columns', how='all')
                 )):
                     # Ignore all NaN columns, and if still a NaN

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 import typing
 
@@ -9,10 +8,7 @@ from pandas.api.types import is_numeric_dtype
 
 import scipy.sparse
 
-import sklearn.utils
-from sklearn import preprocessing
 from sklearn.base import BaseEstimator
-from sklearn.compose import make_column_transformer
 from sklearn.exceptions import NotFittedError
 
 from autosklearn.util.logging_ import PickableLoggerAdapter
@@ -34,40 +30,41 @@ SUPPORTED_FEAT_TYPES = typing.Union[
 
 class FeatureValidator(BaseEstimator):
     """
-    A class to pre-process features. In this regards, the format of the data is checked,
-    and if applicable, features are encoded
+    Checks the input data to Auto-Sklearn.
+
+    It also determines what columns are categorical and which ones are numerical,
+    so that the pre-processing pipeline can process this columns accordingly.
+
     Attributes
     ----------
-        feat_type: typing.Optional[typing.List[str]]
+        feat_type: typing.Optional[typing.Dict[Union[str, int], str]]
             In case the data is not a pandas DataFrame, this list indicates
             which columns should be treated as categorical
         data_type:
             Class name of the data type provided during fit.
-        encoder: typing.Optional[BaseEstimator]
-            Host a encoder object if the data requires transformation (for example,
-            if provided a categorical column in a pandas DataFrame)
-        enc_columns: typing.List[str]
-            List of columns that where encoded
     """
     def __init__(self,
                  feat_type: typing.Optional[typing.List[str]] = None,
                  logger: typing.Optional[PickableLoggerAdapter] = None,
                  ) -> None:
         # If a dataframe was provided, we populate
-        # this attribute with the column types from the dataframe
-        # That is, this attribute contains whether autosklearn
-        # should treat a column as categorical or numerical
-        # During fit, if the user provided feat_types, the user
-        # constrain is honored. If not, this attribute is used.
-        self.feat_type = feat_type  # type: typing.Optional[typing.List[str]]
+        # this attribute with a mapping from column to {numerical | categorical}
+        self.feat_type: typing.Optional[
+            typing.Dict[typing.Union[str, int], str]
+        ] = None
+        if feat_type is not None:
+            if not isinstance(feat_type, list):
+                raise ValueError("Auto-Sklearn expects a list of categorical/"
+                                 "numerical feature types, yet a"
+                                 " {} was provided".format(type(feat_type)))
+
+            # Convert to a dictionary which will be passed to the ColumnTransformer
+            # Column Transformer supports strings or integer indexes
+            self.feat_type = {i: feat for i, feat in enumerate(feat_type)}
 
         # Register types to detect unsupported data format changes
         self.data_type = None  # type: typing.Optional[type]
         self.dtypes = []  # type: typing.List[str]
-        self.column_order = []  # type: typing.List[str]
-
-        self.encoder = None  # type: typing.Optional[BaseEstimator]
-        self.enc_columns = []  # type: typing.List[str]
 
         self.logger = logger if logger is not None else logging.getLogger(__name__)
 
@@ -79,26 +76,26 @@ class FeatureValidator(BaseEstimator):
         X_test: typing.Optional[SUPPORTED_FEAT_TYPES] = None,
     ) -> BaseEstimator:
         """
-        Validates and fit a categorical encoder (if needed) to the features.
+        Validates input data to Auto-Sklearn.
         The supported data types are List, numpy arrays and pandas DataFrames.
         CSR sparse data types are also supported
 
         Parameters
         ----------
-            X_train: SUPPORTED_FEAT_TYPES
-                A set of features that are going to be validated (type and dimensionality
-                checks) and a encoder fitted in the case the data needs encoding
-            X_test: typing.Optional[SUPPORTED_FEAT_TYPES]
-                A hold out set of data used for checking
+        X_train: SUPPORTED_FEAT_TYPES
+            A set of features that are going to be validated (type and dimensionality
+            checks) and a encoder fitted in the case the data needs encoding
+        X_test: typing.Optional[SUPPORTED_FEAT_TYPES]
+            A hold out set of data used for checking
         """
 
         # If a list was provided, it will be converted to pandas
         if isinstance(X_train, list):
             X_train, X_test = self.list_to_dataframe(X_train, X_test)
 
-        # Register the user provided feature types
-        if self.feat_type is not None:
-            if hasattr(X_train, "iloc"):
+        # Handle categorical feature identification for the pipeline
+        if hasattr(X_train, "iloc"):
+            if self.feat_type is not None:
                 raise ValueError("When providing a DataFrame to Auto-Sklearn, we extract "
                                  "the feature types from the DataFrame.dtypes. That is, "
                                  "providing the option feat_type to the fit method is not "
@@ -108,18 +105,26 @@ class FeatureValidator(BaseEstimator):
                                  "DataFrame can be seen in "
                                  "https://pandas.pydata.org/pandas-docs/stable/reference"
                                  "/api/pandas.DataFrame.astype.html")
-            # Some checks if self.feat_type is provided
-            if len(self.feat_type) != np.shape(X_train)[1]:
-                raise ValueError('Array feat_type does not have same number of '
-                                 'variables as X has features. %d vs %d.' %
-                                 (len(self.feat_type), np.shape(X_train)[1]))
-            if not all([isinstance(f, str) for f in self.feat_type]):
-                raise ValueError('Array feat_type must only contain strings.')
+            else:
+                self.feat_type = self.get_feat_type_from_columns(X_train)
+        else:
+            # Numpy array was provided
+            if self.feat_type is None:
+                # Assume numerical columns if a numpy array has no feature types
+                self.feat_type = {i: 'numerical' for i in range(np.shape(X_train)[1])}
+            else:
+                # Check The feat type provided
+                if len(self.feat_type) != np.shape(X_train)[1]:
+                    raise ValueError('Array feat_type does not have same number of '
+                                     'variables as X has features. %d vs %d.' %
+                                     (len(self.feat_type), np.shape(X_train)[1]))
+                if not all([isinstance(f, str) for f in self.feat_type.values()]):
+                    raise ValueError('Array feat_type must only contain strings.')
 
-            for ft in self.feat_type:
-                if ft.lower() not in ['categorical', 'numerical']:
-                    raise ValueError('Only `Categorical` and `Numerical` are '
-                                     'valid feature types, you passed `%s`' % ft)
+                for ft in self.feat_type.values():
+                    if ft.lower() not in ['categorical', 'numerical']:
+                        raise ValueError('Only `Categorical` and `Numerical` are '
+                                         'valid feature types, you passed `%s`' % ft)
 
         self._check_data(X_train)
 
@@ -133,75 +138,8 @@ class FeatureValidator(BaseEstimator):
                                      np.shape(X_test)[1]
                                  ))
 
-        # Fit on the training data
-        self._fit(X_train)
-
         self._is_fitted = True
 
-        return self
-
-    def _fit(
-        self,
-        X: SUPPORTED_FEAT_TYPES,
-    ) -> BaseEstimator:
-        """
-        In case input data is a pandas DataFrame, this utility encodes the user provided
-        features (from categorical for example) to a numerical value that further stages
-        will be able to use
-
-        Parameters
-        ----------
-            X: SUPPORTED_FEAT_TYPES
-                A set of features that are going to be validated (type and dimensionality
-                checks) and a encoder fitted in the case the data needs encoding
-        """
-        if hasattr(X, "iloc") and not scipy.sparse.issparse(X):
-            X = typing.cast(pd.DataFrame, X)
-            # Treat a column with all instances a NaN as numerical
-            # This will prevent doing encoding to a categorical column made completely
-            # out of nan values -- which will trigger a fail, as encoding is not supported
-            # with nan values.
-            # Columns that are completely made of NaN values are provided to the pipeline
-            # so that later stages decide how to handle them
-            if np.any(pd.isnull(X)):
-                for column in X.columns:
-                    if X[column].isna().all():
-                        X[column] = pd.to_numeric(X[column])
-
-            self.enc_columns, self.feat_type = self._get_columns_to_encode(X)
-
-            if len(self.enc_columns) > 0:
-
-                self.encoder = make_column_transformer(
-                    (preprocessing.OrdinalEncoder(
-                        handle_unknown='use_encoded_value',
-                        unknown_value=-1,
-                    ), self.enc_columns),
-                    remainder="passthrough"
-                )
-
-                # Mypy redefinition
-                assert self.encoder is not None
-                self.encoder.fit(X)
-
-                # The column transformer reoders the feature types - we therefore need to change
-                # it as well
-                def comparator(cmp1: str, cmp2: str) -> int:
-                    if (
-                        cmp1 == 'categorical' and cmp2 == 'categorical'
-                        or cmp1 == 'numerical' and cmp2 == 'numerical'
-                    ):
-                        return 0
-                    elif cmp1 == 'categorical' and cmp2 == 'numerical':
-                        return -1
-                    elif cmp1 == 'numerical' and cmp2 == 'categorical':
-                        return 1
-                    else:
-                        raise ValueError((cmp1, cmp2))
-                self.feat_type = sorted(
-                    self.feat_type,
-                    key=functools.cmp_to_key(comparator)
-                )
         return self
 
     def transform(
@@ -241,7 +179,7 @@ class FeatureValidator(BaseEstimator):
         self._check_data(X)
 
         # Pandas related transformations
-        if hasattr(X, "iloc") and self.encoder is not None:
+        if hasattr(X, "iloc"):
             if np.any(pd.isnull(X)):
                 # After above check it means that if there is a NaN
                 # the whole column must be NaN
@@ -249,18 +187,12 @@ class FeatureValidator(BaseEstimator):
                 for column in X.columns:
                     if X[column].isna().all():
                         X[column] = pd.to_numeric(X[column])
-            X = self.encoder.transform(X)
 
         # Sparse related transformations
         # Not all sparse format support index sorting
         if scipy.sparse.issparse(X) and hasattr(X, 'sort_indices'):
             X.sort_indices()
-
-        return sklearn.utils.check_array(
-            X,
-            force_all_finite=False,
-            accept_sparse='csr'
-        )
+        return X
 
     def _check_data(
         self,
@@ -285,6 +217,7 @@ class FeatureValidator(BaseEstimator):
 
         if self.data_type is None:
             self.data_type = type(X)
+
         if self.data_type != type(X):
             self.logger.warning("Auto-sklearn previously received features of type %s "
                                 "yet the current features have type %s. Changing the dtype "
@@ -312,11 +245,11 @@ class FeatureValidator(BaseEstimator):
 
             # Define the column to be encoded here as the feature validator is fitted once
             # per estimator
-            enc_columns, _ = self._get_columns_to_encode(X)
+            feat_type = self.get_feat_type_from_columns(X)
 
-            if len(enc_columns) > 0:
+            if len(feat_type) > 0:
                 if np.any(pd.isnull(
-                    X[enc_columns].dropna(  # type: ignore[call-overload]
+                    X[list(feat_type.keys())].dropna(  # type: ignore[call-overload]
                         axis='columns', how='all')
                 )):
                     # Ignore all NaN columns, and if still a NaN
@@ -327,17 +260,7 @@ class FeatureValidator(BaseEstimator):
                                      "limitation on scikit-learn being addressed via: "
                                      "https://github.com/scikit-learn/scikit-learn/issues/17123)"
                                      )
-            column_order = [column for column in X.columns]
-            if len(self.column_order) > 0:
-                if self.column_order != column_order:
-                    raise ValueError("Changing the column order of the features after fit() is "
-                                     "not supported. Fit() method was called with "
-                                     "{} whereas the new features have {} as type".format(
-                                        self.column_order,
-                                        column_order,
-                                     ))
-            else:
-                self.column_order = column_order
+
             dtypes = [dtype.name for dtype in X.dtypes]
             if len(self.dtypes) > 0:
                 if self.dtypes != dtypes:
@@ -350,12 +273,13 @@ class FeatureValidator(BaseEstimator):
             else:
                 self.dtypes = dtypes
 
-    def _get_columns_to_encode(
+    def get_feat_type_from_columns(
         self,
         X: pd.DataFrame,
-    ) -> typing.Tuple[typing.List[str], typing.List[str]]:
+    ) -> typing.Dict[typing.Union[str, int], str]:
         """
-        Return the columns to be encoded from a pandas dataframe
+        Returns a dictionary that maps pandas dataframe columns to a feature type.
+        This feature type can be categorical or numerical
 
         Parameters
         ----------
@@ -364,23 +288,29 @@ class FeatureValidator(BaseEstimator):
                 checks) and a encoder fitted in the case the data needs encoding
         Returns
         -------
-            enc_columns:
-                Columns to encode, if any
             feat_type:
-                Type of each column numerical/categorical
+                dictionary with column to feature type mapping
         """
-        # Register if a column needs encoding
-        enc_columns = []
+
+        # Treat a column with all instances a NaN as numerical
+        # This will prevent doing encoding to a categorical column made completely
+        # out of nan values -- which will trigger a fail, as encoding is not supported
+        # with nan values.
+        # Columns that are completely made of NaN values are provided to the pipeline
+        # so that later stages decide how to handle them
+        if np.any(pd.isnull(X)):
+            for column in X.columns:
+                if X[column].isna().all():
+                    X[column] = pd.to_numeric(X[column])
 
         # Also, register the feature types for the estimator
-        feat_type = []
+        feat_type = {}
 
         # Make sure each column is a valid type
         for i, column in enumerate(X.columns):
             if X[column].dtype.name in ['category', 'bool']:
 
-                enc_columns.append(column)
-                feat_type.append('categorical')
+                feat_type[column] = 'categorical'
             # Move away from np.issubdtype as it causes
             # TypeError: data type not understood in certain pandas types
             elif not is_numeric_dtype(X[column]):
@@ -419,8 +349,8 @@ class FeatureValidator(BaseEstimator):
                         )
                     )
             else:
-                feat_type.append('numerical')
-        return enc_columns, feat_type
+                feat_type[column] = 'numerical'
+        return feat_type
 
     def list_to_dataframe(
         self,

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -210,7 +210,7 @@ class FeatureValidator(BaseEstimator):
 
         # We consider columns that are all nan in a pandas frame as category
         if hasattr(X, 'columns'):
-            for column in X.columns:
+            for column in typing.cast(pd.DataFrame, X).columns:
                 if X[column].isna().all():
                     X[column] = X[column].astype('category')
 

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -23,8 +23,13 @@ class InputValidator(BaseEstimator):
     Attributes
     ----------
         feat_type: typing.Optional[typing.List[str]]
-            In case the data is not a pandas DataFrame, this list indicates
-            which columns should be treated as categorical
+            In case the dataset is not a pandas DataFrame:
+                + If provided, this list indicates which columns should be treated as categorical
+                  it is internally transformed into a dictionary that indicates a mapping from
+                  column index to categorical/numerical
+                + If not provided, by default all columns are treated as numerical
+            If the input dataset is of type pandas dataframe, this argument
+            must be none, as the column type will be inferred from the pandas dtypes.
         is_classification: bool
             For classification task, this flag indicates that the target data
             should be encoded

--- a/autosklearn/data/xy_data_manager.py
+++ b/autosklearn/data/xy_data_manager.py
@@ -35,7 +35,10 @@ class XYDataManager(AbstractDataManager):
             self.info['has_missing'] = np.all(np.isfinite(X.data))
         else:
             self.info['is_sparse'] = 0
-            self.info['has_missing'] = np.all(np.isfinite(X))
+            if hasattr(X, 'iloc'):
+                self.info['has_missing'] = X.isnull().values.any()
+            else:
+                self.info['has_missing'] = np.all(np.isfinite(X))
 
         label_num = {
             REGRESSION: 1,
@@ -54,14 +57,10 @@ class XYDataManager(AbstractDataManager):
         if y_test is not None:
             self.data['Y_test'] = y_test
 
-        if feat_type is not None:
-            for feat in feat_type:
-                allowed_types = ['numerical', 'categorical']
-                if feat.lower() not in allowed_types:
-                    raise ValueError("Entry '%s' in feat_type not in %s" %
-                                     (feat.lower(), str(allowed_types)))
-
-        self.feat_type = feat_type
+        if feat_type is None:
+            self.feat_type = {i: 'Numerical' for i in range(np.shape(X)[1])}
+        else:
+            self.feat_type = feat_type
 
         # TODO: try to guess task type!
 
@@ -73,9 +72,3 @@ class XYDataManager(AbstractDataManager):
             raise ValueError('X and y must have the same number of '
                              'datapoints, but have %d and %d.' % (X.shape[0],
                                                                   y.shape[0]))
-        if self.feat_type is None:
-            self.feat_type = ['Numerical'] * X.shape[1]
-        if X.shape[1] != len(self.feat_type):
-            raise ValueError('X and feat_type must have the same number of columns, '
-                             'but are %d and %d.' %
-                             (X.shape[1], len(self.feat_type)))

--- a/autosklearn/data/xy_data_manager.py
+++ b/autosklearn/data/xy_data_manager.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-from typing import List, Optional
+from typing import Dict, List, Optional, Union, cast
 
 import numpy as np
 
@@ -24,7 +24,7 @@ class XYDataManager(AbstractDataManager):
         X_test: Optional[np.ndarray],
         y_test: Optional[np.ndarray],
         task: int,
-        feat_type: List[str],
+        feat_type: Optional[Union[List[str], Dict[Union[str, int], str]]],
         dataset_name: str
     ):
         super(XYDataManager, self).__init__(dataset_name)
@@ -57,10 +57,17 @@ class XYDataManager(AbstractDataManager):
         if y_test is not None:
             self.data['Y_test'] = y_test
 
-        if feat_type is None:
-            self.feat_type = {i: 'Numerical' for i in range(np.shape(X)[1])}
+        if feat_type is None or len(feat_type) == 0:
+            self.feat_type: Dict[Union[str, int], str] = {
+                i: 'Numerical' for i in range(np.shape(X)[1])}
+        elif isinstance(feat_type, dict):
+            self.feat_type = cast(Dict, feat_type)
         else:
-            self.feat_type = feat_type
+            raise ValueError("Unsupported feat_type provided. We expect the user to "
+                             "provide a List[str] that will internally be converted to "
+                             "a Dict that states the numerical/categorical type per column. "
+                             "Such dictionary, that provides a mapping from column->type "
+                             "can also be provided. Any other format is not supported.")
 
         # TODO: try to guess task type!
 

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -565,6 +565,7 @@ class AutoSklearnEstimator(BaseEstimator):
         X_test: Optional[SUPPORTED_FEAT_TYPES] = None,
         y_test: Optional[SUPPORTED_TARGET_TYPES] = None,
         dataset_name: Optional[str] = None,
+        feat_type: Optional[List[str]] = None,
     ):
         """
         Returns the Configuration Space object, from which Auto-Sklearn
@@ -590,6 +591,7 @@ class AutoSklearnEstimator(BaseEstimator):
             X, y,
             X_test=X_test, y_test=y_test,
             dataset_name=dataset_name,
+            feat_type=feat_type,
             only_return_configuration_space=True,
         ) if self.automl_.configuration_space is None else self.automl_.configuration_space
 

--- a/autosklearn/evaluation/abstract_evaluator.py
+++ b/autosklearn/evaluation/abstract_evaluator.py
@@ -235,21 +235,11 @@ class AbstractEvaluator(object):
                 self.model_class = autosklearn.pipeline.classification.SimpleClassificationPipeline
             self.predict_function = self._predict_proba
 
-        categorical_mask = []
-        for feat in self.datamanager.feat_type:
-            if feat.lower() == 'numerical':
-                categorical_mask.append(False)
-            elif feat.lower() == 'categorical':
-                categorical_mask.append(True)
-            else:
-                raise ValueError(feat)
-        if np.sum(categorical_mask) > 0:
-            self._init_params = {
-                'data_preprocessing:categorical_features':
-                    categorical_mask
-            }
-        else:
-            self._init_params = {}
+        self._init_params = {
+            'data_preprocessing:feat_type':
+                self.datamanager.feat_type
+        }
+
         if init_params is not None:
             self._init_params.update(init_params)
 

--- a/autosklearn/metalearning/metafeatures/metafeatures.py
+++ b/autosklearn/metalearning/metafeatures/metafeatures.py
@@ -235,7 +235,10 @@ class PercentageOfFeaturesWithMissingValues(MetaFeature):
 @metafeatures.define("NumberOfMissingValues", dependency="MissingValues")
 class NumberOfMissingValues(MetaFeature):
     def _calculate(self, X, y, logger, categorical):
-        return float(np.count_nonzero(helper_functions.get_value("MissingValues")))
+        if scipy.sparse.issparse(X):
+            return float(helper_functions.get_value("MissingValues").sum())
+        else:
+            return float(np.count_nonzero(helper_functions.get_value("MissingValues")))
 
 
 @metafeatures.define("PercentageOfMissingValues",

--- a/autosklearn/metalearning/metafeatures/metafeatures.py
+++ b/autosklearn/metalearning/metafeatures/metafeatures.py
@@ -1002,7 +1002,9 @@ def calculate_all_metafeatures(X, y, categorical, dataset_name, logger,
                 # sparse matrices because of wrong sparse format)
                 sparse = scipy.sparse.issparse(X)
                 DPP = DataPreprocessor(
-                    categorical_features=categorical, force_sparse_output=True)
+                    feat_type={i: 'categorical' if feat else 'numerical'
+                               for i, feat in enumerate(categorical)},
+                    force_sparse_output=True)
                 X_transformed = DPP.fit_transform(X)
                 categorical_transformed = [False] * X_transformed.shape[1]
 

--- a/autosklearn/metalearning/metafeatures/metafeatures.py
+++ b/autosklearn/metalearning/metafeatures/metafeatures.py
@@ -694,7 +694,10 @@ class LandmarkLDA(MetaFeature):
                 predictions = lda.predict(
                     X.iloc[test] if hasattr(X, 'iloc') else X[test],
                 )
-                accuracy += sklearn.metrics.accuracy_score(predictions, y[test])
+                accuracy += sklearn.metrics.accuracy_score(
+                    predictions,
+                    y.iloc[test] if hasattr(y, 'iloc') else y[test],
+                )
             return accuracy / 5
         except scipy.linalg.LinAlgError as e:
             self.logger.warning("LDA failed: %s Returned 0 instead!" % e)
@@ -737,7 +740,10 @@ class LandmarkNaiveBayes(MetaFeature):
             predictions = nb.predict(
                 X.iloc[test] if hasattr(X, 'iloc') else X[test],
             )
-            accuracy += sklearn.metrics.accuracy_score(predictions, y[test])
+            accuracy += sklearn.metrics.accuracy_score(
+                predictions,
+                y.iloc[test] if hasattr(y, 'iloc') else y[test],
+            )
         return accuracy / 5
 
     def _calculate_sparse(self, X, y, logger, categorical):
@@ -775,7 +781,10 @@ class LandmarkDecisionTree(MetaFeature):
             predictions = tree.predict(
                 X.iloc[test] if hasattr(X, 'iloc') else X[test],
             )
-            accuracy += sklearn.metrics.accuracy_score(predictions, y[test])
+            accuracy += sklearn.metrics.accuracy_score(
+                predictions,
+                y.iloc[test] if hasattr(y, 'iloc') else y[test],
+            )
         return accuracy / 5
 
     def _calculate_sparse(self, X, y, logger, categorical):
@@ -819,7 +828,10 @@ class LandmarkDecisionNodeLearner(MetaFeature):
             predictions = node.predict(
                 X.iloc[test] if hasattr(X, 'iloc') else X[test],
             )
-            accuracy += sklearn.metrics.accuracy_score(predictions, y[test])
+            accuracy += sklearn.metrics.accuracy_score(
+                predictions,
+                y.iloc[test] if hasattr(y, 'iloc') else y[test],
+            )
         return accuracy / 5
 
     def _calculate_sparse(self, X, y, logger, categorical):
@@ -849,7 +861,10 @@ class LandmarkRandomNodeLearner(MetaFeature):
             predictions = node.predict(
                 X.iloc[test] if hasattr(X, 'iloc') else X[test],
             )
-            accuracy += sklearn.metrics.accuracy_score(predictions, y[test])
+            accuracy += sklearn.metrics.accuracy_score(
+                predictions,
+                y.iloc[test] if hasattr(y, 'iloc') else y[test],
+            )
         return accuracy / 5
 
     def _calculate_sparse(self, X, y, logger, categorical):
@@ -910,7 +925,10 @@ class Landmark1NN(MetaFeature):
             predictions = kNN.predict(
                 X.iloc[test] if hasattr(X, 'iloc') else X[test],
             )
-            accuracy += sklearn.metrics.accuracy_score(predictions, y[test])
+            accuracy += sklearn.metrics.accuracy_score(
+                predictions,
+                y.iloc[test] if hasattr(y, 'iloc') else y[test],
+            )
         return accuracy / 5
 
 

--- a/autosklearn/pipeline/base.py
+++ b/autosklearn/pipeline/base.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta
+from typing import Dict, Union
 
 import numpy as np
 from ConfigSpace import Configuration
@@ -7,6 +8,8 @@ from sklearn.utils.validation import check_random_state
 
 from .components.base import AutoSklearnChoice, AutoSklearnComponent
 import autosklearn.pipeline.create_searchspace_util
+
+DATASET_PROPERTIES_TYPE = Dict[str, Union[str, int, bool]]
 
 
 class BasePipeline(Pipeline):

--- a/autosklearn/pipeline/base.py
+++ b/autosklearn/pipeline/base.py
@@ -1,8 +1,12 @@
 from abc import ABCMeta
 from typing import Dict, Union
 
-import numpy as np
 from ConfigSpace import Configuration
+
+import numpy as np
+
+import scipy.sparse
+
 from sklearn.pipeline import Pipeline
 from sklearn.utils.validation import check_random_state
 
@@ -10,6 +14,16 @@ from .components.base import AutoSklearnChoice, AutoSklearnComponent
 import autosklearn.pipeline.create_searchspace_util
 
 DATASET_PROPERTIES_TYPE = Dict[str, Union[str, int, bool]]
+PIPELINE_DATA_DTYPE = Union[
+    np.ndarray,
+    scipy.sparse.bsr_matrix,
+    scipy.sparse.coo_matrix,
+    scipy.sparse.csc_matrix,
+    scipy.sparse.csr_matrix,
+    scipy.sparse.dia_matrix,
+    scipy.sparse.dok_matrix,
+    scipy.sparse.lil_matrix,
+]
 
 
 class BasePipeline(Pipeline):

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -4,7 +4,7 @@ import inspect
 import pkgutil
 import sys
 
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_random_state
 
 from autosklearn.pipeline.constants import SPARSE
@@ -235,7 +235,7 @@ class AutoSklearnClassificationAlgorithm(AutoSklearnComponent):
         return self.estimator
 
 
-class AutoSklearnPreprocessingAlgorithm(AutoSklearnComponent):
+class AutoSklearnPreprocessingAlgorithm(TransformerMixin, AutoSklearnComponent):
     """Provide an abstract interface for preprocessing algorithms in
     auto-sklearn.
 

--- a/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
@@ -1,26 +1,34 @@
+from typing import Any, List, Dict, Optional, Tuple, Union
+
 import numpy as np
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
+from sklearn.base import BaseEstimator
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.components.base import \
     AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, SIGNED_DATA, INPUT
 
 
 class Balancing(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, strategy='none', random_state=None):
+    def __init__(self, strategy: str = 'none',
+                 random_state: Optional[np.random.RandomState] = None,):
         self.strategy = strategy
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'Balancing':
         self.fitted_ = True
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         return X
 
-    def get_weights(self, Y, classifier, preprocessor, init_params, fit_params):
+    def get_weights(self, Y: np.ndarray, classifier: BaseEstimator, preprocessor: BaseEstimator,
+                    init_params: Optional[Dict[str, Any]], fit_params: Optional[Dict[str, Any]],
+                    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
         if init_params is None:
             init_params = {}
 
@@ -35,7 +43,7 @@ class Balancing(AutoSklearnPreprocessingAlgorithm):
         #  are used together with warmstarts
         clf_ = ['adaboost', 'random_forest', 'extra_trees', 'sgd', 'passive_aggressive',
                 'gradient_boosting']
-        pre_ = []
+        pre_: List[str] = []
         if classifier in clf_ or preprocessor in pre_:
             if len(Y.shape) > 1:
                 offsets = [2 ** i for i in range(Y.shape[1])]
@@ -88,7 +96,8 @@ class Balancing(AutoSklearnPreprocessingAlgorithm):
         return init_params, fit_params
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'Balancing',
                 'name': 'Balancing Imbalanced Class Distributions',
                 'handles_missing_values': True,
@@ -109,7 +118,8 @@ class Balancing(AutoSklearnPreprocessingAlgorithm):
                 'preferred_dtype': None}
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: DATASET_PROPERTIES_TYPE
+                                        ) -> ConfigurationSpace:
         # TODO add replace by zero!
         strategy = CategoricalHyperparameter(
             "strategy", ["none", "weighting"], default_value="none")

--- a/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
@@ -7,7 +7,7 @@ from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
 from sklearn.base import BaseEstimator
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import \
     AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, SIGNED_DATA, INPUT
@@ -19,14 +19,15 @@ class Balancing(AutoSklearnPreprocessingAlgorithm):
         self.strategy = strategy
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'Balancing':
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None) -> 'Balancing':
         self.fitted_ = True
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         return X
 
-    def get_weights(self, Y: np.ndarray, classifier: BaseEstimator, preprocessor: BaseEstimator,
+    def get_weights(self, Y: PIPELINE_DATA_DTYPE,
+                    classifier: BaseEstimator, preprocessor: BaseEstimator,
                     init_params: Optional[Dict[str, Any]], fit_params: Optional[Dict[str, Any]],
                     ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
         if init_params is None:

--- a/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
@@ -118,7 +118,7 @@ class Balancing(AutoSklearnPreprocessingAlgorithm):
                 'preferred_dtype': None}
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties: DATASET_PROPERTIES_TYPE
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
                                         ) -> ConfigurationSpace:
         # TODO add replace by zero!
         strategy = CategoricalHyperparameter(

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/__init__.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/__init__.py
@@ -1,9 +1,20 @@
 from collections import OrderedDict
 import os
-from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
-    ThirdPartyComponents, AutoSklearnChoice
+
+from typing import Any, Dict, Optional
+
+from ConfigSpace import Configuration
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
+
+import numpy as np
+
+from sklearn.base import BaseEstimator
+
+from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
+    ThirdPartyComponents, AutoSklearnChoice
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 
 ohe_directory = os.path.split(__file__)[0]
 _ohes = find_components(__package__,
@@ -12,23 +23,26 @@ _ohes = find_components(__package__,
 _addons = ThirdPartyComponents(AutoSklearnPreprocessingAlgorithm)
 
 
-def add_ohe(ohe):
+def add_ohe(ohe: 'OHEChoice') -> None:
     _addons.add_component(ohe)
 
 
 class OHEChoice(AutoSklearnChoice):
 
     @classmethod
-    def get_components(cls):
-        components = OrderedDict()
+    def get_components(cls: BaseEstimator) -> Dict[str, BaseEstimator]:
+        components: Dict[str, BaseEstimator] = OrderedDict()
         components.update(_ohes)
         components.update(_addons.components)
         return components
 
-    def get_hyperparameter_search_space(self, dataset_properties=None,
-                                        default=None,
-                                        include=None,
-                                        exclude=None):
+    def get_hyperparameter_search_space(
+        self,
+        dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
+        default: Optional[str] = None,
+        include: Optional[Dict[str, str]] = None,
+        exclude: Optional[Dict[str, str]] = None,
+    ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
 
         if dataset_properties is None:
@@ -67,7 +81,9 @@ class OHEChoice(AutoSklearnChoice):
         self.dataset_properties = dataset_properties
         return cs
 
-    def set_hyperparameters(self, configuration, init_params=None):
+    def set_hyperparameters(self, configuration: Configuration,
+                            init_params: Optional[Dict[str, Any]] = None
+                            ) -> 'OHEChoice':
         new_params = {}
 
         params = configuration.get_dictionary()
@@ -95,5 +111,5 @@ class OHEChoice(AutoSklearnChoice):
 
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         return self.choice.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/__init__.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/__init__.py
@@ -7,14 +7,12 @@ from ConfigSpace import Configuration
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
-import numpy as np
-
 from sklearn.base import BaseEstimator
 
 from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
     ThirdPartyComponents, AutoSklearnChoice
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 
 ohe_directory = os.path.split(__file__)[0]
 _ohes = find_components(__package__,
@@ -111,5 +109,5 @@ class OHEChoice(AutoSklearnChoice):
 
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         return self.choice.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
@@ -6,10 +6,9 @@ from ConfigSpace.configuration_space import ConfigurationSpace
 
 import scipy.sparse
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
-
 from sklearn.preprocessing import OrdinalEncoder
 
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, INPUT, SPARSE, UNSIGNED_DATA
 
@@ -20,7 +19,8 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
                  ):
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'OrdinalEncoding':
+    def fit(self, X: PIPELINE_DATA_DTYPE,
+            y: Optional[PIPELINE_DATA_DTYPE] = None) -> 'OrdinalEncoding':
         if not scipy.sparse.issparse(X):
             self.preprocessor = OrdinalEncoder(
                 categories='auto', handle_unknown='use_encoded_value', unknown_value=-1,
@@ -28,7 +28,7 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
             self.preprocessor.fit(X, y)
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if scipy.sparse.issparse(X):
             return X
         if self.preprocessor is None:
@@ -38,10 +38,6 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
         # This is done because Category shift requires non negative integers
         # Consider removing this if that step is removed
         return self.preprocessor.transform(X) + 1
-
-    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
-                      ) -> 'OrdinalEncoding':
-        return self.fit(X, y).transform(X)
 
     @staticmethod
     def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
@@ -1,6 +1,12 @@
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+
 from ConfigSpace.configuration_space import ConfigurationSpace
 
 import scipy.sparse
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 
 from sklearn.preprocessing import OrdinalEncoder
 
@@ -9,10 +15,12 @@ from autosklearn.pipeline.constants import DENSE, INPUT, SPARSE, UNSIGNED_DATA
 
 
 class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state=None):
+    def __init__(self,
+                 random_state: Optional[np.random.RandomState] = None,
+                 ):
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'OrdinalEncoding':
         if not scipy.sparse.issparse(X):
             self.preprocessor = OrdinalEncoder(
                 categories='auto', handle_unknown='use_encoded_value', unknown_value=-1,
@@ -20,7 +28,7 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
             self.preprocessor.fit(X, y)
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         if scipy.sparse.issparse(X):
             return X
         if self.preprocessor is None:
@@ -31,11 +39,13 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
         # Consider removing this if that step is removed
         return self.preprocessor.transform(X) + 1
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
+                      ) -> 'OrdinalEncoding':
         return self.fit(X, y).transform(X)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'OrdinalEncoder',
                 'name': 'Ordinal Encoder',
                 'handles_regression': True,
@@ -50,5 +60,7 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
                 'output': (INPUT,), }
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(
+        dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
+    ) -> ConfigurationSpace:
         return ConfigurationSpace()

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
@@ -10,7 +10,7 @@ from sklearn.preprocessing import OrdinalEncoder
 
 from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
-from autosklearn.pipeline.constants import DENSE, INPUT, UNSIGNED_DATA
+from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
@@ -52,9 +52,9 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
                 'handles_multilabel': True,
                 'handles_multioutput': True,
                 # TODO find out of this is right!
-                'handles_sparse': False,
+                'handles_sparse': True,
                 'handles_dense': True,
-                'input': (DENSE, UNSIGNED_DATA),
+                'input': (DENSE, SPARSE, UNSIGNED_DATA),
                 'output': (INPUT,), }
 
     @staticmethod

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
@@ -1,0 +1,54 @@
+from ConfigSpace.configuration_space import ConfigurationSpace
+
+import scipy.sparse
+
+from sklearn.preprocessing import OrdinalEncoder
+
+from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
+from autosklearn.pipeline.constants import DENSE, INPUT, SPARSE, UNSIGNED_DATA
+
+
+class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
+    def __init__(self, random_state=None):
+        self.random_state = random_state
+
+    def fit(self, X, y=None):
+        if not scipy.sparse.issparse(X):
+            self.preprocessor = OrdinalEncoder(
+                categories='auto', handle_unknown='use_encoded_value', unknown_value=-1,
+            )
+            self.preprocessor.fit(X, y)
+        return self
+
+    def transform(self, X):
+        if scipy.sparse.issparse(X):
+            return X
+        if self.preprocessor is None:
+            raise NotImplementedError()
+        # Notice we are shifting the unseen categories during fit to 1
+        # from -1, 0, ... to 0,..., cat + 1
+        # This is done because Category shift requires non negative integers
+        # Consider removing this if that step is removed
+        return self.preprocessor.transform(X) + 1
+
+    def fit_transform(self, X, y=None):
+        return self.fit(X, y).transform(X)
+
+    @staticmethod
+    def get_properties(dataset_properties=None):
+        return {'shortname': 'OrdinalEncoder',
+                'name': 'Ordinal Encoder',
+                'handles_regression': True,
+                'handles_classification': True,
+                'handles_multiclass': True,
+                'handles_multilabel': True,
+                'handles_multioutput': True,
+                # TODO find out of this is right!
+                'handles_sparse': True,
+                'handles_dense': True,
+                'input': (DENSE, SPARSE, UNSIGNED_DATA),
+                'output': (INPUT,), }
+
+    @staticmethod
+    def get_hyperparameter_search_space(dataset_properties=None):
+        return ConfigurationSpace()

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
@@ -10,7 +10,7 @@ from sklearn.preprocessing import OrdinalEncoder
 
 from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
-from autosklearn.pipeline.constants import DENSE, INPUT, SPARSE, UNSIGNED_DATA
+from autosklearn.pipeline.constants import DENSE, INPUT, UNSIGNED_DATA
 
 
 class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
@@ -30,6 +30,8 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
 
     def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if scipy.sparse.issparse(X):
+            # Sparse data should be float dtype, which means we do not need
+            # to further encode it.
             return X
         if self.preprocessor is None:
             raise NotImplementedError()
@@ -50,9 +52,9 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
                 'handles_multilabel': True,
                 'handles_multioutput': True,
                 # TODO find out of this is right!
-                'handles_sparse': True,
+                'handles_sparse': False,
                 'handles_dense': True,
-                'input': (DENSE, SPARSE, UNSIGNED_DATA),
+                'input': (DENSE, UNSIGNED_DATA),
                 'output': (INPUT,), }
 
     @staticmethod

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/no_encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/no_encoding.py
@@ -1,23 +1,30 @@
+from typing import Dict, Optional, Tuple, Union
+import numpy as np
+
 from ConfigSpace.configuration_space import ConfigurationSpace
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.components.base import \
     AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class NoEncoding(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state=None):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         pass
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+            ) -> 'NoEncoding':
         self.preprocessor = 'passthrough'
         self.fitted_ = True
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         return X
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'no encoding',
                 'name': 'No categorical variable encoding',
                 'handles_regression': True,
@@ -31,6 +38,7 @@ class NoEncoding(AutoSklearnPreprocessingAlgorithm):
                 'output': (INPUT,)}
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
         return cs

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/no_encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/no_encoding.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import \
     AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
@@ -13,13 +13,13 @@ class NoEncoding(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, random_state: Optional[np.random.RandomState] = None):
         pass
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
             ) -> 'NoEncoding':
         self.preprocessor = 'passthrough'
         self.fitted_ = True
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         return X
 
     @staticmethod

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/one_hot_encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/one_hot_encoding.py
@@ -8,7 +8,7 @@ from sklearn.preprocessing import OneHotEncoder as DenseOneHotEncoder
 
 import numpy as np
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.implementations.SparseOneHotEncoder import SparseOneHotEncoder
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
@@ -18,7 +18,7 @@ class OneHotEncoder(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
             ) -> 'OneHotEncoder':
         if scipy.sparse.issparse(X):
             self.preprocessor = SparseOneHotEncoder()
@@ -28,14 +28,10 @@ class OneHotEncoder(AutoSklearnPreprocessingAlgorithm):
         self.preprocessor.fit(X, y)
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
-
-    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
-                      ) -> np.ndarray:
-        return self.fit(X, y).transform(X)
 
     @staticmethod
     def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/one_hot_encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/one_hot_encoding.py
@@ -1,19 +1,25 @@
+from typing import Dict, Optional, Tuple, Union
+
+from ConfigSpace.configuration_space import ConfigurationSpace
+
 import scipy.sparse
 
 from sklearn.preprocessing import OneHotEncoder as DenseOneHotEncoder
 
-from ConfigSpace.configuration_space import ConfigurationSpace
+import numpy as np
 
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.implementations.SparseOneHotEncoder import SparseOneHotEncoder
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class OneHotEncoder(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state=None):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+            ) -> 'OneHotEncoder':
         if scipy.sparse.issparse(X):
             self.preprocessor = SparseOneHotEncoder()
         else:
@@ -22,16 +28,18 @@ class OneHotEncoder(AutoSklearnPreprocessingAlgorithm):
         self.preprocessor.fit(X, y)
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
+                      ) -> np.ndarray:
         return self.fit(X, y).transform(X)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': '1Hot',
                 'name': 'One Hot Encoder',
                 'handles_regression': True,
@@ -46,5 +54,6 @@ class OneHotEncoder(AutoSklearnPreprocessingAlgorithm):
                 'output': (INPUT,), }
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         return ConfigurationSpace()

--- a/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
+++ b/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
@@ -1,3 +1,9 @@
+from typing import Dict, Optional, Tuple, Union
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+
+import numpy as np
+
 import autosklearn.pipeline.implementations.CategoryShift
 
 from ConfigSpace.configuration_space import ConfigurationSpace
@@ -12,25 +18,28 @@ class CategoryShift(AutoSklearnPreprocessingAlgorithm):
     is not used, so to provide compatibility with sparse matrices.
     """
 
-    def __init__(self, random_state=None):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: np.ndarray[Optional] = None
+            ) -> 'CategoryShift':
         self.preprocessor = autosklearn.pipeline.implementations.CategoryShift\
             .CategoryShift()
         self.preprocessor.fit(X, y)
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
+                      ) -> 'CategoryShift':
         return self.fit(X, y).transform(X)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'CategShift',
                 'name': 'Category Shift',
                 'handles_missing_values': True,
@@ -52,5 +61,6 @@ class CategoryShift(AutoSklearnPreprocessingAlgorithm):
                 'preferred_dtype': None}
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE]
+                                        ) -> ConfigurationSpace:
         return ConfigurationSpace()

--- a/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
+++ b/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
@@ -21,7 +21,7 @@ class CategoryShift(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: np.ndarray[Optional] = None
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
             ) -> 'CategoryShift':
         self.preprocessor = autosklearn.pipeline.implementations.CategoryShift\
             .CategoryShift()
@@ -61,6 +61,6 @@ class CategoryShift(AutoSklearnPreprocessingAlgorithm):
                 'preferred_dtype': None}
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE]
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
                                         ) -> ConfigurationSpace:
         return ConfigurationSpace()

--- a/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
+++ b/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
@@ -1,12 +1,11 @@
 from typing import Dict, Optional, Tuple, Union
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from ConfigSpace.configuration_space import ConfigurationSpace
 
 import numpy as np
 
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 import autosklearn.pipeline.implementations.CategoryShift
-
-from ConfigSpace.configuration_space import ConfigurationSpace
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
@@ -21,21 +20,17 @@ class CategoryShift(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
             ) -> 'CategoryShift':
         self.preprocessor = autosklearn.pipeline.implementations.CategoryShift\
             .CategoryShift()
         self.preprocessor.fit(X, y)
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
-
-    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
-                      ) -> 'CategoryShift':
-        return self.fit(X, y).transform(X)
 
     @staticmethod
     def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_categorical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_categorical.py
@@ -10,6 +10,9 @@ from autosklearn.pipeline.components.data_preprocessing.minority_coalescense \
     import CoalescenseChoice
 from autosklearn.pipeline.components.data_preprocessing.categorical_encoding \
     import OHEChoice
+from autosklearn.pipeline.components.data_preprocessing.categorical_encoding.encoding import (
+    OrdinalEncoding
+)
 
 from autosklearn.pipeline.base import BasePipeline
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
@@ -93,8 +96,9 @@ class CategoricalPreprocessingPipeline(BasePipeline):
             default_dataset_properties.update(dataset_properties)
 
         steps.extend([
-            ["category_shift", CategoryShift()],
             ["imputation", CategoricalImputation()],
+            ["encoding", OrdinalEncoding()],
+            ["category_shift", CategoryShift()],
             ["category_coalescence", CoalescenseChoice(default_dataset_properties)],
             ["categorical_encoding", OHEChoice(default_dataset_properties)],
             ])

--- a/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_numerical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/data_preprocessing_numerical.py
@@ -1,6 +1,10 @@
+from typing import Any, List, Dict, Optional, Tuple, Union
+
+from ConfigSpace.configuration_space import Configuration, ConfigurationSpace
+
 import numpy as np
 
-from ConfigSpace.configuration_space import ConfigurationSpace
+from sklearn.base import BaseEstimator
 
 from autosklearn.pipeline.components.data_preprocessing import rescaling as \
     rescaling_components
@@ -9,7 +13,10 @@ from autosklearn.pipeline.components.data_preprocessing.imputation.numerical_imp
 from autosklearn.pipeline.components.data_preprocessing.variance_threshold\
     .variance_threshold import VarianceThreshold
 
-from autosklearn.pipeline.base import BasePipeline
+from autosklearn.pipeline.base import (
+    BasePipeline,
+    DATASET_PROPERTIES_TYPE,
+)
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
@@ -31,20 +38,24 @@ class NumericalPreprocessingPipeline(BasePipeline):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance
-        used by `np.random`.
+        used by `np.random`."""
 
-    """
-
-    def __init__(self, config=None, steps=None, dataset_properties=None,
-                 include=None, exclude=None, random_state=None,
-                 init_params=None):
+    def __init__(self,
+                 config: Optional[Configuration] = None,
+                 steps: Optional[List[Tuple[str, BaseEstimator]]] = None,
+                 dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
+                 include: Optional[Dict[str, str]] = None,
+                 exclude: Optional[Dict[str, str]] = None,
+                 random_state: Optional[np.random.RandomState] = None,
+                 init_params: Optional[Dict[str, Any]] = None):
         self._output_dtype = np.int32
         super().__init__(
             config, steps, dataset_properties, include, exclude,
             random_state, init_params)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'num_datapreproc',
                 'name': 'numeric data preprocessing',
                 'handles_missing_values': True,
@@ -64,8 +75,12 @@ class NumericalPreprocessingPipeline(BasePipeline):
                 'output': (INPUT,),
                 'preferred_dtype': None}
 
-    def _get_hyperparameter_search_space(self, include=None, exclude=None,
-                                         dataset_properties=None):
+    def _get_hyperparameter_search_space(
+        self,
+        include: Optional[Dict[str, str]] = None,
+        exclude: Optional[Dict[str, str]] = None,
+        dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
+    ) -> ConfigurationSpace:
         """Create the hyperparameter configuration space.
 
         Parameters
@@ -87,7 +102,9 @@ class NumericalPreprocessingPipeline(BasePipeline):
 
         return cs
 
-    def _get_pipeline_steps(self, dataset_properties=None):
+    def _get_pipeline_steps(self,
+                            dataset_properties: Optional[Dict[str, str]] = None,
+                            ) -> List[Tuple[str, BaseEstimator]]:
         steps = []
 
         default_dataset_properties = {}
@@ -95,12 +112,12 @@ class NumericalPreprocessingPipeline(BasePipeline):
             default_dataset_properties.update(dataset_properties)
 
         steps.extend([
-            ["imputation", NumericalImputation()],
-            ["variance_threshold", VarianceThreshold()],
-            ["rescaling", rescaling_components.RescalingChoice(default_dataset_properties)],
+            ("imputation", NumericalImputation()),
+            ("variance_threshold", VarianceThreshold()),
+            ("rescaling", rescaling_components.RescalingChoice(default_dataset_properties)),
             ])
 
         return steps
 
-    def _get_estimator_hyperparameter_name(self):
+    def _get_estimator_hyperparameter_name(self) -> str:
         return "numerical data preprocessing"

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -1,11 +1,18 @@
 from ConfigSpace.configuration_space import ConfigurationSpace
+
+import numpy as np
+
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
     """
-    Substitute missing values by 2
+    Substitute missing values by constant:
+        When strategy == “constant”, fill_value is used to replace all
+        occurrences of missing_values.
+        If left to the default, fill_value will be 0 when imputing
+        numerical data and “missing_value” for strings or object data types.
     """
 
     def __init__(self, random_state=None):
@@ -14,15 +21,31 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
     def fit(self, X, y=None):
         import sklearn.impute
 
+        fill_value = None
+        if hasattr(X, 'columns'):
+            kind = X[X.columns[-1]].dtype.kind
+        else:
+            # Series, sparse and numpy have dtype
+            # Only DataFrame does not
+            kind = X.dtype.kind
+        if kind in ("i", "u", "f"):
+            # We do not want to impute a category with the default
+            # value (0 is the default) in case such default is in the
+            # train data already!
+            fill_value = 0
+            unique = np.unique(X)
+            while fill_value in unique:
+                fill_value -= 1
+
         self.preprocessor = sklearn.impute.SimpleImputer(
-            strategy='constant', fill_value=2, copy=False)
+            strategy='constant', copy=False, fill_value=fill_value)
         self.preprocessor.fit(X)
         return self
 
     def transform(self, X):
         if self.preprocessor is None:
             raise NotImplementedError()
-        X = self.preprocessor.transform(X).astype(int)
+        X = self.preprocessor.transform(X)
         return X
 
     def fit_transform(self, X, y=None):

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -1,7 +1,10 @@
+from typing import Dict, Optional, Tuple, Union
+
 from ConfigSpace.configuration_space import ConfigurationSpace
 
 import numpy as np
 
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
@@ -15,10 +18,10 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
         numerical data and “missing_value” for strings or object data types.
     """
 
-    def __init__(self, random_state=None):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'CategoricalImputation':
         import sklearn.impute
 
         fill_value = None
@@ -42,17 +45,19 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
         self.preprocessor.fit(X)
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         if self.preprocessor is None:
             raise NotImplementedError()
         X = self.preprocessor.transform(X)
         return X
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
+                      ) -> np.ndarray:
         return self.fit(X, y).transform(X)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'CategoricalImputation',
                 'name': 'Categorical Imputation',
                 'handles_missing_values': True,
@@ -74,5 +79,6 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
                 'preferred_dtype': None}
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         return ConfigurationSpace()

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -4,7 +4,7 @@ from ConfigSpace.configuration_space import ConfigurationSpace
 
 import numpy as np
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
@@ -21,7 +21,8 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'CategoricalImputation':
+    def fit(self, X: PIPELINE_DATA_DTYPE,
+            y: Optional[PIPELINE_DATA_DTYPE] = None) -> 'CategoricalImputation':
         import sklearn.impute
 
         fill_value = None
@@ -45,15 +46,11 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
         self.preprocessor.fit(X)
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if self.preprocessor is None:
             raise NotImplementedError()
         X = self.preprocessor.transform(X)
         return X
-
-    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
-                      ) -> np.ndarray:
-        return self.fit(X, y).transform(X)
 
     @staticmethod
     def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/numerical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/numerical_imputation.py
@@ -12,7 +12,8 @@ from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 class NumericalImputation(AutoSklearnPreprocessingAlgorithm):
 
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(self, strategy: str ='mean', random_state: Optional[np.random.RandomState] = None):
+        self.strategy = strategy
         self.random_state = random_state
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'NumericalImputation':

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/numerical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/numerical_imputation.py
@@ -5,18 +5,20 @@ from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
 import numpy as np
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class NumericalImputation(AutoSklearnPreprocessingAlgorithm):
 
-    def __init__(self, strategy: str ='mean', random_state: Optional[np.random.RandomState] = None):
+    def __init__(self, strategy: str = 'mean',
+                 random_state: Optional[np.random.RandomState] = None):
         self.strategy = strategy
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'NumericalImputation':
+    def fit(self, X: PIPELINE_DATA_DTYPE,
+            y: Optional[PIPELINE_DATA_DTYPE] = None) -> 'NumericalImputation':
         import sklearn.impute
 
         self.preprocessor = sklearn.impute.SimpleImputer(
@@ -24,7 +26,7 @@ class NumericalImputation(AutoSklearnPreprocessingAlgorithm):
         self.preprocessor.fit(X)
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/numerical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/numerical_imputation.py
@@ -1,17 +1,21 @@
+from typing import Dict, Optional, Tuple, Union
+
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
+import numpy as np
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class NumericalImputation(AutoSklearnPreprocessingAlgorithm):
 
-    def __init__(self, strategy='mean', random_state=None):
-        self.strategy = strategy
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'NumericalImputation':
         import sklearn.impute
 
         self.preprocessor = sklearn.impute.SimpleImputer(
@@ -19,13 +23,14 @@ class NumericalImputation(AutoSklearnPreprocessingAlgorithm):
         self.preprocessor.fit(X)
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'NumericalImputation',
                 'name': 'Numerical Imputation',
                 'handles_missing_values': True,
@@ -47,7 +52,8 @@ class NumericalImputation(AutoSklearnPreprocessingAlgorithm):
                 'preferred_dtype': None}
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         # TODO add replace by zero!
         strategy = CategoricalHyperparameter(
             "strategy", ["mean", "median", "most_frequent"], default_value="mean")

--- a/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/__init__.py
+++ b/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/__init__.py
@@ -1,9 +1,20 @@
 from collections import OrderedDict
 import os
-from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
-    ThirdPartyComponents, AutoSklearnChoice
+
+from typing import Any, Dict, Optional
+
+from ConfigSpace import Configuration
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
+
+import numpy as np
+
+from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
+    ThirdPartyComponents, AutoSklearnChoice
+
+from sklearn.base import BaseEstimator
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 
 mc_directory = os.path.split(__file__)[0]
 _mcs = find_components(
@@ -11,23 +22,26 @@ _mcs = find_components(
 _addons = ThirdPartyComponents(AutoSklearnPreprocessingAlgorithm)
 
 
-def add_mc(mc):
+def add_mc(mc: BaseEstimator) -> None:
     _addons.add_component(mc)
 
 
 class CoalescenseChoice(AutoSklearnChoice):
 
     @classmethod
-    def get_components(cls):
-        components = OrderedDict()
+    def get_components(cls: BaseEstimator) -> Dict[str, BaseEstimator]:
+        components: Dict[str, BaseEstimator] = OrderedDict()
         components.update(_mcs)
         components.update(_addons.components)
         return components
 
-    def get_hyperparameter_search_space(self, dataset_properties=None,
-                                        default=None,
-                                        include=None,
-                                        exclude=None):
+    def get_hyperparameter_search_space(
+        self,
+        dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
+        default: Optional[str] = None,
+        include: Optional[Dict[str, str]] = None,
+        exclude: Optional[Dict[str, str]] = None,
+    ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
 
         if dataset_properties is None:
@@ -64,7 +78,9 @@ class CoalescenseChoice(AutoSklearnChoice):
         self.dataset_properties = dataset_properties
         return cs
 
-    def set_hyperparameters(self, configuration, init_params=None):
+    def set_hyperparameters(self, configuration: Configuration,
+                            init_params: Optional[Dict[str, Any]] = None
+                            ) -> 'CoalescenseChoice':
         new_params = {}
 
         params = configuration.get_dictionary()
@@ -92,5 +108,5 @@ class CoalescenseChoice(AutoSklearnChoice):
 
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         return self.choice.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/__init__.py
+++ b/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/__init__.py
@@ -7,14 +7,12 @@ from ConfigSpace import Configuration
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
-import numpy as np
-
 from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
     ThirdPartyComponents, AutoSklearnChoice
 
 from sklearn.base import BaseEstimator
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 
 mc_directory = os.path.split(__file__)[0]
 _mcs = find_components(
@@ -108,5 +106,5 @@ class CoalescenseChoice(AutoSklearnChoice):
 
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         return self.choice.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/minority_coalescer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/minority_coalescer.py
@@ -1,8 +1,13 @@
-import autosklearn.pipeline.implementations.MinorityCoalescer
+from typing import Dict, Optional, Tuple, Union
+
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter
 
+import numpy as np
+
+import autosklearn.pipeline.implementations.MinorityCoalescer
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
@@ -11,10 +16,12 @@ class MinorityCoalescer(AutoSklearnPreprocessingAlgorithm):
     """ Group together categories which occurence is less than a specified minimum fraction.
     """
 
-    def __init__(self, minimum_fraction=0.01, random_state=None):
+    def __init__(self, minimum_fraction: float = 0.01,
+                 random_state: Optional[np.random.RandomState] = None):
         self.minimum_fraction = minimum_fraction
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+            ) -> 'MinorityCoalescer':
         self.minimum_fraction = float(self.minimum_fraction)
 
         self.preprocessor = autosklearn.pipeline.implementations.MinorityCoalescer\
@@ -22,16 +29,18 @@ class MinorityCoalescer(AutoSklearnPreprocessingAlgorithm):
         self.preprocessor.fit(X, y)
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
+                      ) -> np.ndarray:
         return self.fit(X, y).transform(X)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'coalescer',
                 'name': 'Categorical minority coalescer',
                 'handles_regression': True,
@@ -46,7 +55,8 @@ class MinorityCoalescer(AutoSklearnPreprocessingAlgorithm):
                 'output': (INPUT,), }
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
         minimum_fraction = UniformFloatHyperparameter(
             "minimum_fraction", lower=.0001, upper=0.5, default_value=0.01, log=True)

--- a/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/minority_coalescer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/minority_coalescer.py
@@ -7,7 +7,7 @@ from ConfigSpace.hyperparameters import UniformFloatHyperparameter
 import numpy as np
 
 import autosklearn.pipeline.implementations.MinorityCoalescer
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
@@ -20,7 +20,7 @@ class MinorityCoalescer(AutoSklearnPreprocessingAlgorithm):
                  random_state: Optional[np.random.RandomState] = None):
         self.minimum_fraction = minimum_fraction
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
             ) -> 'MinorityCoalescer':
         self.minimum_fraction = float(self.minimum_fraction)
 
@@ -29,14 +29,10 @@ class MinorityCoalescer(AutoSklearnPreprocessingAlgorithm):
         self.preprocessor.fit(X, y)
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
-
-    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
-                      ) -> np.ndarray:
-        return self.fit(X, y).transform(X)
 
     @staticmethod
     def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/no_coalescense.py
+++ b/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/no_coalescense.py
@@ -1,25 +1,34 @@
+from typing import Dict, Optional, Tuple, Union
+
+
 from ConfigSpace.configuration_space import ConfigurationSpace
+
+import numpy as np
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.components.base import \
     AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class NoCoalescence(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state=None):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         pass
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.array, y: Optional[np.ndarray] = None
+            ) -> np.ndarray:
         self.preprocessor = 'passthrough'
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         return X
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
+                      ) -> np.ndarray:
         return self.fit(X, y).transform(X)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'no coalescence',
                 'name': 'No categorical variable coalescence',
                 'handles_regression': True,
@@ -33,6 +42,7 @@ class NoCoalescence(AutoSklearnPreprocessingAlgorithm):
                 'output': (INPUT,)}
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
         return cs

--- a/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/no_coalescense.py
+++ b/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/no_coalescense.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Tuple, Union
 from ConfigSpace.configuration_space import ConfigurationSpace
 
 import numpy as np
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import \
     AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
@@ -14,17 +14,13 @@ class NoCoalescence(AutoSklearnPreprocessingAlgorithm):
     def __init__(self, random_state: Optional[np.random.RandomState] = None):
         pass
 
-    def fit(self, X: np.array, y: Optional[np.ndarray] = None
-            ) -> np.ndarray:
+    def fit(self, X: np.array, y: Optional[PIPELINE_DATA_DTYPE] = None
+            ) -> PIPELINE_DATA_DTYPE:
         self.preprocessor = 'passthrough'
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         return X
-
-    def fit_transform(self, X: np.ndarray, y: Optional[np.ndarray] = None
-                      ) -> np.ndarray:
-        return self.fit(X, y).transform(X)
 
     @staticmethod
     def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/__init__.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/__init__.py
@@ -1,10 +1,18 @@
 from collections import OrderedDict
 import os
-from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
-    ThirdPartyComponents, AutoSklearnChoice
+
+from typing import Dict, Optional
+
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
+import numpy as np
+
+from sklearn.base import BaseEstimator
+
+from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
+    ThirdPartyComponents, AutoSklearnChoice
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 
 rescaling_directory = os.path.split(__file__)[0]
 _rescalers = find_components(__package__,
@@ -13,23 +21,26 @@ _rescalers = find_components(__package__,
 _addons = ThirdPartyComponents(AutoSklearnPreprocessingAlgorithm)
 
 
-def add_rescaler(rescaler):
+def add_rescaler(rescaler: 'RescalingChoice') -> None:
     _addons.add_component(rescaler)
 
 
 class RescalingChoice(AutoSklearnChoice):
 
     @classmethod
-    def get_components(cls):
-        components = OrderedDict()
+    def get_components(cls: BaseEstimator) -> Dict[str, BaseEstimator]:
+        components: Dict[str, BaseEstimator] = OrderedDict()
         components.update(_rescalers)
         components.update(_addons.components)
         return components
 
-    def get_hyperparameter_search_space(self, dataset_properties=None,
-                                        default=None,
-                                        include=None,
-                                        exclude=None):
+    def get_hyperparameter_search_space(
+        self,
+        dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
+        default: Optional[str] = None,
+        include: Optional[Dict[str, str]] = None,
+        exclude: Optional[Dict[str, str]] = None,
+    ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
 
         if dataset_properties is None:
@@ -67,5 +78,5 @@ class RescalingChoice(AutoSklearnChoice):
         self.dataset_properties = dataset_properties
         return cs
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         return self.choice.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/__init__.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/__init__.py
@@ -6,13 +6,14 @@ from typing import Dict, Optional
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
-import numpy as np
-
 from sklearn.base import BaseEstimator
 
 from ...base import AutoSklearnPreprocessingAlgorithm, find_components, \
     ThirdPartyComponents, AutoSklearnChoice
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
+from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling import (
+    Rescaling
+)
 
 rescaling_directory = os.path.split(__file__)[0]
 _rescalers = find_components(__package__,
@@ -21,7 +22,7 @@ _rescalers = find_components(__package__,
 _addons = ThirdPartyComponents(AutoSklearnPreprocessingAlgorithm)
 
 
-def add_rescaler(rescaler: 'RescalingChoice') -> None:
+def add_rescaler(rescaler: Rescaling) -> None:
     _addons.add_component(rescaler)
 
 
@@ -78,5 +79,5 @@ class RescalingChoice(AutoSklearnChoice):
         self.dataset_properties = dataset_properties
         return cs
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         return self.choice.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
@@ -7,7 +7,7 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import NotFittedError
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 
 
@@ -16,14 +16,14 @@ class Rescaling(object):
     def __init__(self, random_state: Optional[np.random.RandomState] = None):
         self.preprocessor: Optional[BaseEstimator] = None
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
             ) -> 'AutoSklearnPreprocessingAlgorithm':
         if self.preprocessor is None:
             raise NotFittedError()
         self.preprocessor.fit(X)
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
@@ -1,19 +1,35 @@
+from typing import Optional
+
 from ConfigSpace.configuration_space import ConfigurationSpace
+
+import numpy as np
+
+from sklearn.base import BaseEstimator
+from sklearn.exceptions import NotFittedError
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 
 
 class Rescaling(object):
     # Rescaling does not support fit_transform (as of 0.19.1)!
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+        self.preprocessor: Optional[BaseEstimator] = None
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+            ) -> 'AutoSklearnPreprocessingAlgorithm':
+        if self.preprocessor is None:
+            raise NotFittedError()
         self.preprocessor.fit(X)
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
         return cs

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/minmax.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/minmax.py
@@ -1,3 +1,8 @@
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, SIGNED_DATA, INPUT
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
@@ -5,12 +10,13 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 
 class MinMaxScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         from sklearn.preprocessing import MinMaxScaler
         self.preprocessor = MinMaxScaler(copy=False)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'MinMaxScaler',
                 'name': 'MinMaxScaler',
                 'handles_missing_values': False,

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/none.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/none.py
@@ -1,8 +1,6 @@
 from typing import Dict, Optional, Tuple, Union
 
-import numpy as np
-
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, INPUT, SPARSE
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
@@ -11,12 +9,12 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 class NoRescalingComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
             ) -> 'AutoSklearnPreprocessingAlgorithm':
         self.preprocessor = 'passthrough'
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         return X
 
     @staticmethod

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/none.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/none.py
@@ -1,3 +1,8 @@
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, INPUT, SPARSE
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
@@ -5,18 +10,18 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 
 class NoRescalingComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state=None):
-        pass
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+            ) -> 'AutoSklearnPreprocessingAlgorithm':
         self.preprocessor = 'passthrough'
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         return X
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'NoRescaling',
                 'name': 'NoRescaling',
                 'handles_missing_values': False,

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/normalize.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/normalize.py
@@ -1,3 +1,8 @@
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, INPUT, SPARSE
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
@@ -5,14 +10,15 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 
 class NormalizerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         # Use custom implementation because sklearn implementation cannot
         # handle float32 input matrix
         from sklearn.preprocessing import Normalizer
         self.preprocessor = Normalizer(copy=False)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'Normalizer',
                 'name': 'Normalizer',
                 'handles_missing_values': False,

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
@@ -1,3 +1,8 @@
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, INPUT
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
@@ -5,12 +10,13 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 
 class PowerTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         from sklearn.preprocessing import PowerTransformer
         self.preprocessor = PowerTransformer(copy=False)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'PowerTransformer',
                 'name': 'PowerTransformer',
                 'handles_missing_values': False,

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/quantile_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/quantile_transformer.py
@@ -1,3 +1,8 @@
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformIntegerHyperparameter, \
     CategoricalHyperparameter
@@ -10,7 +15,8 @@ from autosklearn.pipeline.components.base import \
 
 
 class QuantileTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, n_quantiles, output_distribution, random_state):
+    def __init__(self, n_quantiles: int, output_distribution: str,
+                 random_state: Optional[np.random.RandomState] = None):
         from sklearn.preprocessing import QuantileTransformer
         self.n_quantiles = n_quantiles
         self.output_distribution = output_distribution
@@ -21,7 +27,8 @@ class QuantileTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm)
         )
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'QuantileTransformer',
                 'name': 'QuantileTransformer',
                 'handles_regression': True,
@@ -37,7 +44,9 @@ class QuantileTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm)
                 'output': (INPUT, SIGNED_DATA),
                 'preferred_dtype': None}
 
-    def get_hyperparameter_search_space(dataset_properties=None):
+    @staticmethod
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
         # TODO parametrize like the Random Forest as n_quantiles = n_features^param
         n_quantiles = UniformIntegerHyperparameter(

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/robust_scaler.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/robust_scaler.py
@@ -8,7 +8,7 @@ from sklearn.exceptions import NotFittedError
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, SIGNED_DATA, INPUT, SPARSE
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
@@ -57,7 +57,7 @@ class RobustScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
         cs.add_hyperparameters((q_min, q_max))
         return cs
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
             ) -> 'AutoSklearnPreprocessingAlgorithm':
         if self.preprocessor is None:
             raise NotFittedError()

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/standardize.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/standardize.py
@@ -1,4 +1,12 @@
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+
 from scipy import sparse
+
+from sklearn.exceptions import NotFittedError
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
@@ -7,12 +15,13 @@ from autosklearn.pipeline.components.base import \
 
 
 class StandardScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         from sklearn.preprocessing import StandardScaler
         self.preprocessor = StandardScaler(copy=False)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {'shortname': 'StandardScaler',
                 'name': 'StandardScaler',
                 'handles_missing_values': False,
@@ -33,7 +42,10 @@ class StandardScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
                 'output': (INPUT,),
                 'preferred_dtype': None}
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+            ) -> 'AutoSklearnPreprocessingAlgorithm':
+        if self.preprocessor is None:
+            raise NotFittedError()
         if sparse.isspmatrix(X):
             self.preprocessor.set_params(with_mean=False)
 

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/standardize.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/standardize.py
@@ -6,7 +6,7 @@ from scipy import sparse
 
 from sklearn.exceptions import NotFittedError
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 from autosklearn.pipeline.components.data_preprocessing.rescaling.abstract_rescaling \
     import Rescaling
@@ -42,7 +42,7 @@ class StandardScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
                 'output': (INPUT,),
                 'preferred_dtype': None}
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None
+    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
             ) -> 'AutoSklearnPreprocessingAlgorithm':
         if self.preprocessor is None:
             raise NotFittedError()

--- a/autosklearn/pipeline/components/data_preprocessing/variance_threshold/variance_threshold.py
+++ b/autosklearn/pipeline/components/data_preprocessing/variance_threshold/variance_threshold.py
@@ -16,7 +16,7 @@ class VarianceThreshold(AutoSklearnPreprocessingAlgorithm):
         # VarianceThreshold does not support fit_transform (as of 0.19.1)!
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarrray] = None) -> 'VarianceThreshold':
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'VarianceThreshold':
         self.preprocessor = sklearn.feature_selection.VarianceThreshold(
             threshold=0.0
         )

--- a/autosklearn/pipeline/components/data_preprocessing/variance_threshold/variance_threshold.py
+++ b/autosklearn/pipeline/components/data_preprocessing/variance_threshold/variance_threshold.py
@@ -4,7 +4,7 @@ from ConfigSpace.configuration_space import ConfigurationSpace
 
 import numpy as np
 
-from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
@@ -16,14 +16,15 @@ class VarianceThreshold(AutoSklearnPreprocessingAlgorithm):
         # VarianceThreshold does not support fit_transform (as of 0.19.1)!
         self.random_state = random_state
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'VarianceThreshold':
+    def fit(self, X: PIPELINE_DATA_DTYPE,
+            y: Optional[PIPELINE_DATA_DTYPE] = None) -> 'VarianceThreshold':
         self.preprocessor = sklearn.feature_selection.VarianceThreshold(
             threshold=0.0
         )
         self.preprocessor = self.preprocessor.fit(X)
         return self
 
-    def transform(self, X: np.ndarray) -> np.ndarray:
+    def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)

--- a/autosklearn/pipeline/components/data_preprocessing/variance_threshold/variance_threshold.py
+++ b/autosklearn/pipeline/components/data_preprocessing/variance_threshold/variance_threshold.py
@@ -1,5 +1,10 @@
+from typing import Dict, Optional, Tuple, Union
+
 from ConfigSpace.configuration_space import ConfigurationSpace
 
+import numpy as np
+
+from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
@@ -7,24 +12,25 @@ import sklearn.feature_selection
 
 
 class VarianceThreshold(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state=None):
+    def __init__(self, random_state: Optional[np.random.RandomState] = None):
         # VarianceThreshold does not support fit_transform (as of 0.19.1)!
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarrray] = None) -> 'VarianceThreshold':
         self.preprocessor = sklearn.feature_selection.VarianceThreshold(
             threshold=0.0
         )
         self.preprocessor = self.preprocessor.fit(X)
         return self
 
-    def transform(self, X):
+    def transform(self, X: np.ndarray) -> np.ndarray:
         if self.preprocessor is None:
             raise NotImplementedError()
         return self.preprocessor.transform(X)
 
     @staticmethod
-    def get_properties(dataset_properties=None):
+    def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                       ) -> Dict[str, Optional[Union[str, int, bool, Tuple]]]:
         return {
             'shortname': 'Variance Threshold',
             'name': 'Variance Threshold (constant feature removal)',
@@ -41,6 +47,7 @@ class VarianceThreshold(AutoSklearnPreprocessingAlgorithm):
         }
 
     @staticmethod
-    def get_hyperparameter_search_space(dataset_properties=None):
+    def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None
+                                        ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
         return cs

--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -84,8 +84,11 @@ def _calculate_metafeatures(data_feat_type, data_info_task, basename,
         # == Calculate metafeatures
         task_name = 'CalculateMetafeatures'
         watcher.start_task(task_name)
+
+        # data_feat_type is used by both smbo and metafeature calculation
+        feat_types = data_feat_type.values() if isinstance(data_feat_type, dict) else data_feat_type
         categorical = [True if feat_type.lower() in ['categorical'] else False
-                       for i, feat_type in data_feat_type.items()]
+                       for feat_type in feat_types]
 
         EXCLUDE_META_FEATURES = EXCLUDE_META_FEATURES_CLASSIFICATION \
             if data_info_task in CLASSIFICATION_TASKS else EXCLUDE_META_FEATURES_REGRESSION
@@ -122,8 +125,9 @@ def _calculate_metafeatures_encoded(data_feat_type, basename, x_train, y_train, 
 
         task_name = 'CalculateMetafeaturesEncoded'
         watcher.start_task(task_name)
+        feat_types = data_feat_type.values() if isinstance(data_feat_type, dict) else data_feat_type
         categorical = [True if feat_type.lower() in ['categorical'] else False
-                       for i, feat_type in data_feat_type.items()]
+                       for feat_type in feat_types]
 
         result = calculate_all_metafeatures_encoded_labels(
             x_train, y_train, categorical=categorical,

--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -85,10 +85,8 @@ def _calculate_metafeatures(data_feat_type, data_info_task, basename,
         task_name = 'CalculateMetafeatures'
         watcher.start_task(task_name)
 
-        # data_feat_type is used by both smbo and metafeature calculation
-        feat_types = data_feat_type.values() if isinstance(data_feat_type, dict) else data_feat_type
-        categorical = [True if feat_type.lower() in ['categorical'] else False
-                       for feat_type in feat_types]
+        categorical = {col: True if feat_type.lower() == 'categorical' else False
+                       for col, feat_type in data_feat_type.items()}
 
         EXCLUDE_META_FEATURES = EXCLUDE_META_FEATURES_CLASSIFICATION \
             if data_info_task in CLASSIFICATION_TASKS else EXCLUDE_META_FEATURES_REGRESSION
@@ -125,9 +123,8 @@ def _calculate_metafeatures_encoded(data_feat_type, basename, x_train, y_train, 
 
         task_name = 'CalculateMetafeaturesEncoded'
         watcher.start_task(task_name)
-        feat_types = data_feat_type.values() if isinstance(data_feat_type, dict) else data_feat_type
-        categorical = [True if feat_type.lower() in ['categorical'] else False
-                       for feat_type in feat_types]
+        categorical = {col: True if feat_type.lower() == 'categorical' else False
+                       for col, feat_type in data_feat_type.items()}
 
         result = calculate_all_metafeatures_encoded_labels(
             x_train, y_train, categorical=categorical,

--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -85,7 +85,7 @@ def _calculate_metafeatures(data_feat_type, data_info_task, basename,
         task_name = 'CalculateMetafeatures'
         watcher.start_task(task_name)
         categorical = [True if feat_type.lower() in ['categorical'] else False
-                       for feat_type in data_feat_type]
+                       for i, feat_type in data_feat_type.items()]
 
         EXCLUDE_META_FEATURES = EXCLUDE_META_FEATURES_CLASSIFICATION \
             if data_info_task in CLASSIFICATION_TASKS else EXCLUDE_META_FEATURES_REGRESSION
@@ -123,7 +123,7 @@ def _calculate_metafeatures_encoded(data_feat_type, basename, x_train, y_train, 
         task_name = 'CalculateMetafeaturesEncoded'
         watcher.start_task(task_name)
         categorical = [True if feat_type.lower() in ['categorical'] else False
-                       for feat_type in data_feat_type]
+                       for i, feat_type in data_feat_type.items()]
 
         result = calculate_all_metafeatures_encoded_labels(
             x_train, y_train, categorical=categorical,

--- a/scripts/update_metadata_util.py
+++ b/scripts/update_metadata_util.py
@@ -52,7 +52,6 @@ def load_task(task_id):
     del _
     del dataset
     cat = ['categorical' if c else 'numerical' for c in cat]
-    cat = {i: 'categorical' if c else 'numerical' for i, c in enumerate(cat)}
 
     if isinstance(task, openml.tasks.OpenMLClassificationTask):
         task_type = 'classification'

--- a/scripts/update_metadata_util.py
+++ b/scripts/update_metadata_util.py
@@ -52,6 +52,7 @@ def load_task(task_id):
     del _
     del dataset
     cat = ['categorical' if c else 'numerical' for c in cat]
+    cat = {i: 'categorical' if c else 'numerical' for i, c in enumerate(cat)}
 
     if isinstance(task, openml.tasks.OpenMLClassificationTask):
         task_type = 'classification'

--- a/scripts/update_metadata_util.py
+++ b/scripts/update_metadata_util.py
@@ -51,7 +51,7 @@ def load_task(task_id):
     name = dataset.name.lower()
     del _
     del dataset
-    cat = ['categorical' if c else 'numerical' for c in cat]
+    cat = {i: 'categorical' if c else 'numerical' for i, c in enumerate(cat)}
 
     if isinstance(task, openml.tasks.OpenMLClassificationTask):
         task_type = 'classification'

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -439,7 +439,7 @@ def test_fail_if_dummy_prediction_fails(ta_run_mock, backend, dask_client):
         X_train, Y_train,
         X_test, Y_test,
         task=2,
-        feat_type=['Numerical' for i in range(X_train.shape[1])],
+        feat_type={i: 'Numerical' for i in range(X_train.shape[1])},
         dataset_name='iris',
     )
 

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -396,7 +396,7 @@ def test_do_dummy_prediction(backend, dask_client, datasets):
         X_test, Y_test,
         task=task,
         dataset_name=name,
-        feat_type=None,
+        feat_type={i: 'numerical' for i in range(X_train.shape[1])},
     )
 
     auto = autosklearn.automl.AutoML(
@@ -655,7 +655,7 @@ def test_fail_if_feat_type_on_pandas_input(backend, dask_client):
         automl.fit(
             X_train, y_train,
             task=BINARY_CLASSIFICATION,
-            feat_type=['Categorical', 'Numerical'],
+            feat_type={1: 'Categorical', 2: 'Numerical'},
         )
 
 

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -844,11 +844,11 @@ def test_pass_categorical_and_numeric_columns_to_pipeline(
     # We should produce a decent result
     assert run_value.cost < 0.4, f"{run_value}/{run_value.additional_info}"
     prediction = pipeline.predict(automl.automl_.InputValidator.feature_validator.transform(X))
-    print(prediction)
     assert np.shape(prediction)[0], np.shape(y)[0]
 
-    print(vars(pipeline.named_steps['data_preprocessing']))
     if include_categorical:
         expected_dict = {i: 'numerical' for i in range(np.shape(X)[1] - 1)}
         expected_dict[X.shape[1] - 1] = 'categorical'
-        assert expected_dict == pipeline.named_steps['data_preprocessing'].feat_type
+    else:
+        expected_dict = {i: 'numerical' for i in range(np.shape(X)[1])}
+    assert expected_dict == pipeline.named_steps['data_preprocessing'].feat_type

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -852,3 +852,27 @@ def test_pass_categorical_and_numeric_columns_to_pipeline(
     else:
         expected_dict = {i: 'numerical' for i in range(np.shape(X)[1])}
     assert expected_dict == pipeline.named_steps['data_preprocessing'].feat_type
+
+
+@pytest.mark.parametrize("as_frame", [True, False])
+def test_autosklearn_anneal(as_frame):
+    """
+    This test makes sure that anneal dataset can be fitted and scored.
+    This dataset is quite complex, with NaN, categorical and numerical columns
+    so is a good testcase for unit-testing
+    """
+    X, y = sklearn.datasets.fetch_openml(data_id=2, return_X_y=True, as_frame=False)
+    automl = AutoSklearnClassifier(time_left_for_this_task=60, ensemble_size=0,
+                                   resampling_strategy='holdout-iterative-fit')
+
+    automl_fitted = automl.fit(X, y)
+    assert automl is automl_fitted
+
+    automl_ensemble_fitted = automl.fit_ensemble(y, ensemble_size=5)
+    assert automl is automl_ensemble_fitted
+
+    # We want to make sure we can learn from this data.
+    # This is a test to make sure the data format (numpy/pandas)
+    # can be used in a meaningful way -- not meant for generalization,
+    # hence we use the train dataset
+    assert automl_fitted.score(X, y) > 0.9

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -127,13 +127,13 @@ def test_feat_type_wrong_arguments():
     y = np.zeros((100, ))
 
     cls = AutoSklearnClassifier(ensemble_size=0)
-    expected_msg = r".*Array feat_type does not have same number of "
+    expected_msg = r".*feat_type does not have same number of "
     "variables as X has features. 1 vs 100.*"
     with pytest.raises(ValueError, match=expected_msg):
         cls.fit(X=X, y=y, feat_type=[True])
 
     cls = AutoSklearnClassifier(ensemble_size=0)
-    expected_msg = r".*Array feat_type must only contain strings.*"
+    expected_msg = r".*feat_type must only contain strings.*"
     with pytest.raises(ValueError, match=expected_msg):
         cls.fit(X=X, y=y, feat_type=[True]*100)
 

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -851,4 +851,4 @@ def test_pass_categorical_and_numeric_columns_to_pipeline(
     if include_categorical:
         expected_dict = {i: 'numerical' for i in range(np.shape(X)[1] - 1)}
         expected_dict[X.shape[1] - 1] = 'categorical'
-        assert expected_dict == pipeline.named_steps['data_preprocessing'].categorical_features
+        assert expected_dict == pipeline.named_steps['data_preprocessing'].feat_type

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -400,6 +400,7 @@ def test_featurevalidator_new_data_after_fit(openml_id,
         1468,  # cnae-9
         40975,  # car
         40984,  # Segment
+        2,  # anneal
     ),
 )
 def test_list_to_dataframe(openml_id):
@@ -415,6 +416,12 @@ def test_list_to_dataframe(openml_id):
             # convert dtype translates 72.0 to 72. Be robust against this!
             assert is_numeric_dtype(transformed_X[i].dtype)
         else:
+            # For anneal, the pandas has the knowledge of a int column
+            # being categorical. We cannot know that from just a list
+            # for this reason, this check considers categorical and numerical
+            # as equivalent
+            if X_pandas[col].dtype.name == 'category' and 'Int' in transformed_X[i].dtype.name:
+                continue
             assert X_pandas[col].dtype.name == transformed_X[i].dtype.name
 
 

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -432,7 +432,6 @@ def test_list_to_dataframe(openml_id):
             assert X_pandas[col].dtype.name == transformed_X[i].dtype.name, col
 
 
-
 @pytest.mark.parametrize(
     'input_data_featuretest',
     (

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -240,21 +240,6 @@ def test_featurevalidator_unsupported_numpy(input_data_featuretest):
 @pytest.mark.parametrize(
     'input_data_featuretest',
     (
-        'pandas_categoricalonly_nan',
-        'pandas_mixed_nan',
-        'openml_179',  # adult workclass has NaN in columns
-    ),
-    indirect=True
-)
-def test_featurevalidator_unsupported_pandas(input_data_featuretest):
-    validator = FeatureValidator()
-    with pytest.raises(ValueError, match=r"Categorical features in a dataframe.*missing/NaN"):
-        validator.fit(input_data_featuretest)
-
-
-@pytest.mark.parametrize(
-    'input_data_featuretest',
-    (
         'numpy_categoricalonly_nonan',
         'numpy_mixed_nonan',
         'numpy_categoricalonly_nan',
@@ -335,12 +320,9 @@ def test_features_unsupported_calls_are_raised():
         validator.fit(
             pd.DataFrame({'datetime': [pd.Timestamp('20180310')]})
         )
-    with pytest.raises(ValueError, match="has invalid type object"):
-        validator.fit(
-            pd.DataFrame({'string': ['foo']})
-        )
     with pytest.raises(ValueError, match=r"Auto-sklearn only supports.*yet, the provided input"):
         validator.fit({'input1': 1, 'input2': 2})
+    validator = FeatureValidator()
     with pytest.raises(ValueError, match=r"has unsupported dtype string"):
         validator.fit(pd.DataFrame([{'A': 1, 'B': 2}], dtype='string'))
     with pytest.raises(ValueError, match=r"The feature dimensionality of the train and test"):

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -444,3 +444,10 @@ def test_sparse_output_is_csr(input_data_featuretest):
     transformed_X = validator.transform(input_data_featuretest)
     assert sparse.issparse(transformed_X)
     assert isinstance(transformed_X, sparse.csr_matrix)
+
+
+def test_unsupported_dataframe_sparse():
+    df = pd.DataFrame({'A': pd.Series(pd.arrays.SparseArray(np.random.randn(10)))})
+    validator = FeatureValidator()
+    with pytest.raises(ValueError, match=r"Auto-sklearn does not yet support sparse pandas"):
+        validator.fit(df)

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -334,10 +334,10 @@ def test_features_unsupported_calls_are_raised():
     validator = FeatureValidator(feat_type=['Numerical'])
     with pytest.raises(ValueError, match=r"providing the option feat_type to the fit method is.*"):
         validator.fit(pd.DataFrame([[1, 2, 3], [4, 5, 6]]))
-    with pytest.raises(ValueError, match=r"Array feat_type does not have same number of.*"):
+    with pytest.raises(ValueError, match=r"feat_type does not have same number of.*"):
         validator.fit(np.array([[1, 2, 3], [4, 5, 6]]))
     validator = FeatureValidator(feat_type=[1, 2, 3])
-    with pytest.raises(ValueError, match=r"Array feat_type must only contain strings.*"):
+    with pytest.raises(ValueError, match=r"feat_type must only contain strings.*"):
         validator.fit(np.array([[1, 2, 3], [4, 5, 6]]))
     validator = FeatureValidator(feat_type=['1', '2', '3'])
     with pytest.raises(ValueError, match=r"Only `Categorical` and `Numerical` are.*"):

--- a/test/test_data/test_validation.py
+++ b/test/test_data/test_validation.py
@@ -43,15 +43,10 @@ def test_data_validation_for_classification(openmlid, as_frame):
         assert np.any(pd.isnull(X_train_t).all(axis=0))
 
     # make sure everything was encoded to number
-    assert np.issubdtype(X_train_t.dtype, np.number)
     assert np.issubdtype(y_train_t.dtype, np.number)
 
-    # Categorical columns are sorted to the beginning
-    if as_frame:
-        validator.feature_validator.feat_type is not None
-        ordered_unique_elements = list(dict.fromkeys(validator.feature_validator.feat_type))
-        if len(ordered_unique_elements) > 1:
-            assert ordered_unique_elements[0] == 'categorical'
+    # Make sure we created a feat type
+    validator.feature_validator.feat_type is not None
 
 
 @pytest.mark.parametrize('openmlid', [505, 546, 531])
@@ -84,16 +79,7 @@ def test_data_validation_for_regression(openmlid, as_frame):
     elif not as_frame and np.any(pd.isnull(X_train).all(axis=0)):
         assert np.any(pd.isnull(X_train_t).all(axis=0))
 
-    # make sure everything was encoded to number
-    assert np.issubdtype(X_train_t.dtype, np.number)
-    assert np.issubdtype(y_train_t.dtype, np.number)
-
-    # Categorical columns are sorted to the beginning
-    if as_frame:
-        validator.feature_validator.feat_type is not None
-        ordered_unique_elements = list(dict.fromkeys(validator.feature_validator.feat_type))
-        if len(ordered_unique_elements) > 1:
-            assert ordered_unique_elements[0] == 'categorical'
+    validator.feature_validator.feat_type is not None
 
 
 def test_sparse_data_validation_for_regression():

--- a/test/test_evaluation/evaluation_util.py
+++ b/test/test_evaluation/evaluation_util.py
@@ -123,7 +123,10 @@ def get_multiclass_classification_datamanager():
         'X_test': X_test,
         'Y_test': Y_test
     }
-    D.feat_type = ['numerical', 'Numerical', 'numerical', 'numerical']
+    D.feat_type = {0: 'numerical',
+                   1: 'Numerical',
+                   2: 'numerical',
+                   3: 'numerical'}
     return D
 
 
@@ -131,9 +134,10 @@ def get_abalone_datamanager():
     # https://www.openml.org/d/183
     dataset_name = 'abalone'
     data = sklearn.datasets.fetch_openml(data_id=183, as_frame=True)
-    feat_type = [
-        'Categorical' if x.name == 'category' else 'Numerical' for x in data['data'].dtypes
-    ]
+    feat_type = {
+        i: 'Categorical' if x.name == 'category' else 'Numerical'
+        for i, x in enumerate(data['data'].dtypes)
+    }
     X, y = sklearn.datasets.fetch_openml(data_id=183, return_X_y=True, as_frame=False)
     y = preprocessing.LabelEncoder().fit_transform(y)
     X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(
@@ -186,7 +190,10 @@ def get_multilabel_classification_datamanager():
         'X_test': X_test,
         'Y_test': Y_test
     }
-    D.feat_type = ['numerical', 'Numerical', 'numerical', 'numerical']
+    D.feat_type = {0: 'numerical',
+                   1: 'Numerical',
+                   2: 'numerical',
+                   3: 'numerical'}
     return D
 
 
@@ -225,7 +232,10 @@ def get_binary_classification_datamanager():
         'X_test': X_test,
         'Y_test': Y_test.reshape((-1, 1))
     }
-    D.feat_type = ['numerical', 'Numerical', 'numerical', 'numerical']
+    D.feat_type = {0: 'numerical',
+                   1: 'Numerical',
+                   2: 'numerical',
+                   3: 'numerical'}
     return D
 
 
@@ -256,9 +266,7 @@ def get_regression_datamanager():
         'X_test': X_test,
         'Y_test': Y_test.reshape((-1, 1))
     }
-    D.feat_type = ['numerical', 'Numerical', 'numerical', 'numerical',
-                   'numerical', 'numerical', 'numerical', 'numerical',
-                   'numerical', 'numerical', 'numerical']
+    D.feat_type = {i: 'numerical' for i in range(X_train.shape[1])}
     return D
 
 
@@ -290,7 +298,7 @@ def get_500_classes_datamanager():
               'X_valid': X[700:710], 'Y_valid': Y[700:710],
               'X_test': X[710:], 'Y_test': Y[710:]
               }
-    D.feat_type = ['numerical'] * 20
+    D.feat_type = {i: 'numerical' for i in range(20)}
     return D
 
 

--- a/test/test_evaluation/test_train_evaluator.py
+++ b/test/test_evaluation/test_train_evaluator.py
@@ -1063,7 +1063,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         D = unittest.mock.Mock(spec=AbstractDataManager)
         D.data = dict(Y_train=np.array([0, 0, 0, 1, 1, 1]))
         D.info = dict(task=BINARY_CLASSIFICATION)
-        D.feat_type = []
+        D.feat_type = {}
 
         # holdout, binary classification
         evaluator = TrainEvaluator()
@@ -1218,7 +1218,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         D = unittest.mock.Mock(spec=AbstractDataManager)
         D.data = dict(Y_train=np.array([0, 0, 0, 1, 1, 1]))
         D.info = dict(task=BINARY_CLASSIFICATION)
-        D.feat_type = []
+        D.feat_type = {}
 
         # GroupKFold, classification with args
         D.data['Y_train'] = np.array([0, 0, 0, 1, 1, 1])
@@ -2139,7 +2139,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
     def test_holdout_split_size(self, te_mock):
         te_mock.return_value = None
         D = unittest.mock.Mock(spec=AbstractDataManager)
-        D.feat_type = []
+        D.feat_type = {}
 
         evaluator = TrainEvaluator()
         evaluator.resampling_strategy = 'holdout'

--- a/test/test_metalearning/pyMetaLearn/test_meta_features.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features.py
@@ -11,7 +11,7 @@ import pytest
 import arff
 from joblib import Memory
 import numpy as np
-from sklearn.datasets import make_multilabel_classification
+from sklearn.datasets import make_multilabel_classification, fetch_openml
 
 from autosklearn.pipeline.components.data_preprocessing.data_preprocessing \
     import DataPreprocessor
@@ -58,8 +58,9 @@ def meta_train_data(request):
     attribute_types = [
         'numeric' if type(type_) != list else 'nominal'
         for name, type_ in dataset['attributes'][:-1]]
-    categorical = [True if attribute == 'nominal' else False
-                   for attribute in attribute_types]
+
+    categorical = {i: True if attribute == 'nominal' else False
+                   for i, attribute in enumerate(attribute_types)}
 
     data = np.array(dataset['data'], dtype=np.float64)
     X = data[:, :-1]
@@ -101,8 +102,8 @@ def meta_train_data_transformed(request):
     attribute_types = [
         'numeric' if type(type_) != list else 'nominal'
         for name, type_ in dataset['attributes'][:-1]]
-    categorical = [True if attribute == 'nominal' else False
-                   for attribute in attribute_types]
+    categorical = {i: True if attribute == 'nominal' else False
+                   for i, attribute in enumerate(attribute_types)}
 
     data = np.array(dataset['data'], dtype=np.float64)
     X = data[:, :-1]
@@ -122,15 +123,13 @@ def meta_train_data_transformed(request):
     )
 
     DPP = DataPreprocessor(feat_type={
-        i: 'categorical' if feat else 'numerical' for i, feat in enumerate(categorical)
+        col: 'categorical' if category else 'numerical' for col, category in categorical.items()
     })
     X_transformed = DPP.fit_transform(X)
 
-    number_numerical = np.sum(~np.array(categorical))
-    categorical_transformed = [True] * (X_transformed.shape[1] -
-                                        number_numerical) + \
-                              [False] * number_numerical
-    categorical_transformed = categorical_transformed
+    number_numerical = np.sum(~np.array(list(categorical.values())))
+    categorical_transformed = {i: True if i < (X_transformed.shape[1] - number_numerical) else False
+                               for i in range(X_transformed.shape[1])}
 
     # pre-compute values for transformed inputs
     meta_features.helper_functions.set_value(
@@ -153,464 +152,598 @@ def meta_train_data_transformed(request):
         raise ValueError(request.param)
 
 
-class TestMetaFeatures:
-    def test_number_of_instance(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["NumberOfInstances"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == 898
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_number_of_classes(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["NumberOfClasses"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == 5
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_number_of_features(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["NumberOfFeatures"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == 38
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_missing_values(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.helper_functions["MissingValues"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert isinstance(mf.value, pd.DataFrame if hasattr(X, 'iloc') else np.ndarray)
-        assert mf.value.shape == X.shape
-        # TODO: ASK MATTHIAS FOR THIS CHANGE OF np.sum->np.count_nonzero
-        assert 22175 == np.count_nonzero(mf.value)
-
-    def test_number_of_Instances_with_missing_values(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["NumberOfInstancesWithMissingValues"](
-            X, y, logging.getLogger('Meta'), categorical)
-        assert mf.value == 898
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_percentage_of_Instances_with_missing_values(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        meta_features.metafeatures.set_value(
-            "NumberOfInstancesWithMissingValues",
-            meta_features.metafeatures["NumberOfInstancesWithMissingValues"](
-                X, y, logging.getLogger('Meta'),  categorical),
-            )
-        mf = meta_features.metafeatures["PercentageOfInstancesWithMissingValues"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert pytest.approx(mf.value) == 1.0
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_number_of_features_with_missing_values(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["NumberOfFeaturesWithMissingValues"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == 29
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_percentage_of_features_with_missing_values(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        meta_features.metafeatures.set_value(
-            "NumberOfFeaturesWithMissingValues",
-            meta_features.metafeatures["NumberOfFeaturesWithMissingValues"](
-                X, y, logging.getLogger('Meta'),  categorical))
-        mf = meta_features.metafeatures["PercentageOfFeaturesWithMissingValues"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert pytest.approx(mf.value) == float(29)/float(38)
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_number_of_missing_values(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["NumberOfMissingValues"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == 22175
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_percentage_missing_values(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        meta_features.metafeatures.set_value(
-            "NumberOfMissingValues", meta_features.metafeatures["NumberOfMissingValues"](
-                X, y, logging.getLogger('Meta'),  categorical))
-        mf = meta_features.metafeatures["PercentageOfMissingValues"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert pytest.approx(mf.value) == (float(22175)/float(38*898))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_number_of_numeric_features(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["NumberOfNumericFeatures"](
-            X, y, logging.getLogger('Meta'), categorical)
-        assert mf.value == 6
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_number_of_categorical_features(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["NumberOfCategoricalFeatures"](
-            X, y, logging.getLogger('Meta'), categorical)
-        assert mf.value == 32
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_ratio_numerical_to_categorical(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["RatioNumericalToNominal"](
-            X, y, logging.getLogger('Meta'), categorical)
-        assert pytest.approx(mf.value) == (float(6)/float(32))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_ratio_categorical_to_numerical(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["RatioNominalToNumerical"](
-            X, y, logging.getLogger('Meta'), categorical)
-        assert pytest.approx(mf.value) == (float(32)/float(6))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_dataset_ratio(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["DatasetRatio"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert pytest.approx(mf.value) == (float(38)/float(898))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_inverse_dataset_ratio(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["InverseDatasetRatio"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert pytest.approx(mf.value) == (float(898)/float(38))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_class_occurences(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.helper_functions["ClassOccurences"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == {0.0: 8.0, 1.0: 99.0, 2.0: 684.0, 4.0: 67.0, 5.0: 40.0}
-
-    def test_class_probability_min(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["ClassProbabilityMin"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert pytest.approx(mf.value) == (float(8)/float(898))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_class_probability_max(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["ClassProbabilityMax"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        assert pytest.approx(mf.value) == (float(684)/float(898))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_class_probability_mean(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["ClassProbabilityMean"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        classes = np.array((8, 99, 684, 67, 40), dtype=np.float64)
-        prob_mean = (classes / float(898)).mean()
-        assert pytest.approx(mf.value) == prob_mean
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_class_probability_std(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["ClassProbabilitySTD"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        classes = np.array((8, 99, 684, 67, 40), dtype=np.float64)
-        prob_std = (classes / float(898)).std()
-        assert pytest.approx(mf.value) == prob_std
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_num_symbols(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.helper_functions["NumSymbols"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        symbol_frequency = [2, 1, 7, 1, 2, 4, 1, 1, 4, 2, 1, 1, 1, 2, 1, 0,
-                            1, 1, 1, 0, 1, 1, 0, 3, 1, 0, 0, 0, 2, 2, 3, 2]
-        assert mf.value == symbol_frequency
-
-    def test_symbols_min(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["SymbolsMin"](X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == 1
-
-    def test_symbols_max(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        # this is attribute steel
-        mf = meta_features.metafeatures["SymbolsMax"](X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == 7
-
-    def test_symbols_mean(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["SymbolsMean"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        # Empty looking spaces denote empty attributes
-        symbol_frequency = [2, 1, 7, 1, 2, 4, 1, 1, 4, 2, 1, 1, 1, 2, 1,  #
-                            1, 1, 1,   1, 1,    3, 1,           2, 2, 3, 2]
-        assert pytest.approx(mf.value) == np.mean(symbol_frequency)
-
-    def test_symbols_std(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["SymbolsSTD"](X, y, logging.getLogger('Meta'),  categorical)
-        symbol_frequency = [2, 1, 7, 1, 2, 4, 1, 1, 4, 2, 1, 1, 1, 2, 1,  #
-                            1, 1, 1,   1, 1,    3, 1,           2, 2, 3, 2]
-        assert pytest.approx(mf.value) == np.std(symbol_frequency)
-
-    def test_symbols_sum(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["SymbolsSum"](X, y, logging.getLogger('Meta'),  categorical)
-        assert mf.value == 49
-
-    def test_class_entropy(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.metafeatures["ClassEntropy"](
-            X, y, logging.getLogger('Meta'),  categorical)
-        classes = np.array((8, 99, 684, 67, 40), dtype=np.float64)
-        classes = classes / sum(classes)
-        entropy = -np.sum([c * np.log2(c) for c in classes])
-
-        assert pytest.approx(mf.value) == entropy
-
-    def test_calculate_all_metafeatures(self, meta_train_data):
-        X, y, categorical = meta_train_data
-        mf = meta_features.calculate_all_metafeatures(
-            X, y, categorical, "2", logger=logging.getLogger('Meta'))
-        assert 52 == len(mf.metafeature_values)
-        assert mf.metafeature_values['NumberOfCategoricalFeatures'].value == 32
-        sio = StringIO()
-        mf.dump(sio)
-
-
-class TestMetaFeaturesTransformed:
-    def test_kurtosisses(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        mf = meta_features.helper_functions["Kurtosisses"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-        assert 6 == len(mf.value)
-
-    def test_kurtosis_min(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["KurtosisMin"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-
-    def test_kurtosis_max(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["KurtosisMax"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-
-    def test_kurtosis_mean(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["KurtosisMean"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-
-    def test_kurtosis_std(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["KurtosisSTD"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-
-    def test_skewnesses(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        mf = meta_features.helper_functions["Skewnesses"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-        assert 6 == len(mf.value)
-
-    def test_skewness_min(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["SkewnessMin"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-
-    def test_skewness_max(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["SkewnessMax"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-
-    def test_skewness_mean(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["SkewnessMean"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-
-    def test_skewness_std(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["SkewnessSTD"](
-            X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
-
-    def test_landmark_lda(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["LandmarkLDA"](X_transformed, y, logging.getLogger('Meta'))
-
-    def test_landmark_naive_bayes(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["LandmarkNaiveBayes"](
-            X_transformed, y, logging.getLogger('Meta'))
-
-    def test_landmark_decision_tree(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["LandmarkDecisionTree"](
-            X_transformed, y, logging.getLogger('Meta'))
-
-    def test_decision_node(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["LandmarkDecisionNodeLearner"](
-            X_transformed, y, logging.getLogger('Meta'))
-
-    def test_random_node(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["LandmarkRandomNodeLearner"](
-            X_transformed, y, logging.getLogger('Meta'))
-
-    @unittest.skip("Currently not implemented!")
-    def test_worst_node(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["LandmarkWorstNodeLearner"](
-            X_transformed, y, logging.getLogger('Meta'))
-
-    def test_1NN(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        # TODO: somehow compute the expected output?
-        meta_features.metafeatures["Landmark1NN"](X_transformed, y, logging.getLogger('Meta'))
-
-    def test_pca(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        meta_features.helper_functions["PCA"](X_transformed, y, logging.getLogger('Meta'))
-
-    def test_pca_95percent(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        mf = meta_features.metafeatures["PCAFractionOfComponentsFor95PercentVariance"](
-            X_transformed, y, logging.getLogger('Meta'))
-        assert pytest.approx(0.2716049382716049) == mf.value
-
-    def test_pca_kurtosis_first_pc(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        mf = meta_features.metafeatures["PCAKurtosisFirstPC"](
-            X_transformed, y, logging.getLogger('Meta'))
-        assert pytest.approx(-0.702850) != mf.value
-
-    def test_pca_skewness_first_pc(self, meta_train_data_transformed):
-        X_transformed, y, categorical_transformed = meta_train_data_transformed
-        mf = meta_features.metafeatures["PCASkewnessFirstPC"](
-            X_transformed, y, logging.getLogger('Meta'))
-        assert pytest.approx(0.051210) != mf.value
-
-
-class TestMetaFeaturesMultiLabel:
-    def test_class_occurences_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.helper_functions["ClassOccurences"](X, y, logging.getLogger('Meta'))
-        assert mf.value == [{0: 16.0, 1: 84.0},
-                            {0: 8.0, 1: 92.0},
-                            {0: 68.0, 1: 32.0},
-                            {0: 15.0, 1: 85.0},
-                            {0: 28.0, 1: 72.0}]
-
-    def test_class_probability_min_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        meta_features.helper_functions.set_value(
-            "ClassOccurences", meta_features.helper_functions["ClassOccurences"](
-                X, y, logging.getLogger('Meta')))
-        mf = meta_features.metafeatures["ClassProbabilityMin"](X, y, logging.getLogger('Meta'))
-        assert pytest.approx(mf.value) == (float(8) / float(100))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_class_probability_max_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        meta_features.helper_functions.set_value(
-            "ClassOccurences", meta_features.helper_functions["ClassOccurences"](
-                X, y, logging.getLogger('Meta')))
-        mf = meta_features.metafeatures["ClassProbabilityMax"](X, y, logging.getLogger('Meta'))
-        assert pytest.approx(mf.value) == (float(92) / float(100))
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_class_probability_mean_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        meta_features.helper_functions.set_value(
-            "ClassOccurences", meta_features.helper_functions["ClassOccurences"](
-                X, y, logging.getLogger('Meta')))
-        mf = meta_features.metafeatures["ClassProbabilityMean"](X, y, logging.getLogger('Meta'))
-        classes = [(16, 84), (8, 92), (68, 32), (15, 85), (28, 72)]
-        probas = np.mean([np.mean(np.array(cls_)) / 100 for cls_ in classes])
-        assert mf.value == pytest.approx(probas)
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_number_of_classes_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.metafeatures["NumberOfClasses"](X, y, logging.getLogger('Meta'))
-        assert mf.value == 2
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_class_probability_std_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        meta_features.helper_functions.set_value(
-            "ClassOccurences", meta_features.helper_functions["ClassOccurences"](
-                X, y, logging.getLogger('Meta')))
-        mf = meta_features.metafeatures["ClassProbabilitySTD"](X, y, logging.getLogger('Meta'))
-        classes = [(16, 84), (8, 92), (68, 32), (15, 85), (28, 72)]
-        probas = np.mean([np.std(np.array(cls_) / 100.) for cls_ in classes])
-        assert pytest.approx(mf.value) == probas
-        assert isinstance(mf, MetaFeatureValue)
-
-    def test_class_entropy_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.metafeatures["ClassEntropy"](X, y, logging.getLogger('Meta'))
-
-        classes = [(16, 84), (8, 92), (68, 32), (15, 85), (28, 72)]
-        entropies = []
-        for cls in classes:
-            cls = np.array(cls, dtype=np.float32)
-            cls = cls / sum(cls)
-            entropy = -np.sum([c * np.log2(c) for c in cls])
-            entropies.append(entropy)
-
-        assert pytest.approx(mf.value) == np.mean(entropies)
-
-    def test_landmark_lda_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.metafeatures["LandmarkLDA"](X, y, logging.getLogger('Meta'))
-        assert np.isfinite(mf.value)
-
-    def test_landmark_naive_bayes_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.metafeatures["LandmarkNaiveBayes"](X, y, logging.getLogger('Meta'))
-        assert np.isfinite(mf.value)
-
-    def test_landmark_decision_tree_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.metafeatures["LandmarkDecisionTree"](X, y, logging.getLogger('Meta'))
-        assert np.isfinite(mf.value)
-
-    def test_landmark_decision_node_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.metafeatures["LandmarkDecisionNodeLearner"](
-            X, y, logging.getLogger('Meta'))
-        assert np.isfinite(mf.value)
-
-    def test_landmark_random_node_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.metafeatures["LandmarkRandomNodeLearner"](
-            X, y, logging.getLogger('Meta'))
-        assert np.isfinite(mf.value)
-
-    def test_1NN_multilabel(self, multilabel_train_data):
-        X, y = multilabel_train_data
-        mf = meta_features.metafeatures["Landmark1NN"](X, y, logging.getLogger('TestMeta'))
-        assert np.isfinite(mf.value)
-
-    def test_calculate_all_metafeatures_multilabel(self, multilabel_train_data):
-        meta_features.helper_functions.clear()
-        X, y = multilabel_train_data
-        categorical = [False] * 10
-        mf = meta_features.calculate_all_metafeatures(
-            X, y,  categorical, "Generated", logger=logging.getLogger('TestMeta'))
-        assert 52 == len(mf.metafeature_values)
-        sio = StringIO()
-        mf.dump(sio)
+def test_number_of_instance(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["NumberOfInstances"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == 898
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_number_of_classes(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["NumberOfClasses"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == 5
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_number_of_features(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["NumberOfFeatures"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == 38
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_missing_values(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.helper_functions["MissingValues"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert isinstance(mf.value, pd.DataFrame if hasattr(X, 'iloc') else np.ndarray)
+    assert mf.value.shape == X.shape
+    assert 22175 == np.count_nonzero(mf.value)
+
+
+def test_number_of_Instances_with_missing_values(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["NumberOfInstancesWithMissingValues"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert mf.value == 898
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_percentage_of_Instances_with_missing_values(meta_train_data):
+    X, y, categorical = meta_train_data
+    meta_features.metafeatures.set_value(
+        "NumberOfInstancesWithMissingValues",
+        meta_features.metafeatures["NumberOfInstancesWithMissingValues"](
+            X, y, logging.getLogger('Meta'),  categorical),
+        )
+    mf = meta_features.metafeatures["PercentageOfInstancesWithMissingValues"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert pytest.approx(mf.value) == 1.0
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_number_of_features_with_missing_values(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["NumberOfFeaturesWithMissingValues"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == 29
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_percentage_of_features_with_missing_values(meta_train_data):
+    X, y, categorical = meta_train_data
+    meta_features.metafeatures.set_value(
+        "NumberOfFeaturesWithMissingValues",
+        meta_features.metafeatures["NumberOfFeaturesWithMissingValues"](
+            X, y, logging.getLogger('Meta'),  categorical))
+    mf = meta_features.metafeatures["PercentageOfFeaturesWithMissingValues"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert pytest.approx(mf.value) == float(29)/float(38)
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_number_of_missing_values(meta_train_data):
+    X, y, categorical = meta_train_data
+    np.save('/tmp/debug', X)
+    mf = meta_features.metafeatures["NumberOfMissingValues"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == 22175
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_percentage_missing_values(meta_train_data):
+    X, y, categorical = meta_train_data
+    meta_features.metafeatures.set_value(
+        "NumberOfMissingValues", meta_features.metafeatures["NumberOfMissingValues"](
+            X, y, logging.getLogger('Meta'),  categorical))
+    mf = meta_features.metafeatures["PercentageOfMissingValues"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert pytest.approx(mf.value) == (float(22175)/float(38*898))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_number_of_numeric_features(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["NumberOfNumericFeatures"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert mf.value == 6
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_number_of_categorical_features(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["NumberOfCategoricalFeatures"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert mf.value == 32
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_ratio_numerical_to_categorical(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["RatioNumericalToNominal"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert pytest.approx(mf.value) == (float(6)/float(32))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_ratio_categorical_to_numerical(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["RatioNominalToNumerical"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert pytest.approx(mf.value) == (float(32)/float(6))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_dataset_ratio(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["DatasetRatio"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert pytest.approx(mf.value) == (float(38)/float(898))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_inverse_dataset_ratio(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["InverseDatasetRatio"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert pytest.approx(mf.value) == (float(898)/float(38))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_class_occurences(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.helper_functions["ClassOccurences"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == {0.0: 8.0, 1.0: 99.0, 2.0: 684.0, 4.0: 67.0, 5.0: 40.0}
+
+
+def test_class_probability_min(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["ClassProbabilityMin"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert pytest.approx(mf.value) == (float(8)/float(898))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_class_probability_max(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["ClassProbabilityMax"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    assert pytest.approx(mf.value) == (float(684)/float(898))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_class_probability_mean(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["ClassProbabilityMean"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    classes = np.array((8, 99, 684, 67, 40), dtype=np.float64)
+    prob_mean = (classes / float(898)).mean()
+    assert pytest.approx(mf.value) == prob_mean
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_class_probability_std(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["ClassProbabilitySTD"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    classes = np.array((8, 99, 684, 67, 40), dtype=np.float64)
+    prob_std = (classes / float(898)).std()
+    assert pytest.approx(mf.value) == prob_std
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_num_symbols(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.helper_functions["NumSymbols"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    symbol_frequency = [2, 1, 7, 1, 2, 4, 1, 1, 4, 2, 1, 1, 1, 2, 1, 0,
+                        1, 1, 1, 0, 1, 1, 0, 3, 1, 0, 0, 0, 2, 2, 3, 2]
+    assert mf.value == symbol_frequency
+
+
+def test_symbols_min(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["SymbolsMin"](X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == 1
+
+
+def test_symbols_max(meta_train_data):
+    X, y, categorical = meta_train_data
+    # this is attribute steel
+    mf = meta_features.metafeatures["SymbolsMax"](X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == 7
+
+
+def test_symbols_mean(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["SymbolsMean"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    # Empty looking spaces denote empty attributes
+    symbol_frequency = [2, 1, 7, 1, 2, 4, 1, 1, 4, 2, 1, 1, 1, 2, 1,  #
+                        1, 1, 1,   1, 1,    3, 1,           2, 2, 3, 2]
+    assert pytest.approx(mf.value) == np.mean(symbol_frequency)
+
+
+def test_symbols_std(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["SymbolsSTD"](X, y, logging.getLogger('Meta'),  categorical)
+    symbol_frequency = [2, 1, 7, 1, 2, 4, 1, 1, 4, 2, 1, 1, 1, 2, 1,  #
+                        1, 1, 1,   1, 1,    3, 1,           2, 2, 3, 2]
+    assert pytest.approx(mf.value) == np.std(symbol_frequency)
+
+
+def test_symbols_sum(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["SymbolsSum"](X, y, logging.getLogger('Meta'),  categorical)
+    assert mf.value == 49
+
+
+def test_class_entropy(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.metafeatures["ClassEntropy"](
+        X, y, logging.getLogger('Meta'),  categorical)
+    classes = np.array((8, 99, 684, 67, 40), dtype=np.float64)
+    classes = classes / sum(classes)
+    entropy = -np.sum([c * np.log2(c) for c in classes])
+
+    assert pytest.approx(mf.value) == entropy
+
+
+def test_calculate_all_metafeatures(meta_train_data):
+    X, y, categorical = meta_train_data
+    mf = meta_features.calculate_all_metafeatures(
+        X, y, categorical, "2", logger=logging.getLogger('Meta'))
+    assert 52 == len(mf.metafeature_values)
+    assert mf.metafeature_values['NumberOfCategoricalFeatures'].value == 32
+    sio = StringIO()
+    mf.dump(sio)
+
+
+def test_kurtosisses(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    mf = meta_features.helper_functions["Kurtosisses"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+    assert 6 == len(mf.value)
+
+
+def test_kurtosis_min(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["KurtosisMin"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+
+
+def test_kurtosis_max(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["KurtosisMax"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+
+
+def test_kurtosis_mean(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["KurtosisMean"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+
+
+def test_kurtosis_std(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["KurtosisSTD"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+
+
+def test_skewnesses(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    mf = meta_features.helper_functions["Skewnesses"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+    assert 6 == len(mf.value)
+
+
+def test_skewness_min(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["SkewnessMin"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+
+
+def test_skewness_max(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["SkewnessMax"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+
+
+def test_skewness_mean(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["SkewnessMean"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+
+
+def test_skewness_std(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["SkewnessSTD"](
+        X_transformed, y, logging.getLogger('Meta'), categorical_transformed)
+
+
+def test_landmark_lda(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["LandmarkLDA"](X_transformed, y, logging.getLogger('Meta'))
+
+
+def test_landmark_naive_bayes(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["LandmarkNaiveBayes"](
+        X_transformed, y, logging.getLogger('Meta'))
+
+
+def test_landmark_decision_tree(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["LandmarkDecisionTree"](
+        X_transformed, y, logging.getLogger('Meta'))
+
+
+def test_decision_node(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["LandmarkDecisionNodeLearner"](
+        X_transformed, y, logging.getLogger('Meta'))
+
+
+def test_random_node(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["LandmarkRandomNodeLearner"](
+        X_transformed, y, logging.getLogger('Meta'))
+
+
+@unittest.skip("Currently not implemented!")
+def test_worst_node(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["LandmarkWorstNodeLearner"](
+        X_transformed, y, logging.getLogger('Meta'))
+
+
+def test_1NN(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    # TODO: somehow compute the expected output?
+    meta_features.metafeatures["Landmark1NN"](X_transformed, y, logging.getLogger('Meta'))
+
+
+def test_pca(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    meta_features.helper_functions["PCA"](X_transformed, y, logging.getLogger('Meta'))
+
+
+def test_pca_95percent(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    print(f"X_transformed={X_transformed} y={y} categorical_transformed={categorical_transformed}")
+    mf = meta_features.metafeatures["PCAFractionOfComponentsFor95PercentVariance"](
+        X_transformed, y, logging.getLogger('Meta'))
+    assert pytest.approx(0.2716049382716049) == mf.value
+
+
+def test_pca_kurtosis_first_pc(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    mf = meta_features.metafeatures["PCAKurtosisFirstPC"](
+        X_transformed, y, logging.getLogger('Meta'))
+    assert pytest.approx(-0.702850) != mf.value
+
+
+def test_pca_skewness_first_pc(meta_train_data_transformed):
+    X_transformed, y, categorical_transformed = meta_train_data_transformed
+    mf = meta_features.metafeatures["PCASkewnessFirstPC"](
+        X_transformed, y, logging.getLogger('Meta'))
+    assert pytest.approx(0.051210) != mf.value
+
+
+def test_class_occurences_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.helper_functions["ClassOccurences"](X, y, logging.getLogger('Meta'))
+    assert mf.value == [{0: 16.0, 1: 84.0},
+                        {0: 8.0, 1: 92.0},
+                        {0: 68.0, 1: 32.0},
+                        {0: 15.0, 1: 85.0},
+                        {0: 28.0, 1: 72.0}]
+
+
+def test_class_probability_min_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    meta_features.helper_functions.set_value(
+        "ClassOccurences", meta_features.helper_functions["ClassOccurences"](
+            X, y, logging.getLogger('Meta')))
+    mf = meta_features.metafeatures["ClassProbabilityMin"](X, y, logging.getLogger('Meta'))
+    assert pytest.approx(mf.value) == (float(8) / float(100))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_class_probability_max_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    meta_features.helper_functions.set_value(
+        "ClassOccurences", meta_features.helper_functions["ClassOccurences"](
+            X, y, logging.getLogger('Meta')))
+    mf = meta_features.metafeatures["ClassProbabilityMax"](X, y, logging.getLogger('Meta'))
+    assert pytest.approx(mf.value) == (float(92) / float(100))
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_class_probability_mean_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    meta_features.helper_functions.set_value(
+        "ClassOccurences", meta_features.helper_functions["ClassOccurences"](
+            X, y, logging.getLogger('Meta')))
+    mf = meta_features.metafeatures["ClassProbabilityMean"](X, y, logging.getLogger('Meta'))
+    classes = [(16, 84), (8, 92), (68, 32), (15, 85), (28, 72)]
+    probas = np.mean([np.mean(np.array(cls_)) / 100 for cls_ in classes])
+    assert mf.value == pytest.approx(probas)
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_number_of_classes_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.metafeatures["NumberOfClasses"](X, y, logging.getLogger('Meta'))
+    assert mf.value == 5
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_class_probability_std_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    meta_features.helper_functions.set_value(
+        "ClassOccurences", meta_features.helper_functions["ClassOccurences"](
+            X, y, logging.getLogger('Meta')))
+    mf = meta_features.metafeatures["ClassProbabilitySTD"](X, y, logging.getLogger('Meta'))
+    classes = [(16, 84), (8, 92), (68, 32), (15, 85), (28, 72)]
+    probas = np.mean([np.std(np.array(cls_) / 100.) for cls_ in classes])
+    assert pytest.approx(mf.value) == probas
+    assert isinstance(mf, MetaFeatureValue)
+
+
+def test_class_entropy_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.metafeatures["ClassEntropy"](X, y, logging.getLogger('Meta'))
+
+    classes = [(16, 84), (8, 92), (68, 32), (15, 85), (28, 72)]
+    entropies = []
+    for cls in classes:
+        cls = np.array(cls, dtype=np.float32)
+        cls = cls / sum(cls)
+        entropy = -np.sum([c * np.log2(c) for c in cls])
+        entropies.append(entropy)
+
+    assert pytest.approx(mf.value) == np.mean(entropies)
+
+
+def test_landmark_lda_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.metafeatures["LandmarkLDA"](X, y, logging.getLogger('Meta'))
+    assert np.isfinite(mf.value)
+
+
+def test_landmark_naive_bayes_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.metafeatures["LandmarkNaiveBayes"](X, y, logging.getLogger('Meta'))
+    assert np.isfinite(mf.value)
+
+
+def test_landmark_decision_tree_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.metafeatures["LandmarkDecisionTree"](X, y, logging.getLogger('Meta'))
+    assert np.isfinite(mf.value)
+
+
+def test_landmark_decision_node_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.metafeatures["LandmarkDecisionNodeLearner"](
+        X, y, logging.getLogger('Meta'))
+    assert np.isfinite(mf.value)
+
+
+def test_landmark_random_node_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.metafeatures["LandmarkRandomNodeLearner"](
+        X, y, logging.getLogger('Meta'))
+    assert np.isfinite(mf.value)
+
+
+def test_1NN_multilabel(multilabel_train_data):
+    X, y = multilabel_train_data
+    mf = meta_features.metafeatures["Landmark1NN"](X, y, logging.getLogger('TestMeta'))
+    assert np.isfinite(mf.value)
+
+
+def test_calculate_all_metafeatures_multilabel(multilabel_train_data):
+    meta_features.helper_functions.clear()
+    X, y = multilabel_train_data
+    categorical = {i: False for i in range(10)}
+    mf = meta_features.calculate_all_metafeatures(
+        X, y,  categorical, "Generated", logger=logging.getLogger('TestMeta'))
+    assert 52 == len(mf.metafeature_values)
+    sio = StringIO()
+    mf.dump(sio)
+
+
+def test_calculate_all_metafeatures_same_results_across_datatypes():
+    """
+    This test makes sure that numpy and pandas produce the same metafeatures.
+    This also is an excuse to fully test anneal dataset, and make sure
+    all metafeatures work in this complex dataset
+    """
+    X, y = fetch_openml(data_id=2, return_X_y=True, as_frame=True)
+    categorical = {col: True if X[col].dtype.name == 'category' else False
+                   for col in X.columns}
+    mf = meta_features.calculate_all_metafeatures(
+        X, y, categorical, "2", logger=logging.getLogger('Meta'))
+    assert 52 == len(mf.metafeature_values)
+    expected = {
+        # TODO: sync-up with matthias on landmarking
+        # Check all metafeatures, except landmarking
+        # which gives not approximate results. For example:
+        # 0.7616945996275606 == 0.7617070142768466 ± 7.6e-07
+        # among runs
+        'PCASkewnessFirstPC': 0.41897660337677867,
+        'PCAKurtosisFirstPC': -0.677692541156901,
+        'PCAFractionOfComponentsFor95PercentVariance': 0.2716049382716049,
+        'ClassEntropy': 1.1898338562043977,
+        'SkewnessSTD': 7.540418815675546,
+        'SkewnessMean': 1.47397188548894,
+        'SkewnessMax': 29.916569235579203,
+        'SkewnessMin': -29.916569235579203,
+        'KurtosisSTD': 153.0563504598898,
+        'KurtosisMean': 56.998860939761165,
+        'KurtosisMax': 893.0011148272025,
+        'KurtosisMin': -3.0,
+        'SymbolsSum': 49,
+        'SymbolsSTD': 1.3679553264445183,
+        'SymbolsMean': 1.8846153846153846,
+        'SymbolsMax': 7,
+        'SymbolsMin': 1,
+        'ClassProbabilitySTD': 0.28282850691819206,
+        'ClassProbabilityMean': 0.2,
+        'ClassProbabilityMax': 0.7616926503340757,
+        'ClassProbabilityMin': 0.008908685968819599,
+        'InverseDatasetRatio': 23.63157894736842,
+        'DatasetRatio': 0.042316258351893093,
+        'RatioNominalToNumerical': 5.333333333333333,
+        'RatioNumericalToNominal': 0.1875,
+        'NumberOfCategoricalFeatures': 32,
+        'NumberOfNumericFeatures': 6,
+        'NumberOfMissingValues': 22175.0,
+        'NumberOfFeaturesWithMissingValues': 29.0,
+        'NumberOfInstancesWithMissingValues': 898.0,
+        'NumberOfFeatures': 38.0,
+        'NumberOfClasses': 5.0,
+        'NumberOfInstances': 898.0,
+        'LogInverseDatasetRatio': 3.162583908575814,
+        'LogDatasetRatio': -3.162583908575814,
+        'PercentageOfMissingValues': 0.6498358926268901,
+        'PercentageOfFeaturesWithMissingValues': 0.7631578947368421,
+        'PercentageOfInstancesWithMissingValues': 1.0,
+        'LogNumberOfFeatures': 3.6375861597263857,
+        'LogNumberOfInstances': 6.8001700683022,
+    }
+    for key, value in expected.items():
+        assert mf[key].value == pytest.approx(value)
+
+    # Then do numpy!
+    X, y = fetch_openml(data_id=2, return_X_y=True, as_frame=False)
+    categorical = {i: True if categorical else False
+                   for i, categorical in enumerate(categorical.values())}
+    mf = meta_features.calculate_all_metafeatures(
+        X, y, categorical, "2", logger=logging.getLogger('Meta'))
+    for key, value in expected.items():
+        assert mf[key].value == pytest.approx(value)
+
+    sio = StringIO()
+    mf.dump(sio)

--- a/test/test_metalearning/pyMetaLearn/test_meta_features.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import tempfile
-from io import StringIO
 import unittest
 
 import pandas as pd
@@ -400,8 +399,6 @@ def test_calculate_all_metafeatures(meta_train_data):
         X, y, categorical, "2", logger=logging.getLogger('Meta'))
     assert 52 == len(mf.metafeature_values)
     assert mf.metafeature_values['NumberOfCategoricalFeatures'].value == 32
-    sio = StringIO()
-    mf.dump(sio)
 
 
 def test_kurtosisses(meta_train_data_transformed):
@@ -670,8 +667,6 @@ def test_calculate_all_metafeatures_multilabel(multilabel_train_data):
     mf = meta_features.calculate_all_metafeatures(
         X, y,  categorical, "Generated", logger=logging.getLogger('TestMeta'))
     assert 52 == len(mf.metafeature_values)
-    sio = StringIO()
-    mf.dump(sio)
 
 
 def test_calculate_all_metafeatures_same_results_across_datatypes():
@@ -687,11 +682,6 @@ def test_calculate_all_metafeatures_same_results_across_datatypes():
         X, y, categorical, "2", logger=logging.getLogger('Meta'))
     assert 52 == len(mf.metafeature_values)
     expected = {
-        # TODO: sync-up with matthias on landmarking
-        # Check all metafeatures, except landmarking
-        # which gives not approximate results. For example:
-        # 0.7616945996275606 == 0.7617070142768466 ± 7.6e-07
-        # among runs
         'PCASkewnessFirstPC': 0.41897660337677867,
         'PCAKurtosisFirstPC': -0.677692541156901,
         'PCAFractionOfComponentsFor95PercentVariance': 0.2716049382716049,
@@ -744,6 +734,3 @@ def test_calculate_all_metafeatures_same_results_across_datatypes():
         X, y, categorical, "2", logger=logging.getLogger('Meta'))
     for key, value in expected.items():
         assert mf[key].value == pytest.approx(value)
-
-    sio = StringIO()
-    mf.dump(sio)

--- a/test/test_metalearning/pyMetaLearn/test_meta_features.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features.py
@@ -39,7 +39,9 @@ class MetaFeaturesTest(TestCase):
         X = data[:, :-1]
         y = data[:, -1].reshape((-1,))
 
-        DPP = DataPreprocessor(categorical_features=self.categorical)
+        DPP = DataPreprocessor(feat_type={
+            i: 'categorical' if feat else 'numerical' for i, feat in enumerate(self.categorical)
+        })
         X_transformed = DPP.fit_transform(X)
 
         # Transform the array which indicates the categorical metafeatures

--- a/test/test_metalearning/pyMetaLearn/test_meta_features.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features.py
@@ -724,15 +724,16 @@ def test_calculate_all_metafeatures_same_results_across_datatypes():
     }
     assert {k: mf[k].value for k in expected.keys()} == pytest.approx(expected)
 
-    expected_landmark_pandas = {
-        'Landmark1NN': 0.6091806331471135,
-        'LandmarkRandomNodeLearner': 0.7617070142768466,
-        'LandmarkDecisionNodeLearner':  0.6502358783364369,
-        'LandmarkDecisionTree': 0.6047175667287399,
-        'LandmarkNaiveBayes': 0.5534698944754811,
+    expected_landmarks = {
+        'Landmark1NN': 0.9721601489757914,
+        'LandmarkRandomNodeLearner': 0.7616945996275606,
+        'LandmarkDecisionNodeLearner':  0.7827932960893855,
+        'LandmarkDecisionTree': 0.9899875853507139,
+        'LandmarkNaiveBayes': 0.9287150837988827,
+        'LandmarkLDA': 0.9610242085661079,
     }
-    assert {k: mf[k].value for k in expected_landmark_pandas.keys()} == pytest.approx(
-        expected_landmark_pandas, rel=1e-5)
+    assert {k: mf[k].value for k in expected_landmarks.keys()} == pytest.approx(
+        expected_landmarks, rel=1e-5)
 
     # Then do numpy!
     X, y = fetch_openml(data_id=2, return_X_y=True, as_frame=False)
@@ -745,12 +746,6 @@ def test_calculate_all_metafeatures_same_results_across_datatypes():
     # The column-reorder of pandas and numpy array are different after
     # the data preprocessing. So we cannot directly compare, and landmarking is
     # sensible to column order
-    expected_landmark_numpy = {
-        'Landmark1NN': 0.9721601489757914,
-        'LandmarkRandomNodeLearner': 0.7616945996275606,
-        'LandmarkDecisionNodeLearner': 0.7827932960893855,
-        'LandmarkDecisionTree': 0.9922098075729361,
-        'LandmarkNaiveBayes': 0.9287150837988827
-    }
-    assert {k: mf[k].value for k in expected_landmark_numpy.keys()} == pytest.approx(
-        expected_landmark_numpy, rel=1e-5)
+    expected_landmarks['LandmarkDecisionTree'] = 0.9922098075729361
+    assert {k: mf[k].value for k in expected_landmarks.keys()} == pytest.approx(
+        expected_landmarks, rel=1e-5)

--- a/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from io import StringIO
 
 import arff
 
@@ -308,5 +307,3 @@ def test_calculate_all_metafeatures(sparse_data):
     mf = meta_features.calculate_all_metafeatures(
         X, y, categorical, "2", logger=logging.getLogger('Meta'))
     assert 52 == len(mf.metafeature_values)
-    sio = StringIO()
-    mf.dump(sio)

--- a/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
@@ -1,22 +1,20 @@
 from io import StringIO
 import logging
 import os
-import sys
+import tempfile
 import unittest
 
 import arff
+from joblib import Memory
 import numpy as np
 from scipy import sparse
 from sklearn.impute import SimpleImputer
 from sklearn.preprocessing import StandardScaler
+from sklearn.datasets import make_multilabel_classification
 
 from autosklearn.pipeline.components.data_preprocessing.data_preprocessing \
     import DataPreprocessor
 import autosklearn.metalearning.metafeatures.metafeatures as meta_features
-
-# Make the super class importable
-sys.path.append(os.path.dirname(__file__))
-import test_meta_features  # noqa: E402
 
 
 class SparseMetaFeaturesTest(unittest.TestCase):
@@ -104,6 +102,7 @@ class SparseMetaFeaturesTest(unittest.TestCase):
             self.helpers["Kurtosisses"](self.X_transformed, self.y, self.logger,
                                         self.categorical_transformed),
             )
+
     def tearDown(self):
         os.chdir(self.cwd)
 

--- a/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
@@ -19,8 +19,7 @@ sys.path.append(os.path.dirname(__file__))
 import test_meta_features  # noqa: E402
 
 
-class SparseMetaFeaturesTest(test_meta_features.MetaFeaturesTest,
-                             unittest.TestCase):
+class SparseMetaFeaturesTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
@@ -105,6 +104,20 @@ class SparseMetaFeaturesTest(test_meta_features.MetaFeaturesTest,
             self.helpers["Kurtosisses"](self.X_transformed, self.y, self.logger,
                                         self.categorical_transformed),
             )
+    def tearDown(self):
+        os.chdir(self.cwd)
+
+    def get_multilabel(self):
+        cache = Memory(location=tempfile.gettempdir())
+        cached_func = cache.cache(make_multilabel_classification)
+        return cached_func(
+            n_samples=100,
+            n_features=10,
+            n_classes=5,
+            n_labels=5,
+            return_indicator=True,
+            random_state=1
+        )
 
     def test_missing_values(self):
         mf = self.helpers["MissingValues"](self.X, self.y, self.logger, self.categorical)

--- a/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
@@ -1,230 +1,312 @@
-from io import StringIO
 import logging
 import os
-import tempfile
-import unittest
+from io import StringIO
 
 import arff
-from joblib import Memory
+
 import numpy as np
+
+import pytest
+
 from scipy import sparse
+
 from sklearn.impute import SimpleImputer
 from sklearn.preprocessing import StandardScaler
-from sklearn.datasets import make_multilabel_classification
 
+
+import autosklearn.metalearning.metafeatures.metafeatures as meta_features
 from autosklearn.pipeline.components.data_preprocessing.data_preprocessing \
     import DataPreprocessor
-import autosklearn.metalearning.metafeatures.metafeatures as meta_features
 
 
-class SparseMetaFeaturesTest(unittest.TestCase):
-    _multiprocess_can_split_ = True
+@pytest.fixture
+def sparse_data():
+    tests_dir = __file__
+    os.chdir(os.path.dirname(tests_dir))
 
-    def setUp(self):
-        self.cwd = os.getcwd()
-        tests_dir = __file__
-        os.chdir(os.path.dirname(tests_dir))
+    decoder = arff.ArffDecoder()
+    with open(os.path.join("datasets", "dataset.arff")) as fh:
+        dataset = decoder.decode(fh, encode_nominal=True)
 
-        decoder = arff.ArffDecoder()
-        with open(os.path.join("datasets", "dataset.arff")) as fh:
-            dataset = decoder.decode(fh, encode_nominal=True)
+    # -1 because the last attribute is the class
+    attribute_types = [
+        'numeric' if type(type_) != list else 'nominal'
+        for name, type_ in dataset['attributes'][:-1]]
+    categorical = {i: True if attribute == 'nominal' else False
+                   for i, attribute in enumerate(attribute_types)}
 
-        # -1 because the last attribute is the class
-        self.attribute_types = [
-            'numeric' if type(type_) != list else 'nominal'
-            for name, type_ in dataset['attributes'][:-1]]
-        self.categorical = [True if attribute == 'nominal' else False
-                            for attribute in self.attribute_types]
+    data = np.array(dataset['data'], dtype=np.float64)
+    X = data[:, :-1]
+    y = data[:, -1].reshape((-1,))
 
-        data = np.array(dataset['data'], dtype=np.float64)
-        X = data[:, :-1]
-        y = data[:, -1].reshape((-1,))
+    # First, swap NaNs and zeros, because when converting an encoded
+    # dense matrix to sparse, the values which are encoded to zero are lost
+    X_sparse = X.copy()
+    NaNs = ~np.isfinite(X_sparse)
+    X_sparse[NaNs] = 0
+    X_sparse = sparse.csr_matrix(X_sparse)
 
-        # First, swap NaNs and zeros, because when converting an encoded
-        # dense matrix to sparse, the values which are encoded to zero are lost
-        X_sparse = X.copy()
-        NaNs = ~np.isfinite(X_sparse)
-        X_sparse[NaNs] = 0
-        X_sparse = sparse.csr_matrix(X_sparse)
-
-        ohe = DataPreprocessor(feat_type={
-            i: 'categorical' if feat else 'numerical' for i, feat in enumerate(self.categorical)
-        })
-        X_transformed = X_sparse.copy()
-        X_transformed = ohe.fit_transform(X_transformed)
-        imp = SimpleImputer(copy=False)
-        X_transformed = imp.fit_transform(X_transformed)
-        standard_scaler = StandardScaler(with_mean=False)
-        X_transformed = standard_scaler.fit_transform(X_transformed)
-
-        # Transform the array which indicates the categorical metafeatures
-        number_numerical = np.sum(~np.array(self.categorical))
-        categorical_transformed = [True] * (X_transformed.shape[1] -
-                                            number_numerical) + \
-                                  [False] * number_numerical
-        self.categorical_transformed = categorical_transformed
-
-        self.X = X_sparse
-        self.X_transformed = X_transformed
-        self.y = y
-        self.mf = meta_features.metafeatures
-        self.helpers = meta_features.helper_functions
-        self.logger = logging.getLogger()
-
-        # Precompute some helper functions
-        self.helpers.set_value(
-            "PCA",
-            self.helpers["PCA"](self.X_transformed, self.y, self.logger),
-            )
-        self.helpers.set_value(
-            "MissingValues",
-            self.helpers["MissingValues"](self.X, self.y, self.logger, self.categorical),
-            )
-        self.mf.set_value(
-            "NumberOfMissingValues",
-            self.mf["NumberOfMissingValues"](self.X, self.y, self.logger, self.categorical),
-            )
-        self.helpers.set_value(
-            "NumSymbols",
-            self.helpers["NumSymbols"](self.X, self.y, self.logger, self.categorical),
-            )
-        self.helpers.set_value(
-            "ClassOccurences",
-            self.helpers["ClassOccurences"](self.X, self.y, self.logger),
-            )
-        self.helpers.set_value(
-            "Skewnesses",
-            self.helpers["Skewnesses"](self.X_transformed, self.y, self.logger,
-                                       self.categorical_transformed),
-            )
-        self.helpers.set_value(
-            "Kurtosisses",
-            self.helpers["Kurtosisses"](self.X_transformed, self.y, self.logger,
-                                        self.categorical_transformed),
-            )
-
-    def tearDown(self):
-        os.chdir(self.cwd)
-
-    def get_multilabel(self):
-        cache = Memory(location=tempfile.gettempdir())
-        cached_func = cache.cache(make_multilabel_classification)
-        return cached_func(
-            n_samples=100,
-            n_features=10,
-            n_classes=5,
-            n_labels=5,
-            return_indicator=True,
-            random_state=1
+    X = X_sparse
+    y = y
+    mf = meta_features.metafeatures
+    helpers = meta_features.helper_functions
+    logger = logging.getLogger()
+    # Precompute some helper functions
+    helpers.set_value(
+        "MissingValues",
+        helpers["MissingValues"](X, y, logger, categorical),
         )
+    mf.set_value(
+        "NumberOfMissingValues",
+        mf["NumberOfMissingValues"](X, y, logger, categorical),
+        )
+    helpers.set_value(
+        "NumSymbols",
+        helpers["NumSymbols"](X, y, logger, categorical),
+        )
+    helpers.set_value(
+        "ClassOccurences",
+        helpers["ClassOccurences"](X, y, logger),
+        )
+    return X, y, categorical
 
-    def test_missing_values(self):
-        mf = self.helpers["MissingValues"](self.X, self.y, self.logger, self.categorical)
-        self.assertTrue(sparse.issparse(mf.value))
-        self.assertEqual(mf.value.shape, self.X.shape)
-        self.assertEqual(mf.value.dtype, np.bool)
-        self.assertEqual(0, np.sum(mf.value.data))
 
-    def test_number_of_missing_values(self):
-        mf = self.mf["NumberOfMissingValues"](self.X, self.y, self.logger, self.categorical)
-        self.assertEqual(0, mf.value)
+@pytest.fixture
+def sparse_data_transformed():
+    tests_dir = __file__
+    os.chdir(os.path.dirname(tests_dir))
 
-    def test_percentage_missing_values(self):
-        mf = self.mf["PercentageOfMissingValues"](self.X, self.y, self.logger, self.categorical)
-        self.assertEqual(0, mf.value)
+    decoder = arff.ArffDecoder()
+    with open(os.path.join("datasets", "dataset.arff")) as fh:
+        dataset = decoder.decode(fh, encode_nominal=True)
 
-    def test_number_of_Instances_with_missing_values(self):
-        mf = self.mf["NumberOfInstancesWithMissingValues"](
-            self.X, self.y, self.logger, self.categorical)
-        self.assertEqual(0, mf.value)
+    # -1 because the last attribute is the class
+    attribute_types = [
+        'numeric' if type(type_) != list else 'nominal'
+        for name, type_ in dataset['attributes'][:-1]]
+    categorical = {i: True if attribute == 'nominal' else False
+                   for i, attribute in enumerate(attribute_types)}
 
-    def test_percentage_of_Instances_with_missing_values(self):
-        self.mf.set_value("NumberOfInstancesWithMissingValues",
-                          self.mf["NumberOfInstancesWithMissingValues"](
-                              self.X, self.y, self.logger, self.categorical))
-        mf = self.mf["PercentageOfInstancesWithMissingValues"](self.X, self.y, self.logger,
-                                                               self.categorical)
-        self.assertAlmostEqual(0, mf.value)
+    data = np.array(dataset['data'], dtype=np.float64)
+    X = data[:, :-1]
+    y = data[:, -1].reshape((-1,))
 
-    def test_number_of_features_with_missing_values(self):
-        mf = self.mf["NumberOfFeaturesWithMissingValues"](self.X, self.y, self.logger,
-                                                          self.categorical)
-        self.assertEqual(0, mf.value)
+    # First, swap NaNs and zeros, because when converting an encoded
+    # dense matrix to sparse, the values which are encoded to zero are lost
+    X_sparse = X.copy()
+    NaNs = ~np.isfinite(X_sparse)
+    X_sparse[NaNs] = 0
+    X_sparse = sparse.csr_matrix(X_sparse)
 
-    def test_percentage_of_features_with_missing_values(self):
-        self.mf.set_value("NumberOfFeaturesWithMissingValues",
-                          self.mf["NumberOfFeaturesWithMissingValues"](
-                              self.X, self.y, self.logger, self.categorical))
-        mf = self.mf["PercentageOfFeaturesWithMissingValues"](self.X, self.y, self.logger,
-                                                              self.categorical)
-        self.assertAlmostEqual(0, mf.value)
+    ohe = DataPreprocessor(feat_type={
+        col: 'categorical' if category else 'numerical'
+        for col, category in categorical.items()
+    })
+    X_transformed = X_sparse.copy()
+    X_transformed = ohe.fit_transform(X_transformed)
+    imp = SimpleImputer(copy=False)
+    X_transformed = imp.fit_transform(X_transformed)
+    standard_scaler = StandardScaler(with_mean=False)
+    X_transformed = standard_scaler.fit_transform(X_transformed)
 
-    def test_num_symbols(self):
-        mf = self.helpers["NumSymbols"](self.X, self.y, self.logger, self.categorical)
+    # Transform the array which indicates the categorical metafeatures
+    number_numerical = np.sum(~np.array(list(categorical.values())))
+    categorical_transformed = {i: True if i < (X_transformed.shape[1] - number_numerical) else False
+                               for i in range(X_transformed.shape[1])}
 
-        symbol_frequency = [2, 0, 6, 0, 1, 3, 0, 0, 3, 1, 0, 0, 0, 1, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 1, 2, 2]
-        self.assertEqual(mf.value, symbol_frequency)
+    X = X_sparse
+    X_transformed = X_transformed
+    y = y
+    mf = meta_features.metafeatures
+    helpers = meta_features.helper_functions
+    logger = logging.getLogger()
 
-    def test_symbols_max(self):
-        # this is attribute steel
-        mf = self.mf["SymbolsMax"](self.X, self.y, self.logger, self.categorical)
-        self.assertEqual(mf.value, 6)
+    # Precompute some helper functions
+    helpers.set_value(
+        "PCA",
+        helpers["PCA"](X_transformed, y, logger),
+        )
+    helpers.set_value(
+        "MissingValues",
+        helpers["MissingValues"](X, y, logger, categorical),
+        )
+    mf.set_value(
+        "NumberOfMissingValues",
+        mf["NumberOfMissingValues"](X, y, logger, categorical),
+        )
+    helpers.set_value(
+        "NumSymbols",
+        helpers["NumSymbols"](X, y, logger, categorical),
+        )
+    helpers.set_value(
+        "ClassOccurences",
+        helpers["ClassOccurences"](X, y, logger),
+        )
+    helpers.set_value(
+        "Skewnesses",
+        helpers["Skewnesses"](X_transformed, y, logger,
+                              categorical_transformed),
+        )
+    helpers.set_value(
+        "Kurtosisses",
+        helpers["Kurtosisses"](X_transformed, y, logger, categorical_transformed),
+    )
+    return X_transformed, y, categorical_transformed
 
-    def test_symbols_mean(self):
-        mf = self.mf["SymbolsMean"](self.X, self.y, self.logger, self.categorical)
-        # Empty looking spaces denote empty attributes
-        symbol_frequency = [2, 6, 1, 3, 3, 1, 1, 2, 1, 1, 2, 2]
-        self.assertAlmostEqual(mf.value, np.mean(symbol_frequency))
 
-    def test_symbols_std(self):
-        mf = self.mf["SymbolsSTD"](self.X, self.y, self.logger, self.categorical)
-        symbol_frequency = [2, 6, 1, 3, 3, 1, 1, 2, 1, 1, 2, 2]
-        self.assertAlmostEqual(mf.value, np.std(symbol_frequency))
+def test_missing_values(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.helper_functions["MissingValues"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert sparse.issparse(mf.value)
+    assert mf.value.shape == X.shape
+    assert mf.value.dtype == np.bool
+    assert 0 == np.sum(mf.value.data)
 
-    def test_symbols_sum(self):
-        mf = self.mf["SymbolsSum"](self.X, self.y, self.logger, self.categorical)
-        self.assertEqual(mf.value, 25)
 
-    def test_skewnesses(self):
-        fixture = [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                   1.0, 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
-                   0.0, 0.0, -1.0, 0.0, 0.0, 0.0,
-                   -0.6969708499033568, 0.626346013011263,
-                   0.3809987596624038, 1.4762248835141034,
-                   0.07687661087633726, 0.36889797830360116]
-        mf = self.helpers["Skewnesses"](self.X_transformed, self.y, self.logger)
-        print(mf.value)
-        print(fixture)
-        np.testing.assert_allclose(mf.value, fixture)
+def test_number_of_missing_values(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.metafeatures["NumberOfMissingValues"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert 0 == mf.value
 
-    def test_kurtosisses(self):
-        fixture = [-3.0, -3.0, -2.0, -2.0, -3.0, -3.0, -3.0, -3.0,
-                   -3.0, -2.0, -3.0, -2.0, -3.0, -3.0, -2.0, -3.0,
-                   -3.0, -3.0, -3.0, -3.0, -3.0, -2.0, -3.0,
-                   -3.0, -3.0, -1.1005836114255765,
-                   -1.1786325509475712, -1.2387998382327912,
-                   1.393438264413704, -0.9768209837948336,
-                   -1.7937072296512782]
-        mf = self.helpers["Kurtosisses"](self.X_transformed, self.y, self.logger)
-        np.testing.assert_allclose(mf.value, fixture)
 
-    def test_pca_95percent(self):
-        mf = self.mf["PCAFractionOfComponentsFor95PercentVariance"](
-            self.X_transformed, self.y, self.logger)
-        self.assertAlmostEqual(0.7741935483870968, mf.value)
+def test_percentage_missing_values(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.metafeatures["PercentageOfMissingValues"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert 0 == mf.value
 
-    def test_pca_kurtosis_first_pc(self):
-        mf = self.mf["PCAKurtosisFirstPC"](self.X_transformed, self.y, self.logger)
-        self.assertAlmostEqual(-0.15444516166802469, mf.value)
 
-    def test_pca_skewness_first_pc(self):
-        mf = self.mf["PCASkewnessFirstPC"](self.X_transformed, self.y, self.logger)
-        self.assertAlmostEqual(0.026514792083623905, mf.value)
+def test_number_of_Instances_with_missing_values(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.metafeatures["NumberOfInstancesWithMissingValues"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert 0 == mf.value
 
-    def test_calculate_all_metafeatures(self):
-        mf = meta_features.calculate_all_metafeatures(
-            self.X, self.y, self.categorical, "2", logger=self.logger)
-        self.assertEqual(52, len(mf.metafeature_values))
-        sio = StringIO()
-        mf.dump(sio)
+
+def test_percentage_of_Instances_with_missing_values(sparse_data):
+    X, y, categorical = sparse_data
+    meta_features.metafeatures.set_value(
+        "NumberOfInstancesWithMissingValues",
+        meta_features.metafeatures["NumberOfInstancesWithMissingValues"](
+            X, y, logging.getLogger('Meta'), categorical))
+    mf = meta_features.metafeatures["PercentageOfInstancesWithMissingValues"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert pytest.approx(0) == mf.value
+
+
+def test_number_of_features_with_missing_values(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.metafeatures["NumberOfFeaturesWithMissingValues"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert 0 == mf.value
+
+
+def test_percentage_of_features_with_missing_values(sparse_data):
+    X, y, categorical = sparse_data
+    meta_features.metafeatures.set_value(
+        "NumberOfFeaturesWithMissingValues",
+        meta_features.metafeatures["NumberOfFeaturesWithMissingValues"](
+            X, y, logging.getLogger('Meta'), categorical))
+    mf = meta_features.metafeatures["PercentageOfFeaturesWithMissingValues"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert pytest.approx(0, mf.value)
+
+
+def test_num_symbols(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.helper_functions["NumSymbols"](
+        X, y, logging.getLogger('Meta'), categorical)
+
+    symbol_frequency = [2, 0, 6, 0, 1, 3, 0, 0, 3, 1, 0, 0, 0, 1, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 1, 2, 2]
+    assert mf.value == symbol_frequency
+
+
+def test_symbols_max(sparse_data):
+    X, y, categorical = sparse_data
+    # this is attribute steel
+    mf = meta_features.metafeatures["SymbolsMax"](X, y, logging.getLogger('Meta'), categorical)
+    assert mf.value == 6
+
+
+def test_symbols_mean(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.metafeatures["SymbolsMean"](
+        X, y, logging.getLogger('Meta'), categorical)
+    # Empty looking spaces denote empty attributes
+    symbol_frequency = [2, 6, 1, 3, 3, 1, 1, 2, 1, 1, 2, 2]
+    assert pytest.approx(mf.value) == np.mean(symbol_frequency)
+
+
+def test_symbols_std(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.metafeatures["SymbolsSTD"](
+        X, y, logging.getLogger('Meta'), categorical)
+    symbol_frequency = [2, 6, 1, 3, 3, 1, 1, 2, 1, 1, 2, 2]
+    assert pytest.approx(mf.value) == np.std(symbol_frequency)
+
+
+def test_symbols_sum(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.metafeatures["SymbolsSum"](
+        X, y, logging.getLogger('Meta'), categorical)
+    assert mf.value == 25
+
+
+def test_skewnesses(sparse_data_transformed):
+    X_transformed, y, categorical_transformed = sparse_data_transformed
+    fixture = [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+               1.0, 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+               0.0, 0.0, -1.0, 0.0, 0.0, 0.0,
+               -0.6969708499033568, 0.626346013011263,
+               0.3809987596624038, 1.4762248835141034,
+               0.07687661087633726, 0.36889797830360116]
+    mf = meta_features.helper_functions["Skewnesses"](X_transformed, y, logging.getLogger('Meta'))
+    print(mf.value)
+    print(fixture)
+    np.testing.assert_allclose(mf.value, fixture)
+
+
+def test_kurtosisses(sparse_data_transformed):
+    fixture = [-3.0, -3.0, -2.0, -2.0, -3.0, -3.0, -3.0, -3.0,
+               -3.0, -2.0, -3.0, -2.0, -3.0, -3.0, -2.0, -3.0,
+               -3.0, -3.0, -3.0, -3.0, -3.0, -2.0, -3.0,
+               -3.0, -3.0, -1.1005836114255765,
+               -1.1786325509475712, -1.2387998382327912,
+               1.393438264413704, -0.9768209837948336,
+               -1.7937072296512782]
+    X_transformed, y, categorical_transformed = sparse_data_transformed
+    mf = meta_features.helper_functions["Kurtosisses"](X_transformed, y, logging.getLogger('Meta'))
+    np.testing.assert_allclose(mf.value, fixture)
+
+
+def test_pca_95percent(sparse_data_transformed):
+    X_transformed, y, categorical_transformed = sparse_data_transformed
+    mf = meta_features.metafeatures["PCAFractionOfComponentsFor95PercentVariance"](
+        X_transformed, y, logging.getLogger('Meta'))
+    assert pytest.approx(0.7741935483870968) == mf.value
+
+
+def test_pca_kurtosis_first_pc(sparse_data_transformed):
+    X_transformed, y, categorical_transformed = sparse_data_transformed
+    mf = meta_features.metafeatures["PCAKurtosisFirstPC"](
+        X_transformed, y, logging.getLogger('Meta'))
+    assert pytest.approx(-0.15444516166802469) == mf.value
+
+
+def test_pca_skewness_first_pc(sparse_data_transformed):
+    X_transformed, y, categorical_transformed = sparse_data_transformed
+    mf = meta_features.metafeatures["PCASkewnessFirstPC"](
+        X_transformed, y, logging.getLogger('Meta'))
+    assert pytest.approx(0.026514792083623905) == mf.value
+
+
+def test_calculate_all_metafeatures(sparse_data):
+    X, y, categorical = sparse_data
+    mf = meta_features.calculate_all_metafeatures(
+        X, y, categorical, "2", logger=logging.getLogger('Meta'))
+    assert 52 == len(mf.metafeature_values)
+    sio = StringIO()
+    mf.dump(sio)

--- a/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
@@ -50,7 +50,9 @@ class SparseMetaFeaturesTest(test_meta_features.MetaFeaturesTest,
         X_sparse[NaNs] = 0
         X_sparse = sparse.csr_matrix(X_sparse)
 
-        ohe = DataPreprocessor(categorical_features=self.categorical)
+        ohe = DataPreprocessor(feat_type={
+            i: 'categorical' if feat else 'numerical' for i, feat in enumerate(self.categorical)
+        })
         X_transformed = X_sparse.copy()
         X_transformed = ohe.fit_transform(X_transformed)
         imp = SimpleImputer(copy=False)

--- a/test/test_metalearning/test_metalearning.py
+++ b/test/test_metalearning/test_metalearning.py
@@ -81,7 +81,7 @@ class Test(unittest.TestCase):
                     include_preprocessors=['no_preprocessing'])
 
                 X_train, Y_train, X_test, Y_test = get_dataset(dataset_name)
-                categorical = [False] * X_train.shape[1]
+                categorical = {i: False for i in range(X_train.shape[1])}
 
                 meta_features_label = _calculate_metafeatures(
                     X_train, Y_train, categorical, dataset_name, task)

--- a/test/test_optimizer/test_smbo.py
+++ b/test/test_optimizer/test_smbo.py
@@ -53,7 +53,7 @@ def test_smbo_metalearning_configurations(backend, context, dask_client):
         X_test, Y_test,
         task=BINARY_CLASSIFICATION,
         dataset_name='iris',
-        feat_type=None,
+        feat_type={i: 'numerical' for i in range(X_train.shape[1])},
     )
     backend.save_datamanager(datamanager)
     smbo.task = BINARY_CLASSIFICATION

--- a/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_categorical.py
+++ b/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_categorical.py
@@ -28,7 +28,9 @@ class CategoricalPreprocessingPipelineTest(unittest.TestCase):
             [0, 0, 1, 1, 0, 0, 0, 1],
             [0, 1, 0, 0, 0, 1, 1, 0]])
         # dense input
-        Yt = CategoricalPreprocessingPipeline().fit_transform(X)
+        # Notice the X.copy() here as the imputation
+        # is in place to save resources
+        Yt = CategoricalPreprocessingPipeline().fit_transform(X.copy())
         np.testing.assert_array_equal(Yt, Y)
         # sparse input
         X_sparse = sparse.csc_matrix(X)

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -244,6 +244,8 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                        True, True, True, True, True, True, True, True, True,
                        True, True, True, True, True, True, True, False,
                        False, False, True, True, True]
+        categorical = {i: 'categorical' if bool_cat else 'numerical'
+                       for i, bool_cat in enumerate(categorical)}
         this_directory = os.path.dirname(__file__)
         X = np.loadtxt(os.path.join(this_directory, "components",
                                     "data_preprocessing", "dataset.pkl"))
@@ -255,7 +257,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                 'X_test': X_test, 'Y_test': Y_test}
 
         init_params = {
-            'data_preprocessing:categorical_features':
+            'data_preprocessing:feat_type':
                 categorical
         }
 
@@ -271,21 +273,25 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         with unittest.mock.patch('autosklearn.pipeline.classification.SimpleClassificationPipeline'
                                  '._check_init_params_honored'):
             cls = SimpleClassificationPipeline(
-                init_params={'data_preprocessing:categorical_features': [True, False]}
+                init_params={'data_preprocessing:feat_type': {0: 'categorical',
+                                                              1: 'numerical'}}
             )
 
             self.assertEqual(
                 ohe_mock.call_args[1]['init_params'],
-                {'categorical_features': [True, False]}
+                {'feat_type': {0: 'categorical', 1: 'numerical'}}
             )
             default = cls.get_hyperparameter_search_space().get_default_configuration()
             cls.set_hyperparameters(
                 configuration=default,
-                init_params={'data_preprocessing:categorical_features': [True, True, False]},
+                init_params={'data_preprocessing:feat_type': {0: 'categorical',
+                                                              1: 'categorical',
+                                                              2: 'numerical'}},
             )
             self.assertEqual(
                 ohe_mock.call_args[1]['init_params'],
-                {'categorical_features': [True, True, False]}
+                {'feat_type': {0: 'categorical', 1: 'categorical',
+                               2: 'numerical'}}
             )
 
     def _test_configurations(self, configurations_space, make_sparse=False,


### PR DESCRIPTION
- Moves the encoder that translates pandas dataframes to numpy into the pipeline
- Enhances Auto-Sklearn to work with pandas internally, rather than numpy
- Feature type list is internally translated to a dictionary of column->data type to be robust against different pandas column ordering
- Adds extra check to make sure a pandas frame can produce a pipeline (in order words, this new set of checks make sure that A- a pandas frame reaches the base pipeline without being translated to numpy, and that - we can fit the pipeline with a pandas frame)