### PR TITLE
Doc: Fix variable name

### DIFF
--- a/examples/40_advanced/example_pandas_train_test.py
+++ b/examples/40_advanced/example_pandas_train_test.py
@@ -37,7 +37,7 @@ import autosklearn.classification
 
 
 def get_runhistory_models_performance(automl):
-    metric = cls.automl_._metric
+    metric = automl.automl_._metric
     data = automl.automl_.runhistory_.data
     performance_list = []
     for run_key, run_value in data.items():


### PR DESCRIPTION
This is a small fix.

Use `automl` variable that is function's argument instead of `cls` variable that is defined outside the function.