### PR TITLE
Fix test errors with SMAC caused by dask 2021.07

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ scipy>=0.14.1,<1.7.0
 joblib
 scikit-learn>=0.24.0,<0.25.0
 
-dask
-distributed>=2.2.0
+dask>=2021.06,<2021.07
+distributed>=2021.06,<2021.07
 pyyaml
 pandas>=1.0
 liac-arff

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ scipy>=0.14.1,<1.7.0
 joblib
 scikit-learn>=0.24.0,<0.25.0
 
-dask>=2021.06,<2021.07
-distributed>=2021.06,<2021.07
+dask=<2021.07
+distributed>=2.2.0,<2021.07
 pyyaml
 pandas>=1.0
 liac-arff

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.14.1,<1.7.0
 joblib
 scikit-learn>=0.24.0,<0.25.0
 
-dask=<2021.07
+dask<2021.07
 distributed>=2.2.0,<2021.07
 pyyaml
 pandas>=1.0


### PR DESCRIPTION
The latest version of dask (2021.07) does not play nicely with `lazy_import` in SMAC.
Changing the `requirements.txt` to lock the version `dask>=2021.06,<2021.07` fixes this.

### Testing
```bash
> git clone git@github.com:automl/auto-sklearn.git
> cd auto-sklearn
> # Create virtual env
> pip install -e ".[test]"
> pytest "test/test_automl" -k "test_binary_score_and_include"  # causes emcee import error

> deactivate; rm -rf .venv
> # Modify requirements to use dask and distributed to use 2021.06.2, latest non-breaking
>  pip install -e ".[test]"
> pytest "test/test_automl" -k "test_binary_score_and_include"  # passes
```