### PR TITLE
Makes linkcheck not build the examples

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -167,7 +167,7 @@ changes:
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	$(SPHINXBUILD) -D plot_gallery=0 -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."


### PR DESCRIPTION
Linkcheck was causing the examples to be built again but that is already done in the [`doc.yaml`](https://github.com/automl/auto-sklearn/blob/master/.github/workflows/docs.yml) workflow with `make html`. 

* Makes the linkcheck not run the examples when done locally
* Should half the time for docs to build in the workflow. 