### PR TITLE
Enables threadpoolctl to control number of numpy threads

### DIFF
--- a/autosklearn/evaluation/abstract_evaluator.py
+++ b/autosklearn/evaluation/abstract_evaluator.py
@@ -12,6 +12,8 @@ from sklearn.ensemble import VotingClassifier, VotingRegressor
 
 from smac.tae import StatusType
 
+from threadpoolctl import threadpool_limits
+
 import autosklearn.pipeline.classification
 import autosklearn.pipeline.regression
 from autosklearn.constants import (
@@ -192,6 +194,9 @@ class AbstractEvaluator(object):
         budget: Optional[float] = None,
         budget_type: Optional[str] = None,
     ):
+
+        # Limit the number of threads that numpy uses
+        threadpool_limits(limits=1)
 
         self.starttime = time.time()
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -175,11 +175,14 @@ is exhausted.
 *auto-sklearn* employs `threadpoolctl <https://github.com/joblib/threadpoolctl/>`_ to control the number of threads employed by scientific libraries like numpy or scikit-learn. This is done exclusively during the building procedure of models, not during inference. In particular, *auto-sklearn* allows each pipeline to use at most 1 thread during training. At predicting and scoring time this limitation is not enforced by *auto-sklearn*. You can control the number of resources
 employed by the pipelines by setting the following variables in your environment, prior to running *auto-sklearn*:
 
-.. role:: bash(code)
-   :language: bash
-   export OPENBLAS_NUM_THREADS=1
-   export MKL_NUM_THREADS=1
-   export OMP_NUM_THREADS=1
+.. code-block:: shell-session
+
+    $ export OPENBLAS_NUM_THREADS=1
+    $ export MKL_NUM_THREADS=1
+    $ export OMP_NUM_THREADS=1
+
+
+For further information about how scikit-learn handles multiprocessing, please check the `Parallelism, resource management, and configuration <https://scikit-learn.org/stable/computing/parallelism.html>`_ documentation from the library.
 
 Model persistence
 =================

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -172,13 +172,14 @@ is exhausted.
 
 **Note:** *auto-sklearn* requires all workers to have access to a shared file system for storing training data and models.
 
-Furthermore, depending on the installation of scikit-learn and numpy,
-the model building procedure may use up to all cores. Such behaviour is
-unintended by *auto-sklearn* and is most likely due to numpy being installed
-from `pypi` as a binary wheel (`see here <https://scikit-learn-general.narkive
-.com/44ywvAHA/binary-wheel-packages-for-linux-are-coming>`_). Executing
-``export OPENBLAS_NUM_THREADS=1`` should disable such behaviours and make numpy
-only use a single core at a time.
+*auto-sklearn* employs `threadpoolctl <https://github.com/joblib/threadpoolctl/>`_ to control the number of threads employed by scientific libraries like numpy or scikit-learn. This is done exclusively during the building procedure of models, not during inference. In particular, *auto-sklearn* allows each pipeline to use at most 1 thread during training. At predicting and scoring time this limitation is not enforced by *auto-sklearn*. You can control the number of resources
+employed by the pipelines by setting the following variables in your environment, prior to running *auto-sklearn*:
+
+.. role:: bash(code)
+   :language: bash
+   export OPENBLAS_NUM_THREADS=1
+   export MKL_NUM_THREADS=1
+   export OMP_NUM_THREADS=1
 
 Model persistence
 =================

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ distributed>=2.2.0
 pyyaml
 pandas>=1.0
 liac-arff
+threadpoolctl
 
 ConfigSpace>=0.4.14,<0.5
 pynisher>=0.6.3


### PR DESCRIPTION
addresses #924 

One can see with `threadpool_info()` that the number of threads is set to 1 (this at the end of abstract evaluator, for debug purposes):

```
[CRITICAL] [2021-06-18 09:10:32,054:Client-TrainEvaluator(5):breast_cancer] threadpool_info()=[{'filepath': '/home/chico/anaconda3/envs/py38/lib/python3.8/site-packages/scikit_learn.libs/libgomp-f7e03b3e.so.1.0.0', 'prefix': 'libgomp', 'user_api': 'openmp', 'internal_api': 'openmp', 'version': None, 'num_threads': 1}, {'filepath': '/home/chico/anaconda3/envs/py38/lib/python3.8/site-packages/numpy.libs/libopenblasp-r0-5bebc122.3.13.dev.so', 'prefix': 'libopenblas', 'user_api': 'blas', 'internal_api': 'openblas', 'version': '0.3.13.dev', 'num_threads': 1, 'threading_layer': 'pthreads'}, {'filepath': '/home/chico/anaconda3/envs/py38/lib/python3.8/site-packages/scipy.libs/libopenblasp-r0-085ca80a.3.9.so', 'prefix': 'libopenblas', 'user_api': 'blas', 'internal_api': 'openblas', 'version': '0.3.9', 'num_threads': 1, 'threading_layer': 'pthreads'}]

```