### PR TITLE
Update `pytest` workflow and `docker` dist environements from Ubunut 18.04 to 20.04

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ubuntu:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 WORKDIR /auto-sklearn
 

--- a/test/test_pipeline/components/regression/test_sgd.py
+++ b/test/test_pipeline/components/regression/test_sgd.py
@@ -10,11 +10,11 @@ class SGDComponentTest(BaseRegressionComponentTest):
     # Values are extremely bad because the invscaling does not drop the
     # learning rate aggressively enough!
     res = dict()
-    res["default_boston"] = -1.1406255966671184e+28
+    res["default_boston"] = -3.7203740888187194e+28
     res["boston_n_calls"] = 6
-    res["default_boston_iterative"] = -1.1406255966671184e+28
-    res["default_boston_sparse"] = -2.5492867904339725e+28
-    res["default_boston_iterative_sparse"] = -2.5492867904339725e+28
+    res["default_boston_iterative"] = -3.7203740888187194e+28
+    res["default_boston_sparse"] = -2.5490406459756767e+28
+    res["default_boston_iterative_sparse"] = -2.5490406459756767e+28
     res["default_diabetes"] = 0.2731178369559112
     res["diabetes_n_calls"] = 10
     res["default_diabetes_iterative"] = 0.2731178369559112


### PR DESCRIPTION
The docker distribution was failing due to `Python 3.6` being the default Python distribution on `ubuntu 18.04` as seen in issue #1193. The tests were also running on ubuntu `18.04` which should be upgraded the latest LTS version by ubuntu.

Updated the docker file to use `ubuntu:20.04` instead.

Edit:
Upgrading the `pytest` workflow from `18.04` to `20.04` causes numerical differences in 4 tests where it seems all models perform better than the previous hardcoded test results. ([log](https://github.com/automl/auto-sklearn/pull/1198/checks?check_run_id=3202891654#step:8:1590))
```
FAILED test/test_pipeline/components/regression/test_sgd.py::SGDComponentTest::test_default_boston
FAILED test/test_pipeline/components/regression/test_sgd.py::SGDComponentTest::test_default_boston_iterative_fit
FAILED test/test_pipeline/components/regression/test_sgd.py::SGDComponentTest::test_default_boston_iterative_sparse_fit
FAILED test/test_pipeline/components/regression/test_sgd.py::SGDComponentTest::test_default_boston_sparse
```