### PR TITLE
Last scipy breaks dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 
 numpy>=1.9.0
-scipy>=0.14.1
+scipy>=0.14.1,<1.7
 
 joblib
 scikit-learn>=0.24.0,<0.25.0


### PR DESCRIPTION
Fix ModuleNotFoundError: No module named 'scipy.optimize._shgo_lib.sobol_seq'
https://stackoverflow.com/questions/68176331/from-scipy-optimize-shgo-lib-sobol-seq-import-sobol-does-not-work