### PR TITLE
Fix float128  on 32 bits

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -853,7 +853,7 @@ class AutoML(BaseEstimator):
                 multiplier = 4
             elif X.dtype in (np.float64, np.float):
                 multiplier = 8
-            elif X.dtype == np.float128:
+            elif hasattr(np, 'float128') and X.dtype == np.float128:
                 multiplier = 16
             else:
                 # Just assuming some value - very unlikely

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -853,7 +853,14 @@ class AutoML(BaseEstimator):
                 multiplier = 4
             elif X.dtype in (np.float64, np.float):
                 multiplier = 8
-            elif hasattr(np, 'float128') and X.dtype == np.float128:
+            elif (
+                # In spite of the names, np.float96 and np.float128
+                # provide only as much precision as np.longdouble,
+                # that is, 80 bits on most x86 machines and 64 bits
+                # in standard Windows builds.
+                (hasattr(np, 'float128') and X.dtype == np.float128)
+                or (hasattr(np, 'float96') and X.dtype == np.float96)
+            ):
                 multiplier = 16
             else:
                 # Just assuming some value - very unlikely


### PR DESCRIPTION
This PR address the problem from #1127 .

Nevertheless, it is complicated as how many bits are used depends on the OS. For example:
```
In spite of the names, np.float96 and np.float128 provide only as much precision as np.longdouble, that is, 80 bits on most x86 machines and 64 bits in standard Windows builds.
```
This PR, at least will prevent auto-sklearn from crashing on this situations. 