### PR TITLE
[Fix] from 60 to 30 days to stale

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          days-before-stale: 60
+          days-before-stale: 30
           days-before-close: 7
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
I tested the stale behavior in my branch with harder settings [here](https://github.com/franchuterivera/auto-sklearn/issues/12).

We now want to make 30 days the sale policy time.