### PR TITLE
Add a contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing to auto-sklearn
 Thanks for checking out the contribution guide!
-We included a [quick overview](#pull-request-overview) at the end for anyone familiar with open-source contribution or familiar with autosklearn and simply wants to see our workflow.
+We included a [quick overview](#pull-request-overview) at the end for anyone familiar with open-source contribution or familiar with auto-sklearn and simply wants to see our workflow.
 
 If you're new to contributing then hopefully this guide helps with contributing to open-source and auto-sklearn, whether it be a simple doc fix, a small bug fix or even new features that everyone can get use out of.
 If you're looking for a particular project to work on, check out the [Issues](https://github.com/automl/auto-sklearn/issues) for things you might be interested in!
 
-For experienced contributors, you can skip the overview and find the quick walkthrough [here](#pull-request-overview)!
+For experienced contributors, you can skip the overview and find the quick walk-through [here](#pull-request-overview)!
 
 This guide is only aimed towards Unix command line users as that's what we know but the same principles apply.
 
@@ -28,10 +28,10 @@ Following that we'll tell you about how you can test your changes locally and th
     It's important to work off the latest changes on the **development** branch.
     ```bash
     # With https
-    git clone https://github.com/{your-username}/auto-sklearn
+    git clone https://github.com/your-username/auto-sklearn
 
     # ... or with ssh
-    git clone git@github.com:{your-username}/auto-sklearn.git
+    git clone git@github.com:your-username/auto-sklearn.git
 
     # Navigate into the cloned repo
     cd auto-sklearn
@@ -39,7 +39,7 @@ Following that we'll tell you about how you can test your changes locally and th
     # Create a new branch based off the development one
     git checkout -b my_new_branch development
 
-    # ... Alternativly, if you would prefer a more manual method
+    # ... Alternatively, if you would prefer a more manual method
     # Show all the available branches with a * beside your current one
     git branch
 
@@ -65,12 +65,12 @@ Following that we'll tell you about how you can test your changes locally and th
     source my-virtual-env/bin/activate
     ```
     *   A popular alternative to managing Python projects is [conda](https://docs.conda.io/en/latest/).
-    *   The folder `my-virtual-env` is where dependancy packages that are required for auto-sklearn will go.
+    *   The folder `my-virtual-env` is where dependency packages that are required for auto-sklearn will go.
     *   In general, once you have activated the virtual environment with `source my-virtual-env/bin/activate`, anything you install with `pip install` will now go into the virtual environment.
         While this environment is active, any python you run will have access to the packages here.
         If at any time you want to deactivate it simply type `deactivate` in the shell or just close the shell and open a new one.
     *   If you use Python 3.6 or lower on your machine then unfortunately auto-sklearn doesn't support this.
-        Fortunatly, you can check out [pyenv](https://github.com/pyenv/pyenv) which lets you switch between Python versions on the fly!
+        Fortunately, you can check out [pyenv](https://github.com/pyenv/pyenv) which lets you switch between Python versions on the fly!
 
 *   Now that we have a virtual environment, it's time to install all the dependencies into it.
     ```bash
@@ -81,9 +81,9 @@ Following that we'll tell you about how you can test your changes locally and th
     ```
     *   If you're only exposure to using pip is `pip install package_name` then this might be a bit confusing.
     *   If we type `pip install -e .` (notice the 'dot'), this tells `pip` to install a package located here, in this directory, `.`.
-        The `-e` flag indicates that it should be editable, meaning you will not have to run `pip install .` every time you make a change and want to tryit.
+        The `-e` flag indicates that it should be editable, meaning you will not have to run `pip install .` every time you make a change and want to try it.
     *   Finally the `[test,examples,doc]` tells `pip` that there's some extra optional dependencies that we want to install.
-        These are dependancies used in development but ones that are not required to actually run autosklearn itself.
+        These are dependencies used in development but ones that are not required to actually run auto-sklearn itself.
         You can check out what these are in the `setup.py` file.
     *   If you're new to virtual environments, after performing all this, it's a great time to check out what actually exists in the `my-virtual-env` folder.
 
@@ -110,7 +110,7 @@ Some core things to consider in fixing a bug:
         Other times, the bug is an artifact of some larger underlying issue that has gone unnoticed and might require some restructuring.
 
         If this is the case, let us know as you work on it!
-        If it requires breaking, such as changing default behaviour or public API, sometimes a quick patch and fix will do and larger restructing fixes can be tackled in a timely manner.
+        If it requires breaking, such as changing default behaviour or public API, sometimes a quick patch and fix will do and larger restricting fixes can be tackled in a timely manner.
         As a rule of thumb, if a bug requires modifying more then 50-100 lines of code it's probably something we would like to talk through on how best to tackle it.
 
 *   How can we create a test for this bug in the future?
@@ -277,7 +277,7 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     git push --set-upstream origin my_new_branch
     ```
 
-*   At this point, we need to create a pull request (PR) to the [automl/autosklearn](https://github.com/automl/auto-sklearn) repository with our new changes.
+*   At this point, we need to create a pull request (PR) to the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) repository with our new changes.
     This can be done simply by going to your own forked repo, clicking **'Contribute'**, and selecting
     the **development** branch of `automl/auto-sklearn`.
 
@@ -323,7 +323,7 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     The simplest way to reduce the time needed and to help us too is to run the tests, code formatting check and doc building locally.
     If they all pass locally they will very often have no issues in the automated tests.
 
-    Once everyone is happy, it's time for us to hit (*squash*) merge, get it into the development branch and have one more contribution to autosklearn!
+    Once everyone is happy, it's time for us to hit (*squash*) merge, get it into the development branch and have one more contribution to auto-sklearn!
 
 # Pull Request Overview
 * Create a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) git repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,7 +300,7 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     *   Do you think this might have any implications in the future or how would
         further work on this look like?
     *   If you've introduced some new feature, write about who might use it,
-        give a breif code sample to show it and let us know how you tested it!
+        give a brief code sample to show it and let us know how you tested it!
     *   If you've fixed a bug, write about why this bug exists in the first place,
         how you solved it and how a test makes sure it won't pop up again!
 
@@ -333,7 +333,7 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     cd auto-sklearn
     git checkout -b my_new_branch development
 
-    # Create a virtual environemnt and activate it so there are no package
+    # Create a virtual environment and activate it so there are no package
     # conflicts
     python -m venv my-virtual-env
     source my-virtual-env/bin/activate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ plugins that you can see in (`doc/conf.py`)[https://github.com/automl/auto-sklea
 All of your changes can be viewed by first [building the docs](#testing) and then opening `doc/build/html/index.html` with your favourite browser.
 Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` which opens it up with your default browser.
 
-*   If your simply fixing a typo, there shouldn't be much to do accept make the PR and we'll accept it without much issue.
+*   If you're simply fixing a typo, there shouldn't be much to do except make the PR and we'll accept it without much issue.
 *   If you want to fix a link you should know how linking with `sphinx` works
     *   For links to internal documentation, you can create a label with
     ```.rst
@@ -112,8 +112,9 @@ Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` whic
     *   Now if you want to link some external documentation you'll need
         to do something like
     ```.rst
-    Here's a `link<https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html>` to the external documentation on linking for sphinx
+    Here's a `link<https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html>`_ to the external documentation on linking for sphinx
     ```
+    Notice the trailing `_` which is used to specify that it is an external link.
     
 *   If you want to make some more detailed documentation about some feature that you introduced or you think is not well documented, you'll have to think about a few things.
     
@@ -127,9 +128,61 @@ Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` whic
     You'll want to check out some of the [other examples](https://github.com/automl/auto-sklearn/tree/master/examples) to see how to embed rst into a `.py` file.
 
 #### Bug Fixes
-* TODO
+Auto-sklearn has been through quite a few iterations, been used for many purposes and is constantly used in ways we didn't even think of.
+Like any maturing software, there will be bugs, old and new.
+While we try to create unit tests to catch as many of these as we can, some slip through and new bugs get introduced as dependencies update and new features introduced.
+
+If you're looking to help by fixing some bugs, or you've encountered your own bugs you'd like fixed in the official version of auto-sklearn, we would greatly appreciate any help!
+We'd be happy to guide you through what we think may be the underlying cause or at least point you in the right direction if it's something you wish to work on.
+
+Some core things to consider in fixing a bug:
+*   What's the minimal working example that reproduces this bug?
+    *   This is usually the first step.
+        The process of creating a minimal piece of code that reproduces a bug often illuminates what needs to be fixed.
+
+*   What's the quick fix and what's the long term fix?
+    *   Sometimes it's a code typo, a quick correction and problem solved.
+        Other times, the bug is an artifact of some larger underlying issue that has gone unnoticed and might require some restructuring.
+        
+        If this is the case, let us know as you work on it!
+        If it's breaking, sometimes a quick patch and fix will do and larger fixes can be tackled in a timely manner.
+        As a rule of thumb, if a bug requires modifying more then 50-100 lines of code it's probably something we would like to talk through on how best to tackle it.
+
+*   How can we create a test for this bug in the future?
+    *   Of course, once a bug is squashed, we'd like it to not show again and having a test to catch it for the future will future-proof against any changes down the line.
+    
+        Thankfully, most of this is usually captured in the minimal working example and all that is left is to turn it into a comprehensive test!
+
+What's important once fixing a bug is writing a good PR that let's us now how you identified the bug, what the problem was and how it was fixed.
+This lets use review your code with all this in mind and follow the same thought process that lead you to fix it in the first place!
+
 #### Features
-* TODO
+While auto-sklearn has many features we're proud of, there's always room for more and better functionality.
+Features don't have to be performance driven, in fact, most of the new features we'd love to see are to improve a users ability to interact with auto-sklearn, whether it be usability or an ability to inspect the inner workings in an intuitive manner!
+
+However, features are usually a bigger project and for this we'd really advise getting in touch with us first about the feature in mind.
+There are some things we believe best left for external libraries or integrations that we don't wish to consider at this time.
+Another reason to get in touch is to nail exactly what this feature will look like before going to far, the more direct and concise the feature is, the better.
+
+Some things to keep in mind with new features:
+*   A new feature is great, but will this change any existing default behaviours?
+    Unexpected changes for existing users can be detrimental and sometimes it has to be done ... but often these new features can be presented as an option the user can enable.
+*   If you're introducing some new API:
+    *   Creating some code samples of how you'd like your feature to be used is a great start.
+    *   What current way is there to do the same thing, can any functionality already present be used to help with this new API?
+    *   Are you going to deprecate any current API? This is an important fact to consider and something that will definitely have to be discussed.
+
+Writing features are great but new features means new bugs, but thankfully that's what we can write tests for.
+How to test your feature is always tricky, especially if the feature is big in scope.
+Unfortunately there's no secrete or rule of thumb other than try to cover every case you can think of.
+The more it's tested the better!
+Bugs will still get through, that's okay, we will have done what we can and we can fix those in the future but as long as the usual use-cases are covered, this shouldn't be too much of a problem.
+
+Now how are people going to know about your new feature you've introduced?
+This is what documentation is so great for and it's how almost all software functionality is expressed.
+If the feature is enabled by a simple parameter, great, almost all the documentation is present by the in-code docstring and automatically gets rendered in the online docs ... that docstring that was updated ... right?
+Sometimes, the new functionality isn't so clear from a simple parameter description and so maybe something needs to be added to the `manual.rst`, a short paragraph suffices and much appreciated.
+Lastly, if the feature really is a game changer or you're very proud of it, consider making an `example_*.py` that will be run and rendered in the online docs!
 
 ## Testing
 *   Let's assume you've made some changes, now we have to make sure they work.
@@ -236,8 +289,6 @@ Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` whic
     If they all pass locally they will very often have no issues in the automated tests.
 
     Once everyone is happy, it's time for us to hit (*squash*) merge, get it into the development branch and have one more contribution to autosklearn!
-
-
 
 # Pull Request Overview
 * Create a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) git repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` whic
 #### Bug Fixes
 Auto-sklearn has been through quite a few iterations, been used for many purposes and is constantly used in ways we didn't even think of.
 Like any maturing software, there will be bugs, old and new.
-While we try to create unit tests to catch as many of these as we can, some slip through and new bugs get introduced as dependencies update and new features introduced.
+While we try to create unit tests to catch as many of these as we can, some slip through and new bugs get introduced as dependencies are updated and new features are introduced.
 
 If you're looking to help by fixing some bugs, or you've encountered your own bugs you'd like fixed in the official version of auto-sklearn, we would greatly appreciate any help!
 We'd be happy to guide you through what we think may be the underlying cause or at least point you in the right direction if it's something you wish to work on.
@@ -214,7 +214,14 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     cd doc
     make linkcheck
     ```
-    *   To view the documentation itself, 
+    *   To view the documentation itself, make sure it is built with the above commands and then open `doc/build/html/index.html` with your favourite browser:
+    ```bash
+    # Firefox
+    firefox ./doc/build/html/index.html
+
+    # Using your default browser
+    xdg-open ./doc/build/html/index.html
+    ```
 
 *   Once you've made all your changes and all the tests pass successfully, we need to make sure that the code fits a certain format and that the [typing](https://docs.python.org/3/library/typing.html) is correct.
     To do this, we use a tool call `pre-commit` which runs `flake8`, a code checker and `mypy`, a static type checker against the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` whic
     ```.rst
     Here's a `link<https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html>`_ to the external documentation on linking for sphinx
     ```
-    Notice the trailing `_` which is used to specify that it is an external link.
+    Notice the trailing `_` which is important
     
 *   If you want to make some more detailed documentation about some feature that you introduced or you think is not well documented, you'll have to think about a few things.
     

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ This guide is only aimed towards Unix command line users as that's what we know 
 There are many kinds of contributions you can make to auto-sklearn but we'll focus on three main ones **Documentation**, **Bug Fixes** and **Features**, each of which require a little bit of a different flow.
 We need to perform several checks to make sure it meets code standards and won't cause any issues later on.
 
+We tend to follow a development cycle which could be called _Gitflow_ which you are new to git or git-based projects, you can see a nice summary [here](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+
 First we'll go over the general flow, what each step does and then later look at making more specific kinds of changes, what we'd like to see and how you might create a workflow.
 Following that we'll tell you about how you can test your changes locally and then how to submit your pull request!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,131 +1,96 @@
 # Contributing to auto-sklearn
 Thanks for checking out the contribution guide!
-We included a [quick overview](#pull-request-overview) at the end for anyone familiar with open-source contribution or autosklearn and simply wants to see our workflow.
+We included a [quick overview](#pull-request-overview) at the end for anyone familiar with open-source contribution or familiar with autosklearn and simply wants to see our workflow.
 
 If you're new to contributing then hopefully this guide helps with contributing to open-source and auto-sklearn, whether it be a simple doc fix, a small bug fix or even new features that everyone can get use out of.
-Even if you're new to open-source or even new to Python but you want to get your hands dirty, we'll try to be as helpful as possible.
 If you're looking for a particular project to work on, check out the [Issues](https://github.com/automl/auto-sklearn/issues) for things you might be interested in!
 
 For experienced contributors, you can skip the overview and find the quick walkthrough [here](#pull-request-overview)!
-Newer contributors, we provide full documentation to help walk you through everything!
 
 This guide is only aimed towards Unix command line users as that's what we know but the same principles apply.
 
-
 # Contributing
-There are many kinds of contributions you can make to auto-sklearn but we'll focus on three main ones **Documentation**, **Bug Fixes** and **Features**, each of which require a little bit of a different flow to make sure it meets code standards and won't cause any issues later on.
-Following that we'll tell you about how you can test your changes locally and then how to submit your pull request!
+There are many kinds of contributions you can make to auto-sklearn but we'll focus on three main ones **Documentation**, **Bug Fixes** and **Features**, each of which require a little bit of a different flow.
+We need to perform several checks to make sure it meets code standards and won't cause any issues later on.
 
 First we'll go over the general flow, what each step does and then later look at making more specific kinds of changes, what we'd like to see and how you might create a workflow.
+Following that we'll tell you about how you can test your changes locally and then how to submit your pull request!
 
 ## General steps
 *   The first thing to do is create your own [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
-    This gives you a nice place to work on your changes without impacting any code from the original repository.
+    This is to give you a nice place to work on your changes without impacting any code from the original repository.
+
     To do this, navigate to [automl/auto-sklearn](https://github.com/automl/auto-sklearn) and hit the **fork** button in the top-right corner.
-    This will copy the repository as it is, including all its different branches, to you own account.
+    This will copy the repository to your own account, including all of its different branches.
     You'll be able to access this at `https://github.com/{your-username}/auto-sklearn`.
 
 *   The next steps are to download **your own fork** and to create a new [branch](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches) where all your changes will go.
+    It's important to work off the latest changes on the **development** branch.
     ```bash
     # With https
     git clone https://github.com/{your-username}/auto-sklearn
-    
-    # ... or With ssh
-    git clone git@github.com:automl/auto-sklearn.git
-    
+
+    # ... or with ssh
+    git clone git@github.com:{your-username}/auto-sklearn.git
+
     # Navigate into the cloned repo
     cd auto-sklearn
-    
+
+    # Create a new branch based off the development one
+    git checkout -b my_new_branch development
+
+    # ... Alternativly, if you would prefer a more manual method
+    # Show all the available branches with a * beside your current one
+    git branch
+
     # Switch to the development branch
     git checkout development
-    
-    # Show all branches and also a * beside the one you are on
-    git branch
-    
-    # Create a new branch based off the development one
+
+    # Create a new branch based on the currently active branch
     git checkout -b my_new_branch
     ```
-    The reason to create a new branch is two fold
-    
-    *   It lets us keep the commit history cleaner once you want to make a pull
-    request.
-    *   If you have to perform a **rebase** or a **merge** later on, this will be
-    much easier.
-        
+
+    The reason to create a new branch is two fold:
+
+    *   One, it keeps the commit history for your changes much cleaner once we merge them in.
+    *   If you have to perform a **rebase** or a **merge** later on, this will be much easier.
+
 *   You'll need a [virtual environment](https://docs.python.org/3/tutorial/venv.html) to work in.
     If you've never used them before, now is definitely the time to start as a virtual environment lets you keep packages for a project separate.
     ```bash
     # Create a virtual environment in a folder called my-virtual-env
     python -m venv my-virtual-env
-    
+
     # Activate the virtual environment
     source my-virtual-env/bin/activate
     ```
-    *   A popular alternative to managing Python projects is [conda](https://docs.conda.io/en/latest/) for which we refer you to their documentation.
-    *   This is the folder where downloaded packages you will need for auto-sklearn will go.
-        In general, anything you install with `pip install` will now go into the virtual environment.
-        If at any time you want to deactivate it simply type `deactivate` in the shell or just close the shell and open a new one
-    *   As extra steps, if you use Python 3.6 or lower on your machine, unfortunately auto-sklearn doesn't support this.
-        You can check out [pyenv](https://github.com/pyenv/pyenv) which lets you switch between Python versions on the fly and manages them all for you
-    
+    *   A popular alternative to managing Python projects is [conda](https://docs.conda.io/en/latest/).
+    *   The folder `my-virtual-env` is where dependancy packages that are required for auto-sklearn will go.
+    *   In general, once you have activated the virtual environment with `source my-virtual-env/bin/activate`, anything you install with `pip install` will now go into the virtual environment.
+        While this environment is active, any python you run will have access to the packages here.
+        If at any time you want to deactivate it simply type `deactivate` in the shell or just close the shell and open a new one.
+    *   If you use Python 3.6 or lower on your machine then unfortunately auto-sklearn doesn't support this.
+        Fortunatly, you can check out [pyenv](https://github.com/pyenv/pyenv) which lets you switch between Python versions on the fly!
+
 *   Now that we have a virtual environment, it's time to install all the dependencies into it.
     ```bash
     pip install -e .[test,examples,doc]
-    
+
     # If you're using shells other than bash you'll need to use
     pip install -e ".[test,examples,doc]"
     ```
     *   If you're only exposure to using pip is `pip install package_name` then this might be a bit confusing.
-    *   If we type `pip install -e .` (notice the 'dot'), this tells `pip` to install a local package located here, in this directory, `.`.
-        The `-e` flag indicates that it should be editable.
-        This means that you will not have to run `pip install .` every time you make a change and want to use it.
+    *   If we type `pip install -e .` (notice the 'dot'), this tells `pip` to install a package located here, in this directory, `.`.
+        The `-e` flag indicates that it should be editable, meaning you will not have to run `pip install .` every time you make a change and want to tryit.
     *   Finally the `[test,examples,doc]` tells `pip` that there's some extra optional dependencies that we want to install.
-        These are used in development but dependencies that aren't required to actually run autosklearn itself.
-        You can check out what these are in the `setup.py` file!
-    *   If you're new to virtual environments, this is a great time to check out what actually exists in the `my-virtual-env` folder.
+        These are dependancies used in development but ones that are not required to actually run autosklearn itself.
+        You can check out what these are in the `setup.py` file.
+    *   If you're new to virtual environments, after performing all this, it's a great time to check out what actually exists in the `my-virtual-env` folder.
 
 *   Now it's time to make some changes, whether it be for [documentation](#documentation), a [bug fix](#bug-fixes) or a new [features](#features).
 
 ## Making Changes
-We'll go over three main categories of contributions but don't feel limited by these headers, adding to our tests, improving python Typing or even some compliance changes are all super useful!
-
-#### Documentation
-Anything to contribute to better documentation is always appreciated and the main way users can get to know about auto-sklearn.
-Whether it's a typo fix, something you didn't find clear or something you think we didn't explain properly, we'd love to improve it!
-
-All of our documentation is done with (`sphinx`)[https://www.sphinx-doc.org/en/master/] with some various
-plugins that you can see in (`doc/conf.py`)[https://github.com/automl/auto-sklearn/blob/master/doc/conf.py#L42].
-
-All of your changes can be viewed by first [building the docs](#testing) and then opening `doc/build/html/index.html` with your favourite browser.
-Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` which opens it up with your default browser.
-
-*   If you're simply fixing a typo, there shouldn't be much to do except make the PR and we'll accept it without much issue.
-*   If you want to fix a link you should know how linking with `sphinx` works
-    *   For links to internal documentation, you can create a label with
-    ```.rst
-    .. _mylabel:
-    ```
-    *   Later on you can reference this label by
-    ```.rst
-    I am reference to :ref:`the above label<mylabel>`
-    ```
-    *   Now if you want to link some external documentation you'll need
-        to do something like
-    ```.rst
-    Here's a `link<https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html>`_ to the external documentation on linking for sphinx
-    ```
-    Notice the trailing `_` which is important
-    
-*   If you want to make some more detailed documentation about some feature that you introduced or you think is not well documented, you'll have to think about a few things.
-    
-    *   Can you include a code snippet to illustrate what you mean?
-    *   Are there other relevant parts of the documentation or code that should be linked to?
-    *   How much other parts of auto-sklearn are you relying on readers to know before hand, maybe link to those sections if you do.
-
-*   If you want to contribute an example, it's a great way to really illustrate an entire flow of some feature.
-    `sphinx-gallery` will run any python file `example_*.py` in one of the example folders.
-    This allows you to have both ReStructured Markdown (rst) and python code with it's output into a [single html page](https://automl.github.io/auto-sklearn/master/examples/40_advanced/example_calc_multiple_metrics.html#sphx-glr-examples-40-advanced-example-calc-multiple-metrics-py)!
-    You'll want to check out some of the [other examples](https://github.com/automl/auto-sklearn/tree/master/examples) to see how to embed rst into a `.py` file.
+We'll go over three main categories of contributions but don't feel limited by these headers, adding to our tests, improving the typing of functions and methods or even some compliance changes are also super useful!
 
 #### Bug Fixes
 Auto-sklearn has been through quite a few iterations, been used for many purposes and is constantly used in ways we didn't even think of.
@@ -143,18 +108,54 @@ Some core things to consider in fixing a bug:
 *   What's the quick fix and what's the long term fix?
     *   Sometimes it's a code typo, a quick correction and problem solved.
         Other times, the bug is an artifact of some larger underlying issue that has gone unnoticed and might require some restructuring.
-        
+
         If this is the case, let us know as you work on it!
-        If it's breaking, sometimes a quick patch and fix will do and larger fixes can be tackled in a timely manner.
+        If it requires breaking, such as changing default behaviour or public API, sometimes a quick patch and fix will do and larger restructing fixes can be tackled in a timely manner.
         As a rule of thumb, if a bug requires modifying more then 50-100 lines of code it's probably something we would like to talk through on how best to tackle it.
 
 *   How can we create a test for this bug in the future?
     *   Of course, once a bug is squashed, we'd like it to not show again and having a test to catch it for the future will future-proof against any changes down the line.
-    
+
         Thankfully, most of this is usually captured in the minimal working example and all that is left is to turn it into a comprehensive test!
 
-What's important once fixing a bug is writing a good PR that let's us now how you identified the bug, what the problem was and how it was fixed.
+What's important once fixing a bug is [writing a good PR](#creating-the-pr) that let's us now how you identified the bug, what the problem was and how it was fixed.
 This lets use review your code with all this in mind and follow the same thought process that lead you to fix it in the first place!
+
+#### Documentation
+Anything to contribute to better documentation is always appreciated and the main way users can get to know about auto-sklearn.
+Whether it's a typo fix, something you didn't find clear or something you think we didn't explain properly, we'd love to improve it!
+
+All of our documentation is done with [`sphinx`](https://www.sphinx-doc.org/en/master/) with some various
+plugins that you can see in [`doc/conf.py`](https://github.com/automl/auto-sklearn/blob/master/doc/conf.py#L42).
+
+All of your changes can be viewed by first [building the docs](#testing) and then opening `doc/build/html/index.html` in a browser.
+
+*   If you're simply fixing a typo, there shouldn't be much to do except make the PR and we'll accept it without much issue.
+*   If you want to fix a link you should know how linking with `sphinx` works
+    *   For links to internal documentation, you can create a label with
+    ```.rst
+    .. _mylabel:
+    ```
+    *   Later on you can reference this label by
+    ```.rst
+    I am reference to :ref:`the above label<mylabel>`
+    ```
+    *   Now if you want to link some external documentation you'll need
+        to do something like
+    ```.rst
+    Here's a `link<https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html>`_ to the external documentation on linking for sphinx
+    ```
+    Notice the trailing `_` which is important
+
+*   If you want to make some more detailed documentation about some feature that you introduced or you think is not well documented, you'll have to think about a few things.
+    *   Can you include a code snippet to illustrate what you mean?
+    *   Are there other relevant parts of the documentation or code that should be linked to?
+    *   How much other parts of auto-sklearn are you relying on readers to know before hand, maybe link to those sections if you do.
+
+*   If you want to contribute an example, it's a great way to really illustrate an entire flow of some feature.
+    `sphinx-gallery` will run any python file `example_*.py` in one of the example folders.
+    This allows you to have both ReStructured Markdown (rst) and python code with it's output into a [single html page](https://automl.github.io/auto-sklearn/master/examples/40_advanced/example_calc_multiple_metrics.html#sphx-glr-examples-40-advanced-example-calc-multiple-metrics-py)!
+    You'll want to check out some of the [other examples](https://github.com/automl/auto-sklearn/tree/master/examples) to see how to embed rst into a `.py` file.
 
 #### Features
 While auto-sklearn has many features we're proud of, there's always room for more and better functionality.
@@ -162,25 +163,26 @@ Features don't have to be performance driven, in fact, most of the new features 
 
 However, features are usually a bigger project and for this we'd really advise getting in touch with us first about the feature in mind.
 There are some things we believe best left for external libraries or integrations that we don't wish to consider at this time.
-Another reason to get in touch is to nail exactly what this feature will look like before going to far, the more direct and concise the feature is, the better.
+Another reason to get in touch is to nail exactly what this feature will look like beforehand, the more direct and concise the feature is, the better.
 
 Some things to keep in mind with new features:
 *   A new feature is great, but will this change any existing default behaviours?
-    Unexpected changes for existing users can be detrimental and sometimes it has to be done ... but often these new features can be presented as an option the user can enable.
+    Unexpected changes for existing users can be detrimental and unexpected.
+    Sometimes it has to be done but often these new features can be presented as an option the user can enable.
 *   If you're introducing some new API:
     *   Creating some code samples of how you'd like your feature to be used is a great start.
     *   What current way is there to do the same thing, can any functionality already present be used to help with this new API?
     *   Are you going to deprecate any current API? This is an important fact to consider and something that will definitely have to be discussed.
 
-Writing features are great but new features means new bugs, but thankfully that's what we can write tests for.
-How to test your feature is always tricky, especially if the feature is big in scope.
-Unfortunately there's no secrete or rule of thumb other than try to cover every case you can think of.
+**Testing Features** - Writing features are great but new features means new bugs, but thankfully that's what we can write tests for.
+How to [test your feature](#testing) is always tricky, especially if the feature is big in scope.
+Unfortunately there's no secret or rule of thumb other than try to cover every case you can think of.
 The more it's tested the better!
 Bugs will still get through, that's okay, we will have done what we can and we can fix those in the future but as long as the usual use-cases are covered, this shouldn't be too much of a problem.
 
-Now how are people going to know about your new feature you've introduced?
-This is what documentation is so great for and it's how almost all software functionality is expressed.
-If the feature is enabled by a simple parameter, great, almost all the documentation is present by the in-code docstring and automatically gets rendered in the online docs ... that docstring that was updated ... right?
+**Documenting Features** - Now how are people going to know about your new feature you've introduced?
+This is what [documentation](#documentation) is so great for and it's how almost all software functionality is expressed.
+If the feature is enabled by a parameter, great, almost all the documentation is already present in the code docstring, automatically being rendered in the online docs ... that docstring that was updated when you made changes ... right?
 Sometimes, the new functionality isn't so clear from a simple parameter description and so maybe something needs to be added to the `manual.rst`, a short paragraph suffices and much appreciated.
 Lastly, if the feature really is a game changer or you're very proud of it, consider making an `example_*.py` that will be run and rendered in the online docs!
 
@@ -194,6 +196,27 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     *   Note that these may take a while so check out `pytest --help` to see how you can run tests so that only previous failures run or only certain tests are run.
         This can help you try changes and get results faster.
         Do however run one last full `pytest` once you are finished and happy!
+    *   Here are some we find particularly useful
+        ```
+        # Run tests in specific file like 'test_estimators.py'
+        pytest "test/test_automl/test_estimators.py"
+
+        # Run an entire directory of tests such as 'pipeline'
+        pytest "test/test_pipeline"
+
+        # Run a specific test 'test_mytest' in a specific directory 'test_automl'
+        pytest -k "test_mytest" "test/test_automl"
+
+        # Rerun all the tests that failed in the last `pytest` command
+        pytest --last-failed
+
+        # Rerun all tests but run the failed ones first
+        pytest --failed-first
+
+        # Exit on the first test failure
+        pytest -x
+        ```
+    *   More advanced editors like PyCharm may have built in integrations which could be good to check out!
 
 *   Now we are going to use [sphinx](https://www.sphinx-doc.org/en/master/) to generate all the documentation and make sure there are no issues.
     ```bash
@@ -229,12 +252,12 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     pip install pre-commit
     pre-commit run --all-files
     ```
-    *   The reason we use a code standard (e.g. `flake8` )is to make sure that when we review code:
+    *   The reason we use a code standard like `flake8` is to make sure that when we review code:
         *   There are no extra blank spaces and blank lines.
         *   Lines don't end up too long
         *   Code from multiple source keeps a similar appearance.
     *   We perform static type checking with `mypy` as this can remove a majority of bugs, before a test is even run.
-        It points out programmer errors and what makes compiled languages so safe so that is why we try to use it as much as possible.
+        It points out programmer errors and is what makes compiled languages so safe.
         If you are new to Python types, or stuck with how something should be 'typed', please feel free to push the pull request in the following steps and we should be able to help you out.
     * If interested, the configuration for `pre-commit` can be found in `.pre-commit-config.yaml`
 
@@ -243,10 +266,13 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
 *   We've made sure all the changes work, we've maybe added a test for them and run all the tests locally.
     It's time to commit the changes, push them up to your fork and create a pull request!
     ```bash
-    # Add your changes and make a commit
+    # Get an overview of all the files changes
+    git status
+
+    # Add your changed files
     git add {changed files}
     git commit -m "Something as meaningful as possible"
-    
+
     # This will push my_new_branch to your fork located at `origin`
     git push --set-upstream origin my_new_branch
     ```
@@ -254,11 +280,13 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
 *   At this point, we need to create a pull request (PR) to the [automl/autosklearn](https://github.com/automl/auto-sklearn) repository with our new changes.
     This can be done simply by going to your own forked repo, clicking **'Contribute'**, and selecting
     the **development** branch of `automl/auto-sklearn`.
+
     *   `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
-    The reason we don't want to directly merge new PR's into master is to make
-    sure we always have a stable version. With a development branch, we can safely
-    accumulate certain changes and makes sure they all work together before creating
-    a new master version.
+
+        The reason we don't want to directly merge new PR's into master is to make
+        sure we always have a stable version. With a development branch, we can safely
+        accumulate certain changes and makes sure they all work together before creating
+        a new master version.
 
 *   Now you've got to describe what you've changed.
     You'll likely want to check out [this blogpost](https://hugooodias.medium.com/the-anatomy-of-a-perfect-pull-request-567382bb6067) which we believe to give a good overview of what a good PR looks like and will help us get your changes in sooner rather than later!
@@ -301,49 +329,52 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
 * Create a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) git repo
 * Clone your own fork and create a new branch from the branch to work on
     ```bash
-    git clone git@github.com:automl/auto-sklearn.git
+    git clone git@github.com:your-username/auto-sklearn.git
     cd auto-sklearn
     git checkout -b my_new_branch development
-    
+
     # Create a virtual environemnt and activate it so there are no package
     # conflicts
     python -m venv my-virtual-env
     source my-virtual-env/bin/activate
-    
+
     pip install -e .[test,docs,examples] # zsh users need quotes ".[test,...]"
-    
+
     # Edit files...
-    
+
     # If you changed documentation:
     # This will generate all documentation, run examples and check links
     cd doc
+    make html
     make linkcheck
-    
+
     # ... fix any issues
-    
+
     # If you edited any code
     # Check out pytest --help if you want to only run specific tests
     pytest
-    
+
     # ... fix any issues
-    
+
     # Use pre-commit for style and typing checks
     pip install pre-commit
     pre-commit run --all-files
-    
+
     # ... fix any issues
-    
+
+    # Check the changed files
+    git status
+
     # Add the changes
     git add {changed files}
     git commit -m "Meaningful as you can make it message"
-    
+
     # Push back to your fork
     git push --set-upstream origin my_new_branch
     ```
-* Go to github, go to your fork and then make a pull request using the *Contribute*
-icon.
+* Go to github, go to your fork and then make a pull request using the **Contribute** button.
     * `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
-* Write a description of the changes, why you implemented them and any implications.
+* Write a [PR](#creating-the-pr) with a description of the changes, why you implemented them and any implications.
     * Check out this [blog post](https://hugooodias.medium.com/the-anatomy-of-a-perfect-pull-request-567382bb6067) for some inspiration!
 * Once we see this, we will run some automated tests on the pull request. These
 tests are the same as the ones you can run manually and are mentioned in the
@@ -360,11 +391,12 @@ tests are the same as the ones you can run manually and are mentioned in the
 ### I've been asked to rebase my pull request, why and what do I do?
 *   It can often be the case that while you were working on some changes, we may have merged something new into the development branch.
 
-    This can be a problem because the branch you created was based off the old development branch in and so there are new changes in the automl/auto-sklearn code base you don't have in your branch.
-    This is not always an issue, as generally if different parts of the code were touched, they can be merged safely.
+    This can be a problem because the branch you created was based off the old development branch.
+    This means there are new changes in the automl/auto-sklearn code base you don't have in your forked repo or locally.
+    This is not always an issue, generally if different parts of the code were touched they can be merged safely.
     Either way, if we ask you to [rebase](https://www.atlassian.com/git/tutorials/merging-vs-rebasing), it is because it won't merge or we think there may have been overlapping changes between what you were working on and the new code put into the development branch.
 *   First, update the development branch on **your fork**
-    *   The easiest way to do this is go to github.com/{your-username}/auto-sklearn navigate to the development branch and click *fetch upstream*.
+    *   The easiest way to do this is go to *https://github.com/your-username/auto-sklearn*, navigate to the development branch and hit **fetch upstream**.
     *   This will make it so your fork of auto-sklearn is now up to date
 *   Second, we need to go to our clone and pull in these new changes to development
     ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` whic
     *   How much other parts of auto-sklearn are you relying on readers to know before hand, maybe link to those sections if you do.
 
 *   If you want to contribute an example, it's a great way to really illustrate an entire flow of some feature.
-    `sphinx-gallery` will run any python file `examle_*.py` in one of the example folders.
+    `sphinx-gallery` will run any python file `example_*.py` in one of the example folders.
     This allows you to have both ReStructured Markdown (rst) and python code with it's output into a [single html page](https://automl.github.io/auto-sklearn/master/examples/40_advanced/example_calc_multiple_metrics.html#sphx-glr-examples-40-advanced-example-calc-multiple-metrics-py)!
     You'll want to check out some of the [other examples](https://github.com/automl/auto-sklearn/tree/master/examples) to see how to embed rst into a `.py` file.
 
@@ -243,7 +243,7 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     # This will push my_new_branch to your fork located at `origin`
     git push --set-upstream origin my_new_branch
     ```
-    
+
 *   At this point, we need to create a pull request (PR) to the [automl/autosklearn](https://github.com/automl/auto-sklearn) repository with our new changes.
     This can be done simply by going to your own forked repo, clicking **'Contribute'**, and selecting
     the **development** branch of `automl/auto-sklearn`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,218 @@
+# Contributing to auto-sklearn
+Thanks for checking out the contribution guide! Feel free to [skip ahead](#pull-request-overview) if you're not new to open-source or already contributed before. 
+
+Hopefully this guide helps you to contribute to open-source and auto-sklearn, whether it be a simple doc fix, a small bug fix or even new features that everyone can get use out of.
+If you're new to open-source or even new to Python but you want to get your hands dirty, we'll try to be as helpful as possible.
+If you're looking for a particular project to work on, check out the [Issues](https://github.com/automl/auto-sklearn/issues) for things you might be interested in working on!
+
+For new contributors, the first sections will be of most help while contributors to other open-source projects or even auto-sklearn can refer to the [details](#pull-request-overview) section.
+
+This guide is only aimed towards Unix command line users as that's what we know but the same principles apply.
+
+# Contributing Overview
+There are many kinds of contributions you can make to auto-sklearn but we'll focus on three main ones **Documentation**, **Bug Fixes** and **Features**, each of which require a little bit of a different flow to make sure it meets code standards and won't cause any issues later on.
+
+First we'll go over the general flow, what each step does and then later look at making more specific kinds of changes, what we'd like to see and how you might create a workflow.
+
+## General steps
+*   The first thing to do is create your own [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+    This gives you a nice place to work on your changes without impacting any code from the original repository.
+    To do this, navigate to [automl/auto-sklearn](https://github.com/automl/auto-sklearn) and hit the **fork** button in the top-right corner.
+    This will copy the repository as it is, including all its different branches, to you own account.
+    You'll be able to access this at `https://github.com/{your-username}/auto-sklearn`.
+
+*   The next steps are to download **your own fork** and to create a new [branch](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches) where all your changes will go.
+    ```bash
+    # With https
+    git clone https://github.com/{your-username}/auto-sklearn
+    
+    # ... or With ssh
+    git clone git@github.com:automl/auto-sklearn.git
+    
+    # Navigate into the cloned repo
+    cd auto-sklearn
+    
+    # Switch to the development branch
+    git checkout development
+    
+    # Show all branches and also a * beside the one you are on
+    git branch
+    
+    # Create a new branch based off the development one
+    git checkout -b my_new_branch
+    ```
+    The reason to create a new branch is two fold
+    
+    *   It lets us keep the commit history cleaner once you want to make a pull
+    request.
+    *   If you have to perform a **rebase** or a **merge** later on, this will be
+    much easier.
+        
+*   You'll need a [virtual environment](https://docs.python.org/3/tutorial/venv.html) to work in.
+    If you've never used them before, now is definitely the time to start as a virtual environment lets you keep packages for a project separate.
+    ```bash
+    # Create a virtual environment in a folder called my-virtual-env
+    python -m venv my-virtual-env
+    
+    # Activate the virtual environment
+    source my-virtual-env/bin/activate
+    ```
+    *   This is the folder where downloaded packages you will need for auto-sklearn will go.
+        In general, anything you install with `pip install` will now go into the virtual environment.
+        If at any time you want to deactivate it simply type `deactivate` in the shell or just close the shell and open a new one
+    *   As extra steps, if you use Python 3.6 or lower on your machine, unfortunately auto-sklearn doesn't support this.
+        You can check out [pyenv](https://github.com/pyenv/pyenv) which lets you switch between Python versions on the fly and manages them all for you
+    
+*   Now that we have a virtual environment, it's time to install all the dependencies into it.
+    ```bash
+    pip install -e .[test,examples,doc]
+    
+    # If you're using shells other than bash you'll need to use
+    pip install -e ".[test,examples,doc]"
+    ```
+    *   If you're only use to using `pip install package_name` then this might be a bit confusing.
+    *   If we type `pip install -e .` (notice the 'dot'), this tells `pip` to install a local package located here, in this directory, `.`. 
+        The `-e` flag indicates that it should be editable.
+        This means that you want have to run `pip install .` every time you make a change and want to use it.
+    *   Finally the `[test,examples,doc]` tells `pip` that there's some extra optional dependencies that we want to install.
+        These are used in development but dependencies that aren't required to actually run autosklearn itself.
+        You can check out what these are in the `setup.py` file!
+    *   If you new to virtual environments, this is a great time to check out what actually exists in the `my-virtual-env`.
+
+*   Now it's time to make some changes, whether it be for [documentation](#documentation), a [bug fix](#bug-fixes) or a new [features](#features).
+
+*   Let's assume you've made some changes, now we have to make sure they work.
+    Begin by simply running all the tests.
+    If there's any errors, they'll pop up once it's complete.
+    ```bash
+    pytest
+    ```
+    *   Note that these may take a while so check out `pytest --help` to see how you can run tests so that only previous failures run or only certain tests are run.
+        This can help you try changes and get results faster.
+        Do however run one last full `pytest` once you are finished and happy!
+
+*   Now we are going to use [sphinx](https://www.sphinx-doc.org/en/master/) to generate all the documentation and make sure there are no issues.
+    ```bash
+    cd doc
+    make html
+    ```
+    *   If you're unfamiliar with sphinx, it's a documentation generator which can read comments and docstrings from within the code and generate html documentation.
+    *   We also use sphinx-gallery which can take python files (such as those in the `examples` folder) and run them, creating html which shows the code and the output it generates.
+        Unfortunately this can take quite some time but you should only have to run this once.
+    *   If you've made many documentation changes, there are more explicit details for [testing documentation changes](#documentation)
+
+*   Once you've made all your changes and all the tests pass successfully, we need to make sure that the code fits a certain format and that the [typing](https://docs.python.org/3/library/typing.html) is correct.
+    To do this, we use a tool call `pre-commit` which runs `flake8`, a code checker and `mypy`, a static type checker against the code.
+    ```bash
+    pip install pre-commit
+    pre-commit run --all-files
+    ```
+    *   The reason we use a code standard (e.g. `flake8` )is to make sure that when we review code:
+        *   There are no extra blank spaces and blank lines.
+        *   Lines don't end up too long
+        *   Code from multiple source keeps a similar appearance.
+    *   We perform static type checking with `mypy` as this can remove a majority of bugs, before a test is even run.
+        It points out programmer errors and what makes compiled languages so safe so that is why we try to use it as much as possible.
+        If you are new to Python types, or stuck with how something should be 'typed', please feel free to push the pull request in the following steps and we should be able to help you out.
+    * If interested, the configuration for `pre-commit` can be found in `.pre-commit-config.yaml`
+
+*   Finally, we should commit our changes, push them up to our fork and create a pull request.
+    ```bash
+    # Add your changes and make a commit
+    git add {changed files}
+    git commit -m "Something as meaningful as possible"
+    
+    # This will push my_new_branch to your fork located at `origin`
+    git push --set-upstream origin my_new_branch
+    ```
+
+* Creating a PR TODO
+* Writing a PR description TODO
+* Automated tests TODO
+* Fixing Review changes TODO
+
+## Documentation
+* TODO
+## Bug Fixes
+* TODO
+## Features
+* TODO
+
+# Pull Request Overview
+* Create a fork of the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) git repo
+* Clone your own fork and create a new branch from the branch to work on
+    ```bash
+    git clone git@github.com:automl/auto-sklearn.git
+    cd auto-sklearn
+    git checkout -b my_new_branch development
+    
+    python -m venv my-virtual-env
+    source my-virtual-env/bin/activate
+    
+    pip install -e .[test,docs,examples] # zsh users need quotes ".[test,...]"
+    
+    # Edit files...
+    
+    # If you changed documentation:
+    # This will generate all documentation, run examples and check links
+    cd doc
+    make linkcheck
+    
+    # ... fix any issues
+    
+    # If you edited any code
+    # Check out pytest --help if you want to only run specific tests
+    pytest
+    
+    # ... fix any issues
+    
+    # Use pre-commit for style and typing checks
+    pip install pre-commit
+    pre-commit run --all-files
+    
+    # ... fix any issues
+    
+    # Add the changes
+    git add {changed files}
+    git commit -m "Meaningful as you can make it message"
+    
+    # Push back to your fork
+    git push --set-upstream origin my_new_branch
+    ```
+* Go to github, go to our own fork and then make a pull request using the *Contribute*
+icon.
+    * `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
+* Write a description of the changes, why you implemented them and any implications.
+* If it's your first time contributing, we will run some automated tests, mostly
+the same as you can run manually
+* We'll review the code and perhaps ask for some changes
+* Once we're happy with the result, we'll merge it in!
+
+# FAQ
+
+### I've finished my pull request and want it reviewed, now what?
+* In the Pull request on the right there should be a tab **Reviewers** with some suggested
+reviewers, feel free to request once you think your contribution is ready.
+
+### I've been asked to rebase my pull request, why and what do I do?
+* It can often be the case that while you were working on some changes, we may have merged something new into the development branch.
+This is a problem because the branch you created was based off the old development branch in and so there are no changes in the automl/auto-sklearn code base you don't have in your branch.
+This is not always an issue, as generally if different parts of the code were touched, they can be merged safely.
+Either way, if we ask you to [rebase](https://www.atlassian.com/git/tutorials/merging-vs-rebasing), it is because it won't merge or we think there may have been overlapping changes between what you were working on and the new code put into the development branch.
+* First, update the development branch on **your fork**
+    * The easiest way to do this is go to github.com/{your-username}/auto-sklearn navigate to the development branch and click *fetch upstream*.
+    * This will make it so your fork of auto-sklearn is now up to date
+* Second, we need to go to our clone and pull in these new changes to development
+    ```bash
+    git checkout development
+    git pull
+    ```
+* Lastly, we need to rebase the my_new_branch on top of the new development
+    ```bash
+    git checkout my_new_branch
+    git rebase development
+    ```
+* Now if there were no conflicts, that's it, you can continue as normal. If there
+are conflicts, you'll have to sort these out which you can find out how to do
+[here](https://docs.github.com/en/get-started/using-git/resolving-merge-conflicts-after-a-git-rebase) and [here](https://docs.github.com/en/github/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,66 @@
 # Contributing to auto-sklearn
-Thanks for checking out the contribution guide! Feel free to [skip ahead](#pull-request-overview) if you're not new to open-source or already contributed before. 
+Thanks for checking out the contribution guide! 
+We included a quick overview at the start for anyone familiar with open-source contribution or autosklearn and simply wants to see our workflow.
 
-Hopefully this guide helps you to contribute to open-source and auto-sklearn, whether it be a simple doc fix, a small bug fix or even new features that everyone can get use out of.
-If you're new to open-source or even new to Python but you want to get your hands dirty, we'll try to be as helpful as possible.
-If you're looking for a particular project to work on, check out the [Issues](https://github.com/automl/auto-sklearn/issues) for things you might be interested in working on!
+If you're new to contributing then hopefully this guide helps with contributing to open-source and auto-sklearn, whether it be a simple doc fix, a small bug fix or even new features that everyone can get use out of.
+Even if you're new to open-source or even new to Python but you want to get your hands dirty, we'll try to be as helpful as possible.
+If you're looking for a particular project to work on, check out the [Issues](https://github.com/automl/auto-sklearn/issues) for things you might be interested in!
 
-For new contributors, the first sections will be of most help while contributors to other open-source projects or even auto-sklearn can refer to the [details](#pull-request-overview) section.
+For new contributors, you can skip the overview and find the more detailed walkthrough [here](#contributing)!
 
 This guide is only aimed towards Unix command line users as that's what we know but the same principles apply.
 
-# Contributing Overview
+# Pull Request Overview
+* Create a fork of the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) git repo
+* Clone your own fork and create a new branch from the branch to work on
+    ```bash
+    git clone git@github.com:automl/auto-sklearn.git
+    cd auto-sklearn
+    git checkout -b my_new_branch development
+    
+    python -m venv my-virtual-env
+    source my-virtual-env/bin/activate
+    
+    pip install -e .[test,docs,examples] # zsh users need quotes ".[test,...]"
+    
+    # Edit files...
+    
+    # If you changed documentation:
+    # This will generate all documentation, run examples and check links
+    cd doc
+    make linkcheck
+    
+    # ... fix any issues
+    
+    # If you edited any code
+    # Check out pytest --help if you want to only run specific tests
+    pytest
+    
+    # ... fix any issues
+    
+    # Use pre-commit for style and typing checks
+    pip install pre-commit
+    pre-commit run --all-files
+    
+    # ... fix any issues
+    
+    # Add the changes
+    git add {changed files}
+    git commit -m "Meaningful as you can make it message"
+    
+    # Push back to your fork
+    git push --set-upstream origin my_new_branch
+    ```
+* Go to github, go to our own fork and then make a pull request using the *Contribute*
+icon.
+    * `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
+* Write a description of the changes, why you implemented them and any implications.
+* If it's your first time contributing, we will run some automated tests, mostly
+the same as you can run manually
+* We'll review the code and perhaps ask for some changes
+* Once we're happy with the result, we'll merge it in!
+
+# Contributing
 There are many kinds of contributions you can make to auto-sklearn but we'll focus on three main ones **Documentation**, **Bug Fixes** and **Features**, each of which require a little bit of a different flow to make sure it meets code standards and won't cause any issues later on.
 
 First we'll go over the general flow, what each step does and then later look at making more specific kinds of changes, what we'd like to see and how you might create a workflow.
@@ -126,71 +177,65 @@ First we'll go over the general flow, what each step does and then later look at
     git push --set-upstream origin my_new_branch
     ```
 
-* Creating a PR TODO
-* Writing a PR description TODO
-* Automated tests TODO
-* Fixing Review changes TODO
+*   At this point, we need to create a PR request to the [automl/autosklearn](https://github.com/automl/auto-sklearn) repository with our new changes.
+    This can be done simply by going to your own forked repo, clicking **'Contribute'**, and selecting
+    the **development** branch of `automl/auto-sklearn`.
+    *   `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
+    The reason we don't want to directly merge new PR's into master is to make
+    sure we always have a stable version. With a development branch, we can safely
+    accumulate certain changes and makes sure they all work together before creating
+    a new master version.
 
-## Documentation
+*   Now you've got to describe what you've changed.
+    Some key things to include here are:
+    *   A high level overview of what you've done such as fixing a problem or
+        introducing a new feature.
+        If it's a simple doc fix, don't worry too much about this.
+    *   Have you introduced any breaking changes to the API?
+        We may not realise it while reviewing the changes but if you are aware,
+        it definitely helps to tell us!
+    *   Do you think this might have any implications in the future or how would
+        further work on this look like?
+    *   If you've introduced some new feature, write about who might use it,
+        give a breif code sample to show it and let us know how you tested it!
+    *   If you've fixed a bug, write about why this bug exists in the first place,
+        how you solved it and how a test makes sure it won't pop up again!
+
+*   Once you've submitted a PR, we'll probably enable some automatic tests to run.
+    This will make sure all the tests run smoothly, make sure the documentation builds correctly and do some quick check on code quality.
+    You'll be able to see these run in the **Checks** tab or at the bottom of the PR.
+    If you see a red x, that means somethings probably gone wrong which should have been caught by running the tests locally but we also do some checks in environments you were not developing on.
+    Sometimes it is the case that there is a bug unrelated to your changes that cause the tests to fail but we are aware of these.
+    If you see one of these failures, feel free to ask!
+
+*   Meanwhile, we'll also review your code.
+    In the top right you'll see a little **Suggested Reviewers** button so feel free to request a review with that!
+    Some common review points are:
+    * This seems odd, why was this done?
+    * Could you see if you can use the functionality from place X?
+    * Could you creat a test or documentation for this?
+    * This could be a nicer way of doing this, what do you think?
+    Occasionally there will be some major point which will require more discussion but those are more on a case-by-case basis.
+
+*   This process of review, fix and testing may go on a few times.
+    The simplest way to reduce the time needed and to help us too is to run the tests, code formatting check and doc building locall.
+    If they all pass locally they will very often have no issues in the automated tests.
+
+    Once everyone is happy, it's time for us to hit (*squash*) merge, get it into the development branch and have one more contribution to autosklearn!
+
+## Kinds of PRs
+Of course we can't cover every use case but here's some common kinds of PR's along with some pointers!
+
+#### Documentation
+Anything to contribute to better documentation is always appreciated
+#### Bug Fixes
 * TODO
-## Bug Fixes
-* TODO
-## Features
+#### Features
 * TODO
 
-# Pull Request Overview
-* Create a fork of the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) git repo
-* Clone your own fork and create a new branch from the branch to work on
-    ```bash
-    git clone git@github.com:automl/auto-sklearn.git
-    cd auto-sklearn
-    git checkout -b my_new_branch development
-    
-    python -m venv my-virtual-env
-    source my-virtual-env/bin/activate
-    
-    pip install -e .[test,docs,examples] # zsh users need quotes ".[test,...]"
-    
-    # Edit files...
-    
-    # If you changed documentation:
-    # This will generate all documentation, run examples and check links
-    cd doc
-    make linkcheck
-    
-    # ... fix any issues
-    
-    # If you edited any code
-    # Check out pytest --help if you want to only run specific tests
-    pytest
-    
-    # ... fix any issues
-    
-    # Use pre-commit for style and typing checks
-    pip install pre-commit
-    pre-commit run --all-files
-    
-    # ... fix any issues
-    
-    # Add the changes
-    git add {changed files}
-    git commit -m "Meaningful as you can make it message"
-    
-    # Push back to your fork
-    git push --set-upstream origin my_new_branch
-    ```
-* Go to github, go to our own fork and then make a pull request using the *Contribute*
-icon.
-    * `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
-* Write a description of the changes, why you implemented them and any implications.
-* If it's your first time contributing, we will run some automated tests, mostly
-the same as you can run manually
-* We'll review the code and perhaps ask for some changes
-* Once we're happy with the result, we'll merge it in!
+# General FAQ
 
-# FAQ
-
-### I've finished my pull request and want it reviewed, now what?
+### I've finished my pull request or made new changes and want it reviewed, now what?
 * In the Pull request on the right there should be a tab **Reviewers** with some suggested
 reviewers, feel free to request once you think your contribution is ready.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,67 +1,20 @@
 # Contributing to auto-sklearn
-Thanks for checking out the contribution guide! 
-We included a quick overview at the start for anyone familiar with open-source contribution or autosklearn and simply wants to see our workflow.
+Thanks for checking out the contribution guide!
+We included a [quick overview](#pull-request-overview) at the end for anyone familiar with open-source contribution or autosklearn and simply wants to see our workflow.
 
 If you're new to contributing then hopefully this guide helps with contributing to open-source and auto-sklearn, whether it be a simple doc fix, a small bug fix or even new features that everyone can get use out of.
 Even if you're new to open-source or even new to Python but you want to get your hands dirty, we'll try to be as helpful as possible.
 If you're looking for a particular project to work on, check out the [Issues](https://github.com/automl/auto-sklearn/issues) for things you might be interested in!
 
-For new contributors, you can skip the overview and find the more detailed walkthrough [here](#contributing)!
+For experienced contributors, you can skip the overview and find the quick walkthrough [here](#pull-request-overview)!
+Newer contributors, we provide full documentation to help walk you through everything!
 
 This guide is only aimed towards Unix command line users as that's what we know but the same principles apply.
 
-# Pull Request Overview
-* Create a fork of the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) git repo
-* Clone your own fork and create a new branch from the branch to work on
-    ```bash
-    git clone git@github.com:automl/auto-sklearn.git
-    cd auto-sklearn
-    git checkout -b my_new_branch development
-    
-    python -m venv my-virtual-env
-    source my-virtual-env/bin/activate
-    
-    pip install -e .[test,docs,examples] # zsh users need quotes ".[test,...]"
-    
-    # Edit files...
-    
-    # If you changed documentation:
-    # This will generate all documentation, run examples and check links
-    cd doc
-    make linkcheck
-    
-    # ... fix any issues
-    
-    # If you edited any code
-    # Check out pytest --help if you want to only run specific tests
-    pytest
-    
-    # ... fix any issues
-    
-    # Use pre-commit for style and typing checks
-    pip install pre-commit
-    pre-commit run --all-files
-    
-    # ... fix any issues
-    
-    # Add the changes
-    git add {changed files}
-    git commit -m "Meaningful as you can make it message"
-    
-    # Push back to your fork
-    git push --set-upstream origin my_new_branch
-    ```
-* Go to github, go to our own fork and then make a pull request using the *Contribute*
-icon.
-    * `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
-* Write a description of the changes, why you implemented them and any implications.
-* If it's your first time contributing, we will run some automated tests, mostly
-the same as you can run manually
-* We'll review the code and perhaps ask for some changes
-* Once we're happy with the result, we'll merge it in!
 
 # Contributing
 There are many kinds of contributions you can make to auto-sklearn but we'll focus on three main ones **Documentation**, **Bug Fixes** and **Features**, each of which require a little bit of a different flow to make sure it meets code standards and won't cause any issues later on.
+Following that we'll tell you about how you can test your changes locally and then how to submit your pull request!
 
 First we'll go over the general flow, what each step does and then later look at making more specific kinds of changes, what we'd like to see and how you might create a workflow.
 
@@ -108,6 +61,7 @@ First we'll go over the general flow, what each step does and then later look at
     # Activate the virtual environment
     source my-virtual-env/bin/activate
     ```
+    *   A popular alternative to managing Python projects is [conda](https://docs.conda.io/en/latest/) for which we refer you to their documentation.
     *   This is the folder where downloaded packages you will need for auto-sklearn will go.
         In general, anything you install with `pip install` will now go into the virtual environment.
         If at any time you want to deactivate it simply type `deactivate` in the shell or just close the shell and open a new one
@@ -121,17 +75,63 @@ First we'll go over the general flow, what each step does and then later look at
     # If you're using shells other than bash you'll need to use
     pip install -e ".[test,examples,doc]"
     ```
-    *   If you're only use to using `pip install package_name` then this might be a bit confusing.
-    *   If we type `pip install -e .` (notice the 'dot'), this tells `pip` to install a local package located here, in this directory, `.`. 
+    *   If you're only exposure to using pip is `pip install package_name` then this might be a bit confusing.
+    *   If we type `pip install -e .` (notice the 'dot'), this tells `pip` to install a local package located here, in this directory, `.`.
         The `-e` flag indicates that it should be editable.
-        This means that you want have to run `pip install .` every time you make a change and want to use it.
+        This means that you will not have to run `pip install .` every time you make a change and want to use it.
     *   Finally the `[test,examples,doc]` tells `pip` that there's some extra optional dependencies that we want to install.
         These are used in development but dependencies that aren't required to actually run autosklearn itself.
         You can check out what these are in the `setup.py` file!
-    *   If you new to virtual environments, this is a great time to check out what actually exists in the `my-virtual-env`.
+    *   If you're new to virtual environments, this is a great time to check out what actually exists in the `my-virtual-env` folder.
 
 *   Now it's time to make some changes, whether it be for [documentation](#documentation), a [bug fix](#bug-fixes) or a new [features](#features).
 
+## Making Changes
+We'll go over three main categories of contributions but don't feel limited by these headers, adding to our tests, improving python Typing or even some compliance changes are all super useful!
+
+#### Documentation
+Anything to contribute to better documentation is always appreciated and the main way users can get to know about auto-sklearn.
+Whether it's a typo fix, something you didn't find clear or something you think we didn't explain properly, we'd love to improve it!
+
+All of our documentation is done with (`sphinx`)[https://www.sphinx-doc.org/en/master/] with some various
+plugins that you can see in (`doc/conf.py`)[https://github.com/automl/auto-sklearn/blob/master/doc/conf.py#L42].
+
+All of your changes can be viewed by first [building the docs](#testing) and then opening `doc/build/html/index.html` with your favourite browser.
+Alternatively, you can use the command `xdg-open doc/build/hmtl/index.html` which opens it up with your default browser.
+
+*   If your simply fixing a typo, there shouldn't be much to do accept make the PR and we'll accept it without much issue.
+*   If you want to fix a link you should know how linking with `sphinx` works
+    *   For links to internal documentation, you can create a label with
+    ```.rst
+    .. _mylabel:
+    ```
+    *   Later on you can reference this label by
+    ```.rst
+    I am reference to :ref:`the above label<mylabel>`
+    ```
+    *   Now if you want to link some external documentation you'll need
+        to do something like
+    ```.rst
+    Here's a `link<https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html>` to the external documentation on linking for sphinx
+    ```
+    
+*   If you want to make some more detailed documentation about some feature that you introduced or you think is not well documented, you'll have to think about a few things.
+    
+    *   Can you include a code snippet to illustrate what you mean?
+    *   Are there other relevant parts of the documentation or code that should be linked to?
+    *   How much other parts of auto-sklearn are you relying on readers to know before hand, maybe link to those sections if you do.
+
+*   If you want to contribute an example, it's a great way to really illustrate an entire flow of some feature.
+    `sphinx-gallery` will run any python file `examle_*.py` in one of the example folders.
+    This allows you to have both ReStructured Markdown (rst) and python code with it's output into a [single html page](https://automl.github.io/auto-sklearn/master/examples/40_advanced/example_calc_multiple_metrics.html#sphx-glr-examples-40-advanced-example-calc-multiple-metrics-py)!
+    You'll want to check out some of the [other examples](https://github.com/automl/auto-sklearn/tree/master/examples) to see how to embed rst into a `.py` file.
+
+#### Bug Fixes
+* TODO
+#### Features
+* TODO
+
+## Testing
 *   Let's assume you've made some changes, now we have to make sure they work.
     Begin by simply running all the tests.
     If there's any errors, they'll pop up once it's complete.
@@ -150,7 +150,18 @@ First we'll go over the general flow, what each step does and then later look at
     *   If you're unfamiliar with sphinx, it's a documentation generator which can read comments and docstrings from within the code and generate html documentation.
     *   We also use sphinx-gallery which can take python files (such as those in the `examples` folder) and run them, creating html which shows the code and the output it generates.
         Unfortunately this can take quite some time but you should only have to run this once.
-    *   If you've made many documentation changes, there are more explicit details for [testing documentation changes](#documentation)
+    *   If you need to quickly check something, you can run `make html-noexamples` to prevent sphinx from running the examples.
+    ```bash
+    cd doc
+    make html-noexamples
+    ```
+    *   Sphinx also has a command `linkcheck` for making sure all the links correctly go to some destination.
+        This helps tests for dead links or accidental typos.
+    ```bash
+    cd doc
+    make linkcheck
+    ```
+    *   To view the documentation itself, 
 
 *   Once you've made all your changes and all the tests pass successfully, we need to make sure that the code fits a certain format and that the [typing](https://docs.python.org/3/library/typing.html) is correct.
     To do this, we use a tool call `pre-commit` which runs `flake8`, a code checker and `mypy`, a static type checker against the code.
@@ -167,7 +178,10 @@ First we'll go over the general flow, what each step does and then later look at
         If you are new to Python types, or stuck with how something should be 'typed', please feel free to push the pull request in the following steps and we should be able to help you out.
     * If interested, the configuration for `pre-commit` can be found in `.pre-commit-config.yaml`
 
-*   Finally, we should commit our changes, push them up to our fork and create a pull request.
+
+## Creating the PR
+*   We've made sure all the changes work, we've maybe added a test for them and run all the tests locally.
+    It's time to commit the changes, push them up to your fork and create a pull request!
     ```bash
     # Add your changes and make a commit
     git add {changed files}
@@ -176,8 +190,8 @@ First we'll go over the general flow, what each step does and then later look at
     # This will push my_new_branch to your fork located at `origin`
     git push --set-upstream origin my_new_branch
     ```
-
-*   At this point, we need to create a PR request to the [automl/autosklearn](https://github.com/automl/auto-sklearn) repository with our new changes.
+    
+*   At this point, we need to create a pull request (PR) to the [automl/autosklearn](https://github.com/automl/auto-sklearn) repository with our new changes.
     This can be done simply by going to your own forked repo, clicking **'Contribute'**, and selecting
     the **development** branch of `automl/auto-sklearn`.
     *   `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
@@ -187,6 +201,7 @@ First we'll go over the general flow, what each step does and then later look at
     a new master version.
 
 *   Now you've got to describe what you've changed.
+    You'll likely want to check out [this blogpost](https://hugooodias.medium.com/the-anatomy-of-a-perfect-pull-request-567382bb6067) which we believe to give a good overview of what a good PR looks like and will help us get your changes in sooner rather than later!
     Some key things to include here are:
     *   A high level overview of what you've done such as fixing a problem or
         introducing a new feature.
@@ -201,7 +216,7 @@ First we'll go over the general flow, what each step does and then later look at
     *   If you've fixed a bug, write about why this bug exists in the first place,
         how you solved it and how a test makes sure it won't pop up again!
 
-*   Once you've submitted a PR, we'll probably enable some automatic tests to run.
+*   Once you've submitted a PR, we have it set up so github will automatically schedule some unit tests and documentation building to run.
     This will make sure all the tests run smoothly, make sure the documentation builds correctly and do some quick check on code quality.
     You'll be able to see these run in the **Checks** tab or at the bottom of the PR.
     If you see a red x, that means somethings probably gone wrong which should have been caught by running the tests locally but we also do some checks in environments you were not developing on.
@@ -209,45 +224,91 @@ First we'll go over the general flow, what each step does and then later look at
     If you see one of these failures, feel free to ask!
 
 *   Meanwhile, we'll also review your code.
-    In the top right you'll see a little **Suggested Reviewers** button so feel free to request a review with that!
     Some common review points are:
-    * This seems odd, why was this done?
-    * Could you see if you can use the functionality from place X?
-    * Could you creat a test or documentation for this?
-    * This could be a nicer way of doing this, what do you think?
+    *   This seems odd, why was this done?
+    *   Could you see if you can use the functionality from place X?
+    *   Could you create a test or documentation for this?
+    *   This could be a nicer way of doing this, what do you think?
     Occasionally there will be some major point which will require more discussion but those are more on a case-by-case basis.
 
 *   This process of review, fix and testing may go on a few times.
-    The simplest way to reduce the time needed and to help us too is to run the tests, code formatting check and doc building locall.
+    The simplest way to reduce the time needed and to help us too is to run the tests, code formatting check and doc building locally.
     If they all pass locally they will very often have no issues in the automated tests.
 
     Once everyone is happy, it's time for us to hit (*squash*) merge, get it into the development branch and have one more contribution to autosklearn!
 
-## Kinds of PRs
-Of course we can't cover every use case but here's some common kinds of PR's along with some pointers!
 
-#### Documentation
-Anything to contribute to better documentation is always appreciated
-#### Bug Fixes
-* TODO
-#### Features
-* TODO
+
+# Pull Request Overview
+* Create a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of the [automl/auto-sklearn](https://github.com/automl/auto-sklearn) git repo
+* Clone your own fork and create a new branch from the branch to work on
+    ```bash
+    git clone git@github.com:automl/auto-sklearn.git
+    cd auto-sklearn
+    git checkout -b my_new_branch development
+    
+    # Create a virtual environemnt and activate it so there are no package
+    # conflicts
+    python -m venv my-virtual-env
+    source my-virtual-env/bin/activate
+    
+    pip install -e .[test,docs,examples] # zsh users need quotes ".[test,...]"
+    
+    # Edit files...
+    
+    # If you changed documentation:
+    # This will generate all documentation, run examples and check links
+    cd doc
+    make linkcheck
+    
+    # ... fix any issues
+    
+    # If you edited any code
+    # Check out pytest --help if you want to only run specific tests
+    pytest
+    
+    # ... fix any issues
+    
+    # Use pre-commit for style and typing checks
+    pip install pre-commit
+    pre-commit run --all-files
+    
+    # ... fix any issues
+    
+    # Add the changes
+    git add {changed files}
+    git commit -m "Meaningful as you can make it message"
+    
+    # Push back to your fork
+    git push --set-upstream origin my_new_branch
+    ```
+* Go to github, go to your fork and then make a pull request using the *Contribute*
+icon.
+    * `automl/auto-sklearn` | `development` <- `your-username/auto-sklearn` | `my_new_branch`
+* Write a description of the changes, why you implemented them and any implications.
+    * Check out this [blog post](https://hugooodias.medium.com/the-anatomy-of-a-perfect-pull-request-567382bb6067) for some inspiration!
+* Once we see this, we will run some automated tests on the pull request. These
+tests are the same as the ones you can run manually and are mentioned in the
+[test](#testing) section.
+* We'll review the code and perhaps ask for some changes
+* Once we're happy with the result, we'll merge it in!
 
 # General FAQ
 
 ### I've finished my pull request or made new changes and want it reviewed, now what?
-* In the Pull request on the right there should be a tab **Reviewers** with some suggested
-reviewers, feel free to request once you think your contribution is ready.
+*   We'll actively monitor what pull requests are already in progress.
+    Once you believe you pull request to be ready or you need some feedback, feel free to comment on your pull request, tagging @eddiebergman or @mfeurer and we'll provide feedback as soon as we can!
 
 ### I've been asked to rebase my pull request, why and what do I do?
-* It can often be the case that while you were working on some changes, we may have merged something new into the development branch.
-This is a problem because the branch you created was based off the old development branch in and so there are no changes in the automl/auto-sklearn code base you don't have in your branch.
-This is not always an issue, as generally if different parts of the code were touched, they can be merged safely.
-Either way, if we ask you to [rebase](https://www.atlassian.com/git/tutorials/merging-vs-rebasing), it is because it won't merge or we think there may have been overlapping changes between what you were working on and the new code put into the development branch.
-* First, update the development branch on **your fork**
-    * The easiest way to do this is go to github.com/{your-username}/auto-sklearn navigate to the development branch and click *fetch upstream*.
-    * This will make it so your fork of auto-sklearn is now up to date
-* Second, we need to go to our clone and pull in these new changes to development
+*   It can often be the case that while you were working on some changes, we may have merged something new into the development branch.
+
+    This can be a problem because the branch you created was based off the old development branch in and so there are new changes in the automl/auto-sklearn code base you don't have in your branch.
+    This is not always an issue, as generally if different parts of the code were touched, they can be merged safely.
+    Either way, if we ask you to [rebase](https://www.atlassian.com/git/tutorials/merging-vs-rebasing), it is because it won't merge or we think there may have been overlapping changes between what you were working on and the new code put into the development branch.
+*   First, update the development branch on **your fork**
+    *   The easiest way to do this is go to github.com/{your-username}/auto-sklearn navigate to the development branch and click *fetch upstream*.
+    *   This will make it so your fork of auto-sklearn is now up to date
+*   Second, we need to go to our clone and pull in these new changes to development
     ```bash
     git checkout development
     git pull
@@ -257,7 +318,6 @@ Either way, if we ask you to [rebase](https://www.atlassian.com/git/tutorials/me
     git checkout my_new_branch
     git rebase development
     ```
-* Now if there were no conflicts, that's it, you can continue as normal. If there
-are conflicts, you'll have to sort these out which you can find out how to do
-[here](https://docs.github.com/en/get-started/using-git/resolving-merge-conflicts-after-a-git-rebase) and [here](https://docs.github.com/en/github/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line).
+*   Now if there were no conflicts, that's it, you can continue as normal.
+    If there are conflicts, you'll have to sort these out which you can find out how to do [here](https://docs.github.com/en/get-started/using-git/resolving-merge-conflicts-after-a-git-rebase) and [here](https://docs.github.com/en/github/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line).
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -115,8 +115,10 @@ Contributing
 
 We appreciate all contribution to auto-sklearn, from bug reports and
 documentation to new features. If you want to contribute to the code, you can
-pick an issue from the `issue tracker <https://github.com/automl/auto-sklearn/issues>`_
-which is marked with `Needs contributer`.
+pick an issue from the `issue tracker <https://github.com/automl/auto-sklearn/issues>`_.
+
+Check out our `contribution guide on github<https://github.com/automl/auto-sklearn/blob/master/CONTRIBUTING.md>`_ if you want to know more!
+We've catered it for both new and experienced contributers.
 
 .. note::
 
@@ -124,7 +126,3 @@ which is marked with `Needs contributer`.
     get merged, it is highly advised that you contact the developers
     by opening a `github issue <https://github
     .com/automl/auto-sklearn/issues>`_ before starting to work.
-
-When developing new features, please create a new branch from the development
-branch. When to submitting a pull request, make sure that all tests are
-still passing.


### PR DESCRIPTION
This PR introduces a Contribution Guide. Many contributors or interested contributors are not necessarily experienced enough with git or the tools in the workflow to know how to contribute. It also acts as a barrier to entry if there is no place to read it.

We also have three kinds of contributors, prior contributors, open-source contributors, beginner contributors.
For the first two, there is a quick summary of our tool chain and the steps while for beginner contributors, they have the more long-form tutorial if they like.

Ref: Issue #1205 

# Main Goals
* Unified place to link people to for questions regarding contributing.
* A 'beginner-ish' friendly introduction to our workflow, why we do what is done and a more tutorial walkthrough of the steps.
* Categorize contributions that can be made and what kind of things are needed for each in terms of testing and validation.
* FAQ in case needed, i.e. how to rebase which is needed for stale PR's   