### PR TITLE
Fix probability matrix inconsistent with training input

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1112,7 +1112,7 @@ class AutoML(BaseEstimator):
                         unique_X = X[idxs_of_unique]
                         unique_y = y[idxs_of_unique]
 
-                        # TODO optimization
+                        # NOTE optimization
                         #   If this ever turns out to be slow, this actually
                         #   copies the entire array. There might be a better
                         #   solution but it will probably require a lot more

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1094,23 +1094,49 @@ class AutoML(BaseEstimator):
                     new_num_samples,
                 )
                 if task in CLASSIFICATION_TASKS:
-                    try:
+                    # Identify if it has unique labels and allow for
+                    # stratification, with unique labels in training set
+                    values, idxs, counts = np.unique(y, axis=0,
+                                                     return_index=True,
+                                                     return_counts=True)
+                    unique_labels = {
+                        idx: value
+                        for value, idx, count in zip(values, idxs, counts)
+                        if count == 1
+                    }
+
+                    # If there are unique labeled elements, remove them and
+                    # place them back in later
+                    if len(unique_labels) > 0:
+                        idxs_of_unique = np.asarray(list(unique_labels.keys()))
+                        unique_X = X[idxs_of_unique]
+                        unique_y = y[idxs_of_unique]
+
+                        # TODO optimization
+                        #   If this ever turns out to be slow, this actually
+                        #   copies the entire array. There might be a better
+                        #   solution but it will probably require a lot more
+                        #   manual work in how splitting is done.
+                        X = np.delete(X, idxs_of_unique, axis=0)
+                        y = np.delete(y, idxs_of_unique, axis=0)
+
                         X, _, y, _ = sklearn.model_selection.train_test_split(
                             X, y,
                             train_size=new_num_samples,
                             random_state=seed,
                             stratify=y,
                         )
-                    except Exception:
-                        logger.warning(
-                            'Could not sample dataset in stratified manner, resorting to random '
-                            'sampling',
-                            exc_info=True
-                        )
+
+                        X = np.append(X, unique_X, axis=0)
+                        y = np.append(y, unique_y, axis=0)
+
+                    # Otherwise we should be able to stratify as normal
+                    else:
                         X, _, y, _ = sklearn.model_selection.train_test_split(
                             X, y,
                             train_size=new_num_samples,
                             random_state=seed,
+                            stratify=y,
                         )
                 elif task in REGRESSION_TASKS:
                     X, _, y, _ = sklearn.model_selection.train_test_split(

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1122,7 +1122,7 @@ class AutoML(BaseEstimator):
 
                         X, _, y, _ = sklearn.model_selection.train_test_split(
                             X, y,
-                            train_size=new_num_samples,
+                            train_size=new_num_samples - len(unique_y),
                             random_state=seed,
                             stratify=y,
                         )

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -4,12 +4,40 @@ import typing
 
 import numpy as np
 
+from scipy.sparse import issparse, spmatrix
+
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import NotFittedError
 
 from autosklearn.data.feature_validator import FeatureValidator, SUPPORTED_FEAT_TYPES
 from autosklearn.data.target_validator import SUPPORTED_TARGET_TYPES, TargetValidator
 from autosklearn.util.logging_ import get_named_client_logger
+
+
+def convert_if_sparse(
+    y: typing.Union[SUPPORTED_TARGET_TYPES, spmatrix]
+) -> SUPPORTED_TARGET_TYPES:
+    """If the labels `y` are sparse, it will convert it to its dense representation
+
+    Parameters
+    ----------
+    y: {array-like, sparse matrix} of shape (n_samples,) or (n_samples, n_outputs)
+        The labels to 'densify' if sparse
+
+    Returns
+    -------
+    np.ndarray of shape (n_samples, ) or (n_samples, n_outputs)
+    """
+    if issparse(y):
+        y = typing.cast(spmatrix, y)
+        y = y.toarray()
+        y = typing.cast(np.ndarray, y)
+
+        # For one dimensional data, toarray will return (1, nrows)
+        if y.shape[0] == 1:
+            y = y.flatten()
+
+    return y
 
 
 class InputValidator(BaseEstimator):

--- a/autosklearn/ensembles/abstract_ensemble.py
+++ b/autosklearn/ensembles/abstract_ensemble.py
@@ -52,6 +52,7 @@ class AbstractEnsemble(object):
         -------
         array : [n_data_points]
         """
+        pass
 
     @abstractmethod
     def get_models_with_weights(self, models: Dict) -> List[Tuple[float, BasePipeline]]:

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -7,11 +7,13 @@ import dask.distributed
 import joblib
 import numpy as np
 import pandas as pd
+from scipy.sparse import spmatrix
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.utils.multiclass import type_of_target
 from smac.runhistory.runhistory import RunInfo, RunValue
 
 from autosklearn.data.validation import (
+    convert_if_sparse,
     SUPPORTED_FEAT_TYPES,
     SUPPORTED_TARGET_TYPES,
 )
@@ -327,11 +329,11 @@ class AutoSklearnEstimator(BaseEstimator):
     def fit_pipeline(
         self,
         X: SUPPORTED_FEAT_TYPES,
-        y: SUPPORTED_TARGET_TYPES,
+        y: Union[SUPPORTED_TARGET_TYPES, spmatrix],
         config: Union[Configuration,  Dict[str, Union[str, float, int]]],
         dataset_name: Optional[str] = None,
         X_test: Optional[SUPPORTED_FEAT_TYPES] = None,
-        y_test: Optional[SUPPORTED_TARGET_TYPES] = None,
+        y_test: Optional[Union[SUPPORTED_TARGET_TYPES, spmatrix]] = None,
         feat_type: Optional[List[str]] = None,
         *args,
         **kwargs: Dict,
@@ -814,9 +816,9 @@ class AutoSklearnEstimator(BaseEstimator):
     def get_configuration_space(
         self,
         X: SUPPORTED_FEAT_TYPES,
-        y: SUPPORTED_TARGET_TYPES,
+        y: Union[SUPPORTED_TARGET_TYPES, spmatrix],
         X_test: Optional[SUPPORTED_FEAT_TYPES] = None,
-        y_test: Optional[SUPPORTED_TARGET_TYPES] = None,
+        y_test: Optional[Union[SUPPORTED_TARGET_TYPES, spmatrix]] = None,
         dataset_name: Optional[str] = None,
         feat_type: Optional[List[str]] = None,
     ):
@@ -901,6 +903,9 @@ class AutoSklearnClassifier(AutoSklearnEstimator, ClassifierMixin):
         self
 
         """
+        # AutoSklearn does not handle sparse y for now
+        y = convert_if_sparse(y)
+
         # Before running anything else, first check that the
         # type of data is compatible with auto-sklearn. Legal target
         # types are: binary, multiclass, multilabel-indicator.
@@ -1048,6 +1053,9 @@ class AutoSklearnRegressor(AutoSklearnEstimator, RegressorMixin):
         # types are: continuous, continuous-multioutput, and the special cases:
         # multiclass : because [3.0, 1.0, 5.0] is considered as multiclass
         # binary: because [1.0, 0.0] is considered multiclass
+        # AutoSklearn does not handle sparse y for now
+        y = convert_if_sparse(y)
+
         target_type = type_of_target(y)
         supported_types = ['continuous', 'binary', 'multiclass', 'continuous-multioutput']
         if target_type not in supported_types:

--- a/autosklearn/metrics/__init__.py
+++ b/autosklearn/metrics/__init__.py
@@ -9,8 +9,10 @@ from sklearn.utils.multiclass import type_of_target
 
 from smac.utils.constants import MAXINT
 
-from autosklearn.constants import REGRESSION_TASKS, TASK_TYPES
-
+from autosklearn.constants import (
+    BINARY_CLASSIFICATION, MULTICLASS_CLASSIFICATION, MULTILABEL_CLASSIFICATION,
+    MULTIOUTPUT_REGRESSION, REGRESSION, REGRESSION_TASKS, TASK_TYPES,
+)
 
 from .util import sanitize_array
 
@@ -541,3 +543,13 @@ def _compute_scorer(
     else:
         score = metric(solution, prediction)
     return score
+
+
+# Must be at bottom so all metrics are defined
+default_metric_for_task: Dict[int, Scorer] = {
+    BINARY_CLASSIFICATION: CLASSIFICATION_METRICS['accuracy'],
+    MULTICLASS_CLASSIFICATION: CLASSIFICATION_METRICS['accuracy'],
+    MULTILABEL_CLASSIFICATION: CLASSIFICATION_METRICS['f1_macro'],
+    REGRESSION: REGRESSION_METRICS['r2'],
+    MULTIOUTPUT_REGRESSION: REGRESSION_METRICS['r2'],
+}

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -848,6 +848,7 @@ def test_input_and_target_types(dask_client, X, y, task):
     assert automl._metric.name == default_metric_for_task[task].name
 
 
+
 def data_test_model_predict_outsputs_correct_shapes():
     datasets = sklearn.datasets
     binary = datasets.make_classification(n_samples=5, n_classes=2)

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -848,42 +848,6 @@ def test_input_and_target_types(dask_client, X, y, task):
     assert automl._metric.name == default_metric_for_task[task].name
 
 
-@pytest.mark.parametrize("task, y", [
-    (BINARY_CLASSIFICATION, np.asarray(
-        9999 * [0] + 1 * [1]
-    )),
-    (MULTICLASS_CLASSIFICATION, np.asarray(
-        4999 * [1] + 4999 * [2] + 1 * [3] + 1 * [4]
-    )),
-    (MULTILABEL_CLASSIFICATION, np.asarray(
-        4999 * [[0, 1, 1]] + 4999 * [[1, 1, 0]] + 1 * [[1, 0, 1]] + 1 * [[0, 0, 0]]
-    ))
-])
-def test_subsample_classification_unique_labels_stay_in_training_set(task, y):
-    n_samples = 10000
-    X = np.random.random(size=(n_samples, 3))
-    memory_limit = 1  # Force subsampling
-    mock = unittest.mock.Mock()
-
-    # Make sure our test assumptions are correct
-    assert len(y) == n_samples, "Ensure tests are correctly setup"
-
-    values, counts = np.unique(y, axis=0, return_counts=True)
-    unique_labels = [value for value, count in zip(values, counts) if count == 1]
-    assert len(unique_labels), "Ensure we have unique labels in the test"
-
-    _, y_sampled = AutoML.subsample_if_too_large(X, y,
-                                                 logger=mock,
-                                                 seed=1,
-                                                 memory_limit=memory_limit,
-                                                 task=task)
-
-    assert len(y_sampled) <= len(y), \
-        "Ensure sampling took place"
-    assert all(label in y_sampled for label in unique_labels), \
-        "All unique labels present in the return sampled set"
-
-
 def data_test_model_predict_outsputs_correct_shapes():
     datasets = sklearn.datasets
     binary = datasets.make_classification(n_samples=5, n_classes=2)

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -994,13 +994,13 @@ def test_model_predict_outputs_to_stdout_if_no_logger():
         4999 * [1] + 4999 * [2] + 1 * [3] + 1 * [4]
     )),
     (MULTILABEL_CLASSIFICATION, np.asarray(
-        4999 * [[0,1,1]] + 4999 * [[1,1,0]] + 1 * [[1,0,1]] + 1 * [[0,0,0]]
+        4999 * [[0, 1, 1]] + 4999 * [[1, 1, 0]] + 1 * [[1, 0, 1]] + 1 * [[0, 0, 0]]
     ))
 ])
 def test_subsample_classification_unique_labels_stay_in_training_set(task, y):
     n_samples = 10000
     X = np.random.random(size=(n_samples, 3))
-    memory_limit = 1 # Force subsampling
+    memory_limit = 1  # Force subsampling
     mock = unittest.mock.Mock()
 
     # Make sure our test assumptions are correct

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -1018,9 +1018,5 @@ def test_subsample_classification_unique_labels_stay_in_training_set(task, y):
 
     assert len(y_sampled) <= len(y), \
         "Ensure sampling took place"
-    # TODO issue 1190
-    #   Not a large fan on relying the warning call count to identify
-    #   if stratification did or didn't take place
-    assert mock.warning.call_count == 2
     assert all(label in y_sampled for label in unique_labels), \
         "All unique labels present in the return sampled set"

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -984,3 +984,43 @@ def test_model_predict_outputs_to_stdout_if_no_logger():
         _model_predict(model, X, task, logger=None)
 
         assert len(w) == 1, "One warning sould have been emmited"
+
+
+@pytest.mark.parametrize("task, y", [
+    (BINARY_CLASSIFICATION, np.asarray(
+        9999 * [0] + 1 * [1]
+    )),
+    (MULTICLASS_CLASSIFICATION, np.asarray(
+        4999 * [1] + 4999 * [2] + 1 * [3] + 1 * [4]
+    )),
+    (MULTILABEL_CLASSIFICATION, np.asarray(
+        4999 * [[0,1,1]] + 4999 * [[1,1,0]] + 1 * [[1,0,1]] + 1 * [[0,0,0]]
+    ))
+])
+def test_subsample_classification_unique_labels_stay_in_training_set(task, y):
+    n_samples = 10000
+    X = np.random.random(size=(n_samples, 3))
+    memory_limit = 1 # Force subsampling
+    mock = unittest.mock.Mock()
+
+    # Make sure our test assumptions are correct
+    assert len(y) == n_samples, "Ensure tests are correctly setup"
+
+    values, counts = np.unique(y, axis=0, return_counts=True)
+    unique_labels = [value for value, count in zip(values, counts) if count == 1]
+    assert len(unique_labels), "Ensure we have unique labels in the test"
+
+    _, y_sampled = AutoML.subsample_if_too_large(X, y,
+                                                 logger=mock,
+                                                 seed=1,
+                                                 memory_limit=memory_limit,
+                                                 task=task)
+
+    assert len(y_sampled) <= len(y), \
+        "Ensure sampling took place"
+    # TODO issue 1190
+    #   Not a large fan on relying the warning call count to identify
+    #   if stratification did or didn't take place
+    assert mock.warning.call_count == 2
+    assert all(label in y_sampled for label in unique_labels), \
+        "All unique labels present in the return sampled set"

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -12,16 +12,19 @@ import warnings
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.sparse import csr_matrix
 import sklearn.datasets
 from sklearn.ensemble import VotingRegressor, VotingClassifier
 from smac.scenario.scenario import Scenario
 from smac.facade.roar_facade import ROAR
 
-from autosklearn.automl import AutoML, _model_predict
+from autosklearn.automl import AutoML, AutoMLClassifier, AutoMLRegressor, _model_predict
 from autosklearn.data.validation import InputValidator
 import autosklearn.automl
 from autosklearn.data.xy_data_manager import XYDataManager
-from autosklearn.metrics import accuracy, log_loss, balanced_accuracy
+from autosklearn.metrics import (
+    accuracy, log_loss, balanced_accuracy, default_metric_for_task
+)
 from autosklearn.evaluation.abstract_evaluator import MyDummyClassifier, MyDummyRegressor
 from autosklearn.util.logging_ import PickableLoggerAdapter
 import autosklearn.pipeline.util as putil
@@ -61,7 +64,7 @@ def test_fit(dask_client):
         dask_client=dask_client,
     )
     automl.fit(
-        X_train, Y_train, task=MULTICLASS_CLASSIFICATION,
+        X_train, Y_train, task=MULTICLASS_CLASSIFICATION
     )
     score = automl.score(X_test, Y_test)
     assert score > 0.8
@@ -731,6 +734,118 @@ def test_subsample_if_too_large(memory_limit, precision, task):
             assert mock.warning.call_count == 1
     else:
         assert mock.warning.call_count == 0
+
+
+def data_input_and_target_types():
+    n_rows = 100
+
+    # Create valid inputs
+    X_ndarray = np.random.random(size=(n_rows, 5))
+    X_ndarray[X_ndarray < .9] = 0
+
+    # Binary Classificaiton
+    y_binary_ndarray = np.random.random(size=n_rows)
+    y_binary_ndarray[y_binary_ndarray >= 0.5] = 1
+    y_binary_ndarray[y_binary_ndarray < 0.5] = 0
+
+    # Multiclass classification
+    y_multiclass_ndarray = np.random.random(size=n_rows)
+    y_multiclass_ndarray[y_multiclass_ndarray > 0.66] = 2
+    y_multiclass_ndarray[(y_multiclass_ndarray <= 0.66) & (y_multiclass_ndarray >= 0.33)] = 1
+    y_multiclass_ndarray[y_multiclass_ndarray < 0.33] = 0
+
+    # Multilabel classificaiton
+    y_multilabel_ndarray = np.random.random(size=(n_rows, 3))
+    y_multilabel_ndarray[y_multilabel_ndarray > 0.5] = 1
+    y_multilabel_ndarray[y_multilabel_ndarray <= 0.5] = 0
+
+    # Regression
+    y_regression_ndarray = np.random.random(size=n_rows)
+
+    # Multioutput Regression
+    y_multioutput_regression_ndarray = np.random.random(size=(n_rows, 3))
+
+    xs = [
+        X_ndarray,
+        list(X_ndarray),
+        csr_matrix(X_ndarray),
+        pd.DataFrame(data=X_ndarray),
+    ]
+
+    ys_binary = [
+        y_binary_ndarray,
+        list(y_binary_ndarray),
+        csr_matrix(y_binary_ndarray),
+        pd.Series(y_binary_ndarray),
+        pd.DataFrame(data=y_binary_ndarray),
+    ]
+
+    ys_multiclass = [
+        y_multiclass_ndarray,
+        list(y_multiclass_ndarray),
+        csr_matrix(y_multiclass_ndarray),
+        pd.Series(y_multiclass_ndarray),
+        pd.DataFrame(data=y_multiclass_ndarray),
+    ]
+
+    ys_multilabel = [
+        y_multilabel_ndarray,
+        list(y_multilabel_ndarray),
+        csr_matrix(y_multilabel_ndarray),
+        # pd.Series(y_multilabel_ndarray)
+        pd.DataFrame(data=y_multilabel_ndarray),
+    ]
+
+    ys_regression = [
+        y_regression_ndarray,
+        list(y_regression_ndarray),
+        csr_matrix(y_regression_ndarray),
+        pd.Series(y_regression_ndarray),
+        pd.DataFrame(data=y_regression_ndarray),
+    ]
+
+    ys_multioutput_regression = [
+        y_multioutput_regression_ndarray,
+        list(y_multioutput_regression_ndarray),
+        csr_matrix(y_multioutput_regression_ndarray),
+        # pd.Series(y_multioutput_regression_ndarray),
+        pd.DataFrame(data=y_multioutput_regression_ndarray),
+    ]
+
+    # [ (X, y, task), ... ]
+    return (
+        (X, y, task)
+        for X in xs
+        for y, task in itertools.chain(
+            itertools.product(ys_binary, [BINARY_CLASSIFICATION]),
+            itertools.product(ys_multiclass, [MULTICLASS_CLASSIFICATION]),
+            itertools.product(ys_multilabel, [MULTILABEL_CLASSIFICATION]),
+            itertools.product(ys_regression, [REGRESSION]),
+            itertools.product(ys_multioutput_regression, [MULTIOUTPUT_REGRESSION]),
+        )
+    )
+
+
+@pytest.mark.parametrize("X, y, task", data_input_and_target_types())
+def test_input_and_target_types(dask_client, X, y, task):
+
+    if task in CLASSIFICATION_TASKS:
+        automl = AutoMLClassifier(
+            time_left_for_this_task=15,
+            per_run_time_limit=5,
+            dask_client=dask_client,
+        )
+    else:
+        automl = AutoMLRegressor(
+            time_left_for_this_task=15,
+            per_run_time_limit=5,
+            dask_client=dask_client,
+        )
+    # To save time fitting and only validate the inputs we only return
+    # the configuration space
+    automl.fit(X, y, only_return_configuration_space=True)
+    assert automl._task == task
+    assert automl._metric.name == default_metric_for_task[task].name
 
 
 def data_test_model_predict_outsputs_correct_shapes():


### PR DESCRIPTION
Fixes issue #1190 where subsampling on classification tasks would cause outlier classes to not show up in model predictions, causing shape inconsistencies between training input and predictions output.

# Changes
* Adds a check in subsampling for unique labels and making sure they are **always included in the training set** when subsampling.
* Removed random sub-sampling, autosklearn now fails if it cannot stratify sample.
* Tests checking that subsampling will include outlier labels in the training set.

# Diagnoses
* `test_train_split(X, y, stratify=y)` splits the data into two splits. However, if there is only one sample with a particular label, it can not go into both splits. The solution is just to remove that sample before splitting and then re-add it to the training set.

# Concerns
* Cross validation creates n_splits which are not garunteed to have the outlier label present either. This will need to be addressed.
* In general, a review of how outlier labels are persisted into training in all cases is probably of importance for retaining consistency between input and output shapes.
* **This should be addressed in this PR or raised as a maintenance issue**
 

