### PR TITLE
Make train loss calculation optional

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1621,12 +1621,13 @@ class AutoML(BaseEstimator):
             endtime = pd.Timestamp(time.strftime('%Y-%m-%d %H:%M:%S',
                                                  time.localtime(run_value.endtime)))
             val_score = metric._optimum - (metric._sign * run_value.cost)
-            train_score = metric._optimum - (metric._sign * run_value.additional_info['train_loss'])
             scores = {
                 'Timestamp': endtime,
                 'single_best_optimization_score': val_score,
-                'single_best_train_score': train_score,
             }
+            if 'train_loss' in run_value.additional_info:
+                scores['single_best_train_score'] = metric._optimum - (
+                    metric._sign * run_value.additional_info['train_loss'])
             # Append test-scores, if data for test_loss are available.
             # This is the case, if X_test and y_test where provided.
             if 'test_loss' in run_value.additional_info:

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -185,7 +185,6 @@ class AutoML(BaseEstimator):
                  metric=None,
                  scoring_functions=None,
                  get_trials_callback=None,
-                 compute_train_loss=False,
                  ):
         super(AutoML, self).__init__()
         self.configuration_space = None
@@ -212,7 +211,6 @@ class AutoML(BaseEstimator):
             if resampling_strategy_arguments is not None else {}
         self._n_jobs = n_jobs
         self._dask_client = dask_client
-        self.compute_train_loss = compute_train_loss
 
         self.precision = precision
         self._disable_evaluator_output = disable_evaluator_output
@@ -439,7 +437,6 @@ class AutoML(BaseEstimator):
                                     abort_on_first_run_crash=False,
                                     cost_for_crash=get_cost_of_crash(self._metric),
                                     port=self._logger_port,
-                                    compute_train_loss=self.compute_train_loss,
                                     pynisher_context=self._multiprocessing_context,
                                     **self._resampling_strategy_arguments)
 
@@ -923,7 +920,6 @@ class AutoML(BaseEstimator):
                 pynisher_context=self._multiprocessing_context,
                 ensemble_callback=proc_ensemble,
                 trials_callback=self._get_trials_callback,
-                compute_train_loss=self.compute_train_loss,
             )
 
             try:
@@ -1315,8 +1311,6 @@ class AutoML(BaseEstimator):
             kwargs['disable_file_output'] = self._disable_evaluator_output
         if 'pynisher_context' not in kwargs:
             kwargs['pynisher_context'] = self._multiprocessing_context
-        if 'compute_train_loss' not in kwargs:
-            kwargs['compute_train_loss'] = self.compute_train_loss
         if 'stats' not in kwargs:
             scenario_mock = unittest.mock.Mock()
             scenario_mock.wallclock_limit = self._time_for_task

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1344,7 +1344,7 @@ class AutoML(BaseEstimator):
         )
 
         pipeline = None
-        if kwargs['disable_file_output'] or kwargs['resampling_strategy'] == 'test':
+        if kwargs['disable_file_output'] is True or kwargs['resampling_strategy'] == 'test':
             self._logger.warning("File output is disabled. No pipeline can returned")
         elif run_value.status == StatusType.SUCCESS:
             if kwargs['resampling_strategy'] in ('cv', 'cv-iterative-fit'):

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -184,7 +184,8 @@ class AutoML(BaseEstimator):
                  logging_config=None,
                  metric=None,
                  scoring_functions=None,
-                 get_trials_callback=None
+                 get_trials_callback=None,
+                 compute_train_loss=False,
                  ):
         super(AutoML, self).__init__()
         self.configuration_space = None
@@ -211,6 +212,7 @@ class AutoML(BaseEstimator):
             if resampling_strategy_arguments is not None else {}
         self._n_jobs = n_jobs
         self._dask_client = dask_client
+        self.compute_train_loss = compute_train_loss
 
         self.precision = precision
         self._disable_evaluator_output = disable_evaluator_output
@@ -437,6 +439,7 @@ class AutoML(BaseEstimator):
                                     abort_on_first_run_crash=False,
                                     cost_for_crash=get_cost_of_crash(self._metric),
                                     port=self._logger_port,
+                                    compute_train_loss=self.compute_train_loss,
                                     pynisher_context=self._multiprocessing_context,
                                     **self._resampling_strategy_arguments)
 
@@ -919,7 +922,8 @@ class AutoML(BaseEstimator):
                 port=self._logger_port,
                 pynisher_context=self._multiprocessing_context,
                 ensemble_callback=proc_ensemble,
-                trials_callback=self._get_trials_callback
+                trials_callback=self._get_trials_callback,
+                compute_train_loss=self.compute_train_loss,
             )
 
             try:
@@ -1311,6 +1315,8 @@ class AutoML(BaseEstimator):
             kwargs['disable_file_output'] = self._disable_evaluator_output
         if 'pynisher_context' not in kwargs:
             kwargs['pynisher_context'] = self._multiprocessing_context
+        if 'compute_train_loss' not in kwargs:
+            kwargs['compute_train_loss'] = self.compute_train_loss
         if 'stats' not in kwargs:
             scenario_mock = unittest.mock.Mock()
             scenario_mock.wallclock_limit = self._time_for_task

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -219,7 +219,10 @@ class AutoML(BaseEstimator):
             raise ValueError('disable_evaluator_output must be of type bool '
                              'or list.')
         if isinstance(self._disable_evaluator_output, list):
-            allowed_elements = ['model', 'cv_model', 'y_optimization', 'y_test', 'y_valid']
+            allowed_elements = [
+                'model', 'cv_model', 'y_optimization',
+                'y_test', 'y_valid', 'training_predictions',
+            ]
             for element in self._disable_evaluator_output:
                 if element not in allowed_elements:
                     raise ValueError("List member '%s' for argument "

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -42,7 +42,7 @@ class AutoSklearnEstimator(BaseEstimator):
         delete_tmp_folder_after_terminate=True,
         n_jobs: Optional[int] = None,
         dask_client: Optional[dask.distributed.Client] = None,
-        disable_evaluator_output=False,
+        disable_evaluator_output=['training_predictions'],
         get_smac_object_callback=None,
         smac_scenario_args=None,
         logging_config=None,
@@ -51,7 +51,6 @@ class AutoSklearnEstimator(BaseEstimator):
         scoring_functions: Optional[List[Scorer]] = None,
         load_models: bool = True,
         get_trials_callback=None,
-        compute_train_loss: bool = False,
     ):
         """
         Parameters
@@ -184,6 +183,10 @@ class AutoSklearnEstimator(BaseEstimator):
               optimization/validation set, which would later on be used to build
               an ensemble.
             * ``'model'`` : do not save any model files
+            * ``'training_predictions'`` : Do not calculate nor save train loss while evaluating
+              pipeline configurations. Train loss is useful to understand how each pipeline overfits
+              the train data. However, calculating this loss can incurr in resource overhead, which
+              might be demanding for big datasets (especially when using Cross-validation).
 
         smac_scenario_args : dict, optional (None)
             Additional arguments inserted into the scenario of SMAC. See the
@@ -225,10 +228,6 @@ class AutoSklearnEstimator(BaseEstimator):
             `smac.callbacks <https://automl.github.io/SMAC3/master/apidoc/smac.callbacks.html>`_.
             This is an advanced feature. Use only if you are familiar with
             `SMAC <https://automl.github.io/SMAC3/master/index.html>`_.
-
-        compute_train_loss: bool (False)
-            Computes the train loss for every pipeline explored and registers the result in
-            the RunHistory from SMAC.
 
         Attributes
         ----------
@@ -274,7 +273,6 @@ class AutoSklearnEstimator(BaseEstimator):
         self.scoring_functions = scoring_functions
         self.load_models = load_models
         self.get_trials_callback = get_trials_callback
-        self.compute_train_loss = compute_train_loss
 
         self.automl_ = None  # type: Optional[AutoML]
 
@@ -321,7 +319,6 @@ class AutoSklearnEstimator(BaseEstimator):
             metric=self.metric,
             scoring_functions=self.scoring_functions,
             get_trials_callback=self.get_trials_callback,
-            compute_train_loss=self.compute_train_loss,
         )
 
         return automl

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -50,7 +50,8 @@ class AutoSklearnEstimator(BaseEstimator):
         metric=None,
         scoring_functions: Optional[List[Scorer]] = None,
         load_models: bool = True,
-        get_trials_callback=None
+        get_trials_callback=None,
+        compute_train_loss: bool = False,
     ):
         """
         Parameters
@@ -103,7 +104,7 @@ class AutoSklearnEstimator(BaseEstimator):
 
         include : dict, optional (None)
             If None, all possible algorithms are used. Otherwise specifies
-            set of algorithms for each added component is used. Include and 
+            set of algorithms for each added component is used. Include and
             exclude are incompatible if used together on the same component
 
         exclude : dict, optional (None)
@@ -218,12 +219,16 @@ class AutoSklearnEstimator(BaseEstimator):
 
         load_models : bool, optional (True)
             Whether to load the models after fitting Auto-sklearn.
-           
+
         get_trials_callback: callable
             Callback function to create an object of subclass defined in module
             `smac.callbacks <https://automl.github.io/SMAC3/master/apidoc/smac.callbacks.html>`_.
             This is an advanced feature. Use only if you are familiar with
             `SMAC <https://automl.github.io/SMAC3/master/index.html>`_.
+
+        compute_train_loss: bool (False)
+            Computes the train loss for every pipeline explored and registers the result in
+            the RunHistory from SMAC.
 
         Attributes
         ----------
@@ -269,6 +274,7 @@ class AutoSklearnEstimator(BaseEstimator):
         self.scoring_functions = scoring_functions
         self.load_models = load_models
         self.get_trials_callback = get_trials_callback
+        self.compute_train_loss = compute_train_loss
 
         self.automl_ = None  # type: Optional[AutoML]
 
@@ -314,7 +320,8 @@ class AutoSklearnEstimator(BaseEstimator):
             metadata_directory=self.metadata_directory,
             metric=self.metric,
             scoring_functions=self.scoring_functions,
-            get_trials_callback=self.get_trials_callback
+            get_trials_callback=self.get_trials_callback,
+            compute_train_loss=self.compute_train_loss,
         )
 
         return automl

--- a/autosklearn/evaluation/__init__.py
+++ b/autosklearn/evaluation/__init__.py
@@ -130,7 +130,6 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
         init_params: Optional[Dict[str, Any]] = None,
         budget_type: Optional[str] = None,
         ta: Optional[Callable] = None,
-        compute_train_loss: bool = False,
         **resampling_strategy_args: Any,
     ):
 
@@ -187,7 +186,6 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
         self.disable_file_output = disable_file_output
         self.init_params = init_params
         self.budget_type = budget_type
-        self.compute_train_loss = compute_train_loss
 
         if memory_limit is not None:
             memory_limit = int(math.ceil(memory_limit))
@@ -338,7 +336,6 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
             init_params=init_params,
             budget=budget,
             budget_type=self.budget_type,
-            compute_train_loss=self.compute_train_loss,
         )
 
         if self.resampling_strategy != 'test':
@@ -460,9 +457,14 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
                 additional_run_info['learning_curve'] = learning_curve
                 additional_run_info['learning_curve_runtime'] = learning_curve_runtime
 
-            train_learning_curve = autosklearn.evaluation.util.extract_learning_curve(
-                info, 'train_loss'
-            ) if self.compute_train_loss else []
+            train_learning_curve: List[float] = []
+            if isinstance(
+                self.disable_file_output, list
+            ) and 'training_predictions' not in self.disable_file_output:
+                train_learning_curve = autosklearn.evaluation.util.extract_learning_curve(
+                    info, 'train_loss'
+                )
+
             if len(train_learning_curve) > 1:
                 additional_run_info['train_learning_curve'] = train_learning_curve
                 additional_run_info['learning_curve_runtime'] = learning_curve_runtime

--- a/autosklearn/evaluation/__init__.py
+++ b/autosklearn/evaluation/__init__.py
@@ -130,6 +130,7 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
         init_params: Optional[Dict[str, Any]] = None,
         budget_type: Optional[str] = None,
         ta: Optional[Callable] = None,
+        compute_train_loss: bool = False,
         **resampling_strategy_args: Any,
     ):
 
@@ -186,6 +187,7 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
         self.disable_file_output = disable_file_output
         self.init_params = init_params
         self.budget_type = budget_type
+        self.compute_train_loss = compute_train_loss
 
         if memory_limit is not None:
             memory_limit = int(math.ceil(memory_limit))
@@ -336,6 +338,7 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
             init_params=init_params,
             budget=budget,
             budget_type=self.budget_type,
+            compute_train_loss=self.compute_train_loss,
         )
 
         if self.resampling_strategy != 'test':
@@ -459,7 +462,7 @@ class ExecuteTaFuncWithQueue(AbstractTAFunc):
 
             train_learning_curve = autosklearn.evaluation.util.extract_learning_curve(
                 info, 'train_loss'
-            )
+            ) if self.compute_train_loss else []
             if len(train_learning_curve) > 1:
                 additional_run_info['train_learning_curve'] = train_learning_curve
                 additional_run_info['learning_curve_runtime'] = learning_curve_runtime

--- a/autosklearn/evaluation/abstract_evaluator.py
+++ b/autosklearn/evaluation/abstract_evaluator.py
@@ -263,7 +263,6 @@ class AbstractEvaluator(object):
             )
 
         self.Y_optimization: Optional[Union[List, np.ndarray]] = None
-        self.Y_actual_train = None
 
         self.budget = budget
         self.budget_type = budget_type

--- a/autosklearn/evaluation/test_evaluator.py
+++ b/autosklearn/evaluation/test_evaluator.py
@@ -123,6 +123,7 @@ def eval_t(
     init_params: Optional[Dict[str, Any]] = None,
     budget: Optional[float] = None,
     budget_type: Optional[str] = None,
+    compute_train_loss: bool = False,
 ) -> None:
     evaluator = TestEvaluator(configuration=config,
                               backend=backend, metric=metric, seed=seed,

--- a/autosklearn/evaluation/test_evaluator.py
+++ b/autosklearn/evaluation/test_evaluator.py
@@ -123,7 +123,6 @@ def eval_t(
     init_params: Optional[Dict[str, Any]] = None,
     budget: Optional[float] = None,
     budget_type: Optional[str] = None,
-    compute_train_loss: bool = False,
 ) -> None:
     evaluator = TestEvaluator(configuration=config,
                               backend=backend, metric=metric, seed=seed,

--- a/autosklearn/evaluation/train_evaluator.py
+++ b/autosklearn/evaluation/train_evaluator.py
@@ -176,7 +176,6 @@ class TrainEvaluator(AbstractEvaluator):
         exclude: Optional[List[str]] = None,
         disable_file_output: bool = False,
         init_params: Optional[Dict[str, Any]] = None,
-        compute_train_loss: bool = False,
     ):
 
         super().__init__(
@@ -214,7 +213,11 @@ class TrainEvaluator(AbstractEvaluator):
         self.indices: List[Optional[Tuple[List[int], List[int]]]] = [None] * self.num_cv_folds
 
         # Compute train performances only if needed
-        self.compute_train_loss = compute_train_loss
+        self.compute_train_loss = True
+        if isinstance(
+            self.disable_file_output, list
+        ) and 'training_predictions' in self.disable_file_output:
+            self.compute_train_loss = False
 
         # Necessary for full CV. Makes full CV not write predictions if only
         # a subset of folds is evaluated but time is up. Complicated, because
@@ -1164,7 +1167,6 @@ def eval_holdout(
     budget: Optional[float] = 100.0,
     budget_type: Optional[str] = None,
     iterative: bool = False,
-    compute_train_loss: bool = False,
 ) -> None:
     evaluator = TrainEvaluator(
         backend=backend,
@@ -1184,7 +1186,6 @@ def eval_holdout(
         init_params=init_params,
         budget=budget,
         budget_type=budget_type,
-        compute_train_loss=compute_train_loss,
     )
     evaluator.fit_predict_and_loss(iterative=iterative)
 
@@ -1208,7 +1209,6 @@ def eval_iterative_holdout(
     init_params: Optional[Dict[str, Any]] = None,
     budget: Optional[float] = 100.0,
     budget_type: Optional[str] = None,
-    compute_train_loss: bool = False,
 ) -> None:
     return eval_holdout(
         queue=queue,
@@ -1230,7 +1230,6 @@ def eval_iterative_holdout(
         init_params=init_params,
         budget=budget,
         budget_type=budget_type,
-        compute_train_loss=compute_train_loss,
     )
 
 
@@ -1254,7 +1253,6 @@ def eval_partial_cv(
     budget: Optional[float] = None,
     budget_type: Optional[str] = None,
     iterative: bool = False,
-    compute_train_loss: bool = False,
 ) -> None:
     if budget_type is not None:
         raise NotImplementedError()
@@ -1279,7 +1277,6 @@ def eval_partial_cv(
         init_params=init_params,
         budget=budget,
         budget_type=budget_type,
-        compute_train_loss=compute_train_loss,
     )
 
     evaluator.partial_fit_predict_and_loss(fold=fold, iterative=iterative)
@@ -1304,7 +1301,6 @@ def eval_partial_cv_iterative(
     init_params: Optional[Dict[str, Any]] = None,
     budget: Optional[float] = None,
     budget_type: Optional[str] = None,
-    compute_train_loss: bool = False,
 ) -> None:
     if budget_type is not None:
         raise NotImplementedError()
@@ -1326,7 +1322,6 @@ def eval_partial_cv_iterative(
         disable_file_output=disable_file_output,
         iterative=True,
         init_params=init_params,
-        compute_train_loss=compute_train_loss,
     )
 
 
@@ -1351,7 +1346,6 @@ def eval_cv(
     budget: Optional[float] = None,
     budget_type: Optional[str] = None,
     iterative: bool = False,
-    compute_train_loss: bool = False,
 ) -> None:
     evaluator = TrainEvaluator(
         backend=backend,
@@ -1371,7 +1365,6 @@ def eval_cv(
         init_params=init_params,
         budget=budget,
         budget_type=budget_type,
-        compute_train_loss=compute_train_loss,
     )
 
     evaluator.fit_predict_and_loss(iterative=iterative)
@@ -1397,7 +1390,6 @@ def eval_iterative_cv(
     budget: Optional[float] = None,
     budget_type: Optional[str] = None,
     iterative: bool = True,
-    compute_train_loss: bool = False,
 ) -> None:
     eval_cv(
         backend=backend,
@@ -1419,5 +1411,4 @@ def eval_iterative_cv(
         budget_type=budget_type,
         iterative=iterative,
         instance=instance,
-        compute_train_loss=compute_train_loss,
     )

--- a/autosklearn/experimental/askl2.py
+++ b/autosklearn/experimental/askl2.py
@@ -192,13 +192,12 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
         delete_tmp_folder_after_terminate: bool = True,
         n_jobs: Optional[int] = None,
         dask_client: Optional[dask.distributed.Client] = None,
-        disable_evaluator_output: bool = False,
+        disable_evaluator_output=['training_predictions'],
         smac_scenario_args: Optional[Dict[str, Any]] = None,
         logging_config: Optional[Dict[str, Any]] = None,
         metric: Optional[Scorer] = None,
         scoring_functions: Optional[List[Scorer]] = None,
         load_models: bool = True,
-        compute_train_loss: bool = False,
     ):
 
         """
@@ -277,6 +276,10 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
               optimization/validation set, which would later on be used to build
               an ensemble.
             * ``'model'`` : do not save any model files
+            * ``'training_predictions'`` : Do not calculate nor save train loss while evaluating
+              pipeline configurations. Train loss is useful to understand how each pipeline overfits
+              the train data. However, calculating this loss can incurr in resource overhead, which
+              might be demanding for big datasets (especially when using Cross-validation).
 
         smac_scenario_args : dict, optional (None)
             Additional arguments inserted into the scenario of SMAC. See the
@@ -303,9 +306,6 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
         load_models : bool, optional (True)
             Whether to load the models after fitting Auto-sklearn.
 
-        compute_train_loss: bool (False)
-            Computes the train loss for every pipeline explored and registers the result in
-            the RunHistory from SMAC.
 
         Attributes
         ----------
@@ -349,7 +349,6 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
             metric=metric,
             scoring_functions=scoring_functions,
             load_models=load_models,
-            compute_train_loss=compute_train_loss,
         )
 
     def fit(self, X, y,

--- a/autosklearn/experimental/askl2.py
+++ b/autosklearn/experimental/askl2.py
@@ -198,6 +198,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
         metric: Optional[Scorer] = None,
         scoring_functions: Optional[List[Scorer]] = None,
         load_models: bool = True,
+        compute_train_loss: bool = False,
     ):
 
         """
@@ -302,6 +303,10 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
         load_models : bool, optional (True)
             Whether to load the models after fitting Auto-sklearn.
 
+        compute_train_loss: bool (False)
+            Computes the train loss for every pipeline explored and registers the result in
+            the RunHistory from SMAC.
+
         Attributes
         ----------
 
@@ -344,6 +349,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
             metric=metric,
             scoring_functions=scoring_functions,
             load_models=load_models,
+            compute_train_loss=compute_train_loss,
         )
 
     def fit(self, X, y,

--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -239,7 +239,8 @@ class AutoMLSMBO(object):
                  scoring_functions=None,
                  pynisher_context='spawn',
                  ensemble_callback: typing.Optional[EnsembleBuilderManager] = None,
-                 trials_callback: typing.Optional[IncorporateRunResultCallback] = None
+                 trials_callback: typing.Optional[IncorporateRunResultCallback] = None,
+                 compute_train_loss: bool = False,
                  ):
         super(AutoMLSMBO, self).__init__()
         # data related
@@ -249,6 +250,7 @@ class AutoMLSMBO(object):
         self.task = None
         self.backend = backend
         self.port = port
+        self.compute_train_loss = compute_train_loss
 
         # the configuration space
         self.config_space = config_space
@@ -426,6 +428,7 @@ class AutoMLSMBO(object):
             disable_file_output=self.disable_file_output,
             scoring_functions=self.scoring_functions,
             port=self.port,
+            compute_train_loss=self.compute_train_loss,
             pynisher_context=self.pynisher_context,
             **self.resampling_strategy_args
         )

--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -240,7 +240,6 @@ class AutoMLSMBO(object):
                  pynisher_context='spawn',
                  ensemble_callback: typing.Optional[EnsembleBuilderManager] = None,
                  trials_callback: typing.Optional[IncorporateRunResultCallback] = None,
-                 compute_train_loss: bool = False,
                  ):
         super(AutoMLSMBO, self).__init__()
         # data related
@@ -250,7 +249,6 @@ class AutoMLSMBO(object):
         self.task = None
         self.backend = backend
         self.port = port
-        self.compute_train_loss = compute_train_loss
 
         # the configuration space
         self.config_space = config_space
@@ -428,7 +426,6 @@ class AutoMLSMBO(object):
             disable_file_output=self.disable_file_output,
             scoring_functions=self.scoring_functions,
             port=self.port,
-            compute_train_loss=self.compute_train_loss,
             pynisher_context=self.pynisher_context,
             **self.resampling_strategy_args
         )

--- a/examples/40_advanced/example_get_pipeline_components.py
+++ b/examples/40_advanced/example_get_pipeline_components.py
@@ -35,6 +35,12 @@ X_train, X_test, y_train, y_test = \
 automl = autosklearn.classification.AutoSklearnClassifier(
     time_left_for_this_task=30,
     per_run_time_limit=10,
+    # By default, auto-sklearn does not calculate the train performance
+    # of each pipeline. In other words, by default
+    # disable_evaluator_output=['training_predictions']
+    # We can set the following argument to False or as an empty list
+    # to instruct auto-sklearn to additionally compute the train loss for each pipeline
+    # and report it on the RunHistory of SMAC.
     disable_evaluator_output=False,
     # To simplify querying the models in the final ensemble, we
     # restrict auto-sklearn to use only pca as a preprocessor

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -271,6 +271,7 @@ def test_performance_over_time_no_ensemble(tmp_dir):
                                 tmp_folder=tmp_dir,
                                 seed=1,
                                 initial_configurations_via_metalearning=0,
+                                disable_evaluator_output=False,
                                 ensemble_size=0,)
     cls.fit(X_train, Y_train, X_test, Y_test)
 
@@ -612,6 +613,7 @@ def test_binary(tmp_dir, dask_client):
         'iris', make_binary=True)
     automl = AutoSklearnClassifier(time_left_for_this_task=40,
                                    delete_tmp_folder_after_terminate=False,
+                                   disable_evaluator_output=False,
                                    per_run_time_limit=10,
                                    tmp_folder=tmp_dir,
                                    dask_client=dask_client,

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -77,6 +77,7 @@ def test_fit_n_jobs(tmp_dir):
                  'feature_preprocessor': ['no_preprocessing']},
         get_smac_object_callback=get_smac_object_wrapper_instance,
         max_models_on_disc=None,
+        disable_file_output=False,
     )
     automl.fit(X_train, Y_train)
 
@@ -704,6 +705,7 @@ def test_cv_regression(tmp_dir, dask_client):
                                   resampling_strategy='cv',
                                   tmp_folder=tmp_dir,
                                   dask_client=dask_client,
+                                  disable_file_output=False,
                                   )
 
     automl.fit(X_train, Y_train)
@@ -732,6 +734,7 @@ def test_regression_pandas_support(tmp_dir, dask_client):
         per_run_time_limit=5,
         dask_client=dask_client,
         tmp_folder=tmp_dir,
+        disable_file_output=False,
     )
 
     # Make sure we error out because y is not encoded

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -77,7 +77,7 @@ def test_fit_n_jobs(tmp_dir):
                  'feature_preprocessor': ['no_preprocessing']},
         get_smac_object_callback=get_smac_object_wrapper_instance,
         max_models_on_disc=None,
-        disable_file_output=False,
+        disable_evaluator_output=False,
     )
     automl.fit(X_train, Y_train)
 
@@ -539,6 +539,7 @@ def test_can_pickle_classifier(tmp_dir, dask_client):
                                    per_run_time_limit=5,
                                    tmp_folder=tmp_dir,
                                    dask_client=dask_client,
+                                   disable_evaluator_output=False,
                                    )
     automl.fit(X_train, Y_train)
 
@@ -587,6 +588,7 @@ def test_multilabel(tmp_dir, dask_client):
                                    per_run_time_limit=5,
                                    tmp_folder=tmp_dir,
                                    dask_client=dask_client,
+                                   disable_evaluator_output=False,
                                    )
 
     automl.fit(X_train, Y_train)
@@ -649,6 +651,7 @@ def test_classification_pandas_support(tmp_dir, dask_client):
         dask_client=dask_client,
         seed=5,
         tmp_folder=tmp_dir,
+        disable_evaluator_output=False,
     )
 
     automl.fit(X, y)
@@ -676,6 +679,7 @@ def test_regression(tmp_dir, dask_client):
                                   per_run_time_limit=5,
                                   tmp_folder=tmp_dir,
                                   dask_client=dask_client,
+                                  disable_evaluator_output=False,
                                   )
 
     automl.fit(X_train, Y_train)
@@ -705,7 +709,7 @@ def test_cv_regression(tmp_dir, dask_client):
                                   resampling_strategy='cv',
                                   tmp_folder=tmp_dir,
                                   dask_client=dask_client,
-                                  disable_file_output=False,
+                                  disable_evaluator_output=False,
                                   )
 
     automl.fit(X_train, Y_train)
@@ -734,7 +738,7 @@ def test_regression_pandas_support(tmp_dir, dask_client):
         per_run_time_limit=5,
         dask_client=dask_client,
         tmp_folder=tmp_dir,
-        disable_file_output=False,
+        disable_evaluator_output=False,
     )
 
     # Make sure we error out because y is not encoded

--- a/test/test_evaluation/test_train_evaluator.py
+++ b/test/test_evaluation/test_train_evaluator.py
@@ -104,6 +104,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
                                    output_y_hat_optimization=True,
                                    metric=accuracy,
                                    port=self.port,
+                                   compute_train_loss=True,
                                    )
         evaluator.file_output = unittest.mock.Mock(spec=evaluator.file_output)
         evaluator.file_output.return_value = (None, {})
@@ -170,6 +171,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
                                    scoring_functions=None,
                                    output_y_hat_optimization=True,
                                    metric=accuracy,
+                                   compute_train_loss=True,
                                    budget=0.0)
         evaluator.file_output = unittest.mock.Mock(spec=evaluator.file_output)
         evaluator.file_output.return_value = (None, {})
@@ -268,6 +270,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
                                    scoring_functions=None,
                                    output_y_hat_optimization=True,
                                    metric=accuracy,
+                                   compute_train_loss=True,
                                    budget=0.0)
         evaluator.file_output = unittest.mock.Mock(spec=evaluator.file_output)
         evaluator.file_output.return_value = (None, {})
@@ -337,6 +340,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
                                    resampling_strategy='holdout-iterative-fit',
                                    scoring_functions=None,
                                    output_y_hat_optimization=True,
+                                   compute_train_loss=True,
                                    metric=accuracy)
         evaluator.file_output = unittest.mock.Mock(spec=evaluator.file_output)
         evaluator.file_output.return_value = (None, {})
@@ -379,6 +383,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
                                    resampling_strategy='cv',
                                    resampling_strategy_args={'folds': 5},
                                    scoring_functions=None,
+                                   compute_train_loss=True,
                                    output_y_hat_optimization=True,
                                    metric=accuracy)
         evaluator.file_output = unittest.mock.Mock(spec=evaluator.file_output)
@@ -434,6 +439,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
                                    resampling_strategy_args={'folds': 5},
                                    scoring_functions=None,
                                    output_y_hat_optimization=True,
+                                   compute_train_loss=True,
                                    metric=accuracy)
 
         evaluator.file_output = unittest.mock.Mock(spec=evaluator.file_output)
@@ -495,6 +501,7 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
                                    scoring_functions=None,
                                    output_y_hat_optimization=True,
                                    metric=accuracy,
+                                   compute_train_loss=True,
                                    budget=0.0)
         evaluator.file_output = unittest.mock.Mock(spec=evaluator.file_output)
         evaluator.file_output.return_value = (None, {})
@@ -787,7 +794,6 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         evaluator.model = unittest.mock.Mock()
         evaluator.model.estimator_supports_iterative_fit.return_value = False
         evaluator.Y_targets[0] = np.array([1] * 23)
-        evaluator.Y_train_targets = np.array([1] * 69)
         rval = evaluator.fit_predict_and_loss(iterative=False)
         self.assertIsNone(rval)
         element = queue_.get()
@@ -831,7 +837,6 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         evaluator.file_output.return_value = (None, {})
         evaluator.Y_targets[0] = np.array([1] * 35)
         evaluator.Y_targets[1] = np.array([1] * 34)
-        evaluator.Y_train_targets = np.array([1] * 69)
 
         self.assertRaisesRegex(
             TAEAbortException,
@@ -883,7 +888,6 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         evaluator.file_output = unittest.mock.Mock(spec=evaluator.file_output)
         evaluator.file_output.return_value = (None, {})
         evaluator.Y_targets[0] = np.array([1] * 23).reshape((-1, 1))
-        evaluator.Y_train_targets = np.array([1] * 69).reshape((-1, 1))
         rval = evaluator.fit_predict_and_loss(iterative=True)
         self.assertIsNone(rval)
         self.assertEqual(finish_up_mock.call_count, 1)
@@ -921,7 +925,6 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         evaluator.file_output.return_value = (None, {})
 
         evaluator.Y_targets[0] = np.array([1] * 23).reshape((-1, 1))
-        evaluator.Y_train_targets = np.array([1] * 69).reshape((-1, 1))
         rval = evaluator.fit_predict_and_loss(iterative=True)
         self.assertIsNone(rval)
         self.assertEqual(finish_up_mock.call_count, 1)
@@ -971,7 +974,6 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         evaluator.file_output.return_value = (None, {})
 
         evaluator.Y_targets[0] = np.array([1] * 23).reshape((-1, 1))
-        evaluator.Y_train_targets = np.array([1] * 69).reshape((-1, 1))
         rval = evaluator.fit_predict_and_loss(iterative=False)
         self.assertIsNone(rval)
         self.assertEqual(finish_up_mock.call_count, 1)
@@ -1011,7 +1013,6 @@ class TestTrainEvaluator(BaseEvaluatorTest, unittest.TestCase):
         evaluator.file_output.return_value = (None, {})
 
         evaluator.Y_targets[0] = np.array([1] * 23).reshape((-1, 1))
-        evaluator.Y_train_targets = np.array([1] * 69).reshape((-1, 1))
         rval = evaluator.fit_predict_and_loss(iterative=False)
         self.assertIsNone(rval)
         self.assertEqual(finish_up_mock.call_count, 1)
@@ -2272,6 +2273,7 @@ class FunctionsTest(unittest.TestCase):
             disable_file_output=False,
             instance=self.dataset_name,
             metric=accuracy,
+            compute_train_loss=True,
         )
         rval = read_queue(self.queue)
         self.assertEqual(len(rval), 1)
@@ -2509,6 +2511,7 @@ class FunctionsTest(unittest.TestCase):
             disable_file_output=False,
             instance=self.dataset_name,
             metric=accuracy,
+            compute_train_loss=True,
         )
         rval = read_queue(self.queue)
         self.assertEqual(len(rval), 1)


### PR DESCRIPTION
**What?**
Don't calculate the training loss unless required -- this helps with memory consumption in Auto-sklearn

 **Details**
 I found no strong reason to keep Y_actual_train -- maybe this is legacy.
Y_train_targets/Y_train_pred[*] variable (don't confuse with self.Y_train_targets) was unnecessarily created. Maybe it makes sense to enable a more strict mypy :).