### PR TITLE
Multioutput regression fix

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -89,7 +89,7 @@ def _model_predict(
     # TODO issue 1169
     #   As CV models are collected into a VotingRegressor which does not
     #   not support multioutput regression, we need to manually transform and
-    #   transform their predictions.
+    #   average their predictions.
 
     Parameters
     ----------

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -51,6 +51,7 @@ from autosklearn.util.stopwatch import StopWatch
 from autosklearn.util.logging_ import (
     setup_logger,
     start_log_server,
+    get_named_client_logger,
     warnings_to,
     PicklableClientLogger,
 )

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -99,9 +99,9 @@ def _model_predict(
     X: array-like (n_samples, ...)
         The data to perform predictions on.
 
-    requires_proba: bool
-        Whether the probability predictions are required. Usually this will be
-        dependant on the task type.
+    task: int
+        The int identifier indicating the kind of task that the model was
+        trained on.
 
     batchsize: Optional[int] = None
         If the model supports batch_size predictions then it's possible to pass

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -18,13 +18,7 @@ SUPPORTED_FEAT_TYPES = typing.Union[
     typing.List,
     pd.DataFrame,
     np.ndarray,
-    scipy.sparse.bsr_matrix,
-    scipy.sparse.coo_matrix,
-    scipy.sparse.csc_matrix,
-    scipy.sparse.csr_matrix,
-    scipy.sparse.dia_matrix,
-    scipy.sparse.dok_matrix,
-    scipy.sparse.lil_matrix,
+    scipy.sparse.spmatrix,
 ]
 
 

--- a/autosklearn/data/target_validator.py
+++ b/autosklearn/data/target_validator.py
@@ -22,13 +22,7 @@ SUPPORTED_TARGET_TYPES = typing.Union[
     pd.Series,
     pd.DataFrame,
     np.ndarray,
-    scipy.sparse.bsr_matrix,
-    scipy.sparse.coo_matrix,
-    scipy.sparse.csc_matrix,
-    scipy.sparse.csr_matrix,
-    scipy.sparse.dia_matrix,
-    scipy.sparse.dok_matrix,
-    scipy.sparse.lil_matrix,
+    scipy.sparse.spmatrix,
 ]
 
 

--- a/autosklearn/ensembles/abstract_ensemble.py
+++ b/autosklearn/ensembles/abstract_ensemble.py
@@ -52,7 +52,6 @@ class AbstractEnsemble(object):
         -------
         array : [n_data_points]
         """
-        self
 
     @abstractmethod
     def get_models_with_weights(self, models: Dict) -> List[Tuple[float, BasePipeline]]:

--- a/autosklearn/pipeline/implementations/util.py
+++ b/autosklearn/pipeline/implementations/util.py
@@ -18,20 +18,51 @@ def softmax(df):
 
 
 def convert_multioutput_multiclass_to_multilabel(probas):
+    """ Converts the model predicted probabilities to useable format.
+
+    In some cases, models predicted_proba can output an array of shape
+    (2, n_samples, n_labels) where the 2 stands for the probability of positive
+    or negative. This function will convert this to an (n_samples, n_labels)
+    array where the probability of a label being true is kept.
+
+    Parameters
+    ----------
+    probas: array_like (1 or 2, n_samples, n_labels) | (n_samples, n_labels)
+        The output of predict_proba of a classifier model
+
+    Returns
+    -------
+    np.ndarray (n_samples, n_labels)
+        The probabilities of each label for every sample
+    """
     if isinstance(probas, np.ndarray) and len(probas.shape) > 2:
         raise ValueError('New unsupported sklearn output!')
+
     if isinstance(probas, list):
-        multioutput_probas = np.ndarray((probas[0].shape[0], len(probas)))
-        for i, output in enumerate(probas):
-            if output.shape[1] > 2:
+        # probas = (prob of positive/negative label, n_samples, n_labels)
+        n_samples = probas[0].shape[0]
+        n_labels = len(probas)
+        multioutput_probas = np.ndarray((n_samples, n_labels))
+
+        for i, label_scores in enumerate(probas):
+            n_probabilities = label_scores.shape[1]
+
+            # Label was never observer so it has a probability of 0
+            if n_probabilities == 1:
+                multioutput_probas[:, i] = 0
+
+            # Label has a probability of true or false
+            elif n_probabilities == 2:
+                multioutput_probas[:, i] = label_scores[:, 1]
+
+            # In case multioutput-multiclass input was used
+            elif n_probabilities > 2:
                 raise ValueError('Multioutput-Multiclass supported by '
                                  'scikit-learn, but not by auto-sklearn!')
-            # Only copy the probability of something having class 1
-            elif output.shape[1] == 2:
-                multioutput_probas[:, i] = output[:, 1]
-            # This label was never observed positive in the training data,
-            # therefore it is only the probability for the label being False
             else:
-                multioutput_probas[:, i] = 0
-        probas = multioutput_probas
-    return probas
+                RuntimeError(f"Unkown predict_proba output={probas}")
+
+        return multioutput_probas
+
+    else:
+        return probas

--- a/autosklearn/pipeline/implementations/util.py
+++ b/autosklearn/pipeline/implementations/util.py
@@ -27,19 +27,16 @@ def convert_multioutput_multiclass_to_multilabel(probas):
 
     Parameters
     ----------
-    probas: array_like (1 or 2, n_samples, n_labels) | (n_samples, n_labels)
+    probas: array_like (1 or 2, n_samples, n_labels) or (n_samples, n_labels)
         The output of predict_proba of a classifier model
 
     Returns
     -------
-    np.ndarray (n_samples, n_labels)
+    np.ndarray shape of (n_samples, n_labels)
         The probabilities of each label for every sample
     """
-    if isinstance(probas, np.ndarray) and len(probas.shape) > 2:
-        raise ValueError('New unsupported sklearn output!')
-
     if isinstance(probas, list):
-        # probas = (prob of positive/negative label, n_samples, n_labels)
+        # probas = shape of (prob of positive/negative label, n_samples, n_labels)
         n_samples = probas[0].shape[0]
         n_labels = len(probas)
         multioutput_probas = np.ndarray((n_samples, n_labels))
@@ -47,15 +44,16 @@ def convert_multioutput_multiclass_to_multilabel(probas):
         for i, label_scores in enumerate(probas):
             n_probabilities = label_scores.shape[1]
 
-            # Label was never observer so it has a probability of 0
+            # Label was never observed so it has a probability of 0
             if n_probabilities == 1:
                 multioutput_probas[:, i] = 0
 
-            # Label has a probability of true or false
+            # Label has a probability score for true or false
             elif n_probabilities == 2:
                 multioutput_probas[:, i] = label_scores[:, 1]
 
-            # In case multioutput-multiclass input was used
+            # In case multioutput-multiclass input was used, where we have
+            # a probability for each class
             elif n_probabilities > 2:
                 raise ValueError('Multioutput-Multiclass supported by '
                                  'scikit-learn, but not by auto-sklearn!')
@@ -64,5 +62,11 @@ def convert_multioutput_multiclass_to_multilabel(probas):
 
         return multioutput_probas
 
+    elif isinstance(probas, np.ndarray):
+        if len(probas.shape) > 2:
+            raise ValueError('New unsupported sklearn output!')
+        else:
+            return probas
+
     else:
-        return probas
+        return ValueError(f"Unrecognized probas\n{type(probas)}\n{probas}")

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -730,6 +730,7 @@ def test_subsample_if_too_large(memory_limit, precision, task):
     else:
         assert mock.warning.call_count == 0
 
+
 def data_test_model_predict_outsputs_correct_shapes():
     datasets = sklearn.datasets
     binary = datasets.make_classification(n_samples=5, n_classes=2)
@@ -774,7 +775,7 @@ def data_test_model_predict_outsputs_correct_shapes():
 
     def voting_regressor(X, y):
         regressors = [
-            MyDummyRegressor(config=1, random_state=seed()).fit(X, y) 
+            MyDummyRegressor(config=1, random_state=seed()).fit(X, y)
             for _ in range(5)
         ]
         vr = VotingRegressor(estimators=None)
@@ -782,19 +783,19 @@ def data_test_model_predict_outsputs_correct_shapes():
         return vr
 
     test_data = {
-        BINARY_CLASSIFICATION : {
+        BINARY_CLASSIFICATION: {
             'models': [classifier(*binary), voting_classifier(*binary)],
             'data': binary,
             # prob of false/true for the one class
             'expected_output_shape': (len(binary[0]), 2)
         },
-        MULTICLASS_CLASSIFICATION : {
+        MULTICLASS_CLASSIFICATION: {
             'models': [classifier(*multiclass), voting_classifier(*multiclass)],
             'data': multiclass,
             # prob of true for each possible class
             'expected_output_shape': (len(multiclass[0]), 3)
         },
-        MULTILABEL_CLASSIFICATION : {
+        MULTILABEL_CLASSIFICATION: {
             'models': [classifier(*multilabel), voting_classifier(*multilabel)],
             'data': multilabel,
             # probability of true for each binary label
@@ -806,7 +807,7 @@ def data_test_model_predict_outsputs_correct_shapes():
             # array of single outputs
             'expected_output_shape': (len(regression[0]), )
         },
-        MULTIOUTPUT_REGRESSION : {
+        MULTIOUTPUT_REGRESSION: {
             'models': [regressor(*multioutput), voting_regressor(*multioutput)],
             'data': multioutput,
             # array of vector otuputs
@@ -830,7 +831,4 @@ def data_test_model_predict_outsputs_correct_shapes():
 def test_model_predict_outputs_correct_shapes(model, data, task, expected_output_shape):
     X, y = data
     prediction = _model_predict(model=model, X=X, task=task)
-    print(prediction)
     assert prediction.shape == expected_output_shape
-
-

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -835,6 +835,7 @@ def test_model_predict_outputs_correct_shapes(model, data, task, expected_output
     prediction = _model_predict(model=model, X=X, task=task)
     assert prediction.shape == expected_output_shape
 
+
 def test_model_predict_outputs_warnings_to_logs():
     X = list(range(20))
     task = REGRESSION
@@ -852,6 +853,7 @@ def test_model_predict_outputs_warnings_to_logs():
 
     assert logger.warning.call_count == 1, "Logger should have had warning called"
 
+
 def test_model_predict_outputs_to_stdout_if_no_logger():
     X = list(range(20))
     task = REGRESSION
@@ -863,12 +865,7 @@ def test_model_predict_outputs_to_stdout_if_no_logger():
 
     model = DummyModel()
 
-
     with warnings.catch_warnings(record=True) as w:
         _model_predict(model, X, task, logger=None)
 
         assert len(w) == 1, "One warning sould have been emmited"
-
-
-
-

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -12,14 +12,16 @@ import numpy as np
 import pandas as pd
 import pytest
 import sklearn.datasets
+from sklearn.ensemble import VotingRegressor, VotingClassifier
 from smac.scenario.scenario import Scenario
 from smac.facade.roar_facade import ROAR
 
-from autosklearn.automl import AutoML
+from autosklearn.automl import AutoML, _model_predict
 from autosklearn.data.validation import InputValidator
 import autosklearn.automl
 from autosklearn.data.xy_data_manager import XYDataManager
 from autosklearn.metrics import accuracy, log_loss, balanced_accuracy
+from autosklearn.evaluation.abstract_evaluator import MyDummyClassifier, MyDummyRegressor
 import autosklearn.pipeline.util as putil
 from autosklearn.constants import (
     MULTICLASS_CLASSIFICATION,
@@ -727,3 +729,92 @@ def test_subsample_if_too_large(memory_limit, precision, task):
             assert mock.warning.call_count == 1
     else:
         assert mock.warning.call_count == 0
+
+def data_test_model_predict_outsputs_correct_shapes():
+    datasets = sklearn.datasets
+    binary = datasets.make_classification(n_samples=5, n_classes=2)
+    multiclass = datasets.make_classification(n_samples=5, n_informative=3, n_classes=3)
+    multilabel = datasets.make_multilabel_classification(n_samples=5, n_classes=3)
+    regression = datasets.make_regression(n_samples=5)
+    multioutput = datasets.make_regression(n_samples=5, n_targets=3)
+
+    # TODO issue 1169
+    #   While testing output shapes, realised all models are wrapped to provide
+    #   a special predict_proba that outputs a different shape than usual.
+    #   This includes DummyClassifier and DummyRegressor which are wrapped as
+    #   `MyDummyClassifier/Regressor` and require a config object.
+    #   config == 1 : Classifier uses 'uniform', Regressor uses 'mean'
+    #   else        : Classifier uses 'most_frequent', Regressor uses 'median'
+    #
+    #   This wrapping of probabilities with
+    #       `convert_multioutput_multiclass_to_multilabel`
+    #   can probably be just put into a base class which queries subclasses
+    #   as to whether it's needed.
+    #
+    #   tldr; thats why we use MyDummyX here instead of the default models
+    #         from sklearn
+    def seed():
+        return np.random.RandomState(42)
+
+    def classifier(X, y):
+        return MyDummyClassifier(config=1, random_state=seed()).fit(X, y)
+
+    def regressor(X, y):
+        return MyDummyRegressor(config=1, random_state=seed()).fit(X, y)
+
+    # How cross validation models are currently grouped together
+    def voting_classifier(X, y):
+        classifiers = [
+            MyDummyClassifier(config=1, random_state=seed()).fit(X, y)
+            for _ in range(5)
+        ]
+        vc = VotingClassifier(estimators=None, voting='soft')
+        vc.estimators_ = classifiers
+        return vc
+
+    def voting_regressor(X, y):
+        regressors = [
+            MyDummyRegressor(config=1, random_state=seed()).fit(X, y) 
+            for _ in range(5)
+        ]
+        vr = VotingRegressor(estimators=None)
+        vr.estimators_ = regressors
+        return vr
+
+    test_data = {
+        BINARY_CLASSIFICATION : {
+            'models': [classifier(*binary), voting_classifier(*binary)],
+            'data': binary
+        },
+        MULTICLASS_CLASSIFICATION : {
+            'models': [classifier(*multiclass), voting_classifier(*multiclass)],
+            'data': multiclass
+        },
+        MULTILABEL_CLASSIFICATION : {
+            'models': [classifier(*multilabel), voting_classifier(*multilabel)],
+            'data': multilabel
+        },
+        REGRESSION: {
+            'models': [regressor(*regression), voting_regressor(*regression)],
+            'data': regression
+        },
+        MULTIOUTPUT_REGRESSION : {
+            'models': [regressor(*multioutput), voting_regressor(*multioutput)],
+            'data': multioutput
+        }
+    }
+
+    return itertools.chain.from_iterable(
+        [(model, cfg['data'], task) for model in cfg['models']]
+        for task, cfg in test_data.items()
+    )
+
+
+@pytest.mark.parametrize(
+    "model, data, task", data_test_model_predict_outsputs_correct_shapes()
+)
+def test_model_predict_outputs_correct_shapes(model, data, task):
+    X, y = data
+    prediction = _model_predict(model=model, X=X, task=task)
+    assert prediction.shape[0] == X.shape[0]
+

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -784,37 +784,53 @@ def data_test_model_predict_outsputs_correct_shapes():
     test_data = {
         BINARY_CLASSIFICATION : {
             'models': [classifier(*binary), voting_classifier(*binary)],
-            'data': binary
+            'data': binary,
+            # prob of false/true for the one class
+            'expected_output_shape': (len(binary[0]), 2)
         },
         MULTICLASS_CLASSIFICATION : {
             'models': [classifier(*multiclass), voting_classifier(*multiclass)],
-            'data': multiclass
+            'data': multiclass,
+            # prob of true for each possible class
+            'expected_output_shape': (len(multiclass[0]), 3)
         },
         MULTILABEL_CLASSIFICATION : {
             'models': [classifier(*multilabel), voting_classifier(*multilabel)],
-            'data': multilabel
+            'data': multilabel,
+            # probability of true for each binary label
+            'expected_output_shape': (len(multilabel[0]), 3)  # type: ignore
         },
         REGRESSION: {
             'models': [regressor(*regression), voting_regressor(*regression)],
-            'data': regression
+            'data': regression,
+            # array of single outputs
+            'expected_output_shape': (len(regression[0]), )
         },
         MULTIOUTPUT_REGRESSION : {
             'models': [regressor(*multioutput), voting_regressor(*multioutput)],
-            'data': multioutput
+            'data': multioutput,
+            # array of vector otuputs
+            'expected_output_shape': (len(multioutput[0]), 3)
         }
     }
 
     return itertools.chain.from_iterable(
-        [(model, cfg['data'], task) for model in cfg['models']]
+        [
+            (model, cfg['data'], task, cfg['expected_output_shape'])
+            for model in cfg['models']
+        ]
         for task, cfg in test_data.items()
     )
 
 
 @pytest.mark.parametrize(
-    "model, data, task", data_test_model_predict_outsputs_correct_shapes()
+    "model, data, task, expected_output_shape",
+    data_test_model_predict_outsputs_correct_shapes()
 )
-def test_model_predict_outputs_correct_shapes(model, data, task):
+def test_model_predict_outputs_correct_shapes(model, data, task, expected_output_shape):
     X, y = data
     prediction = _model_predict(model=model, X=X, task=task)
-    assert prediction.shape[0] == X.shape[0]
+    print(prediction)
+    assert prediction.shape == expected_output_shape
+
 


### PR DESCRIPTION
This PR fixes issue #1169 in which the output shape of the predictions with CV models was not as expected and unusable.

# Changes
* `_model_predict()` in `automl.py` now checks for multioutput regression and converts accordingly.
* Changed the logger warnings about size mismatches to assertion errors. This also removes the need for the logger param.
* Updated the code in `_model_predict` to give assertion errors in general as we do not expect use errors to get this far.
* Created tests to catch issue #1169 and any other output shape mismatches with `_model_predict()`
* SUPPORTED_{FEAT/TARGET}_TYPES now generalize to use `spmatrix` instead of listing each kind of sparse matrix.
* Doc and code legibility improvements to `convert_multioutput_multiclass_to_multilabel()` and `_model_predict()`

# Diagnoses of issue
* Mostly described in #1169
* CV models are ensembled together in a `VotingRegressor` which does not support multioutput regression. Normally this is caught in `fit()` but we bypass this as the models are already fitted.
* `VotingRegressor` then treats the models outputs as if they're 2d and averages along the wrong axis, causing the shape mistmatch.

# Future work
* A better method to ensemble together CV models, please see issue #1169 for a more full description of the problem.
