### PR TITLE
Fixes sources of indeterminism for tests and `Pipeline` steps

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -32,6 +32,7 @@ from smac.stats.stats import Stats
 import joblib
 import sklearn.utils
 from scipy.sparse import spmatrix
+from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_is_fitted
 from sklearn.metrics._classification import type_of_target
 from sklearn.dummy import DummyClassifier, DummyRegressor
@@ -1165,7 +1166,7 @@ class AutoML(BaseEstimator):
         if self.ensemble_ is None:
             raise ValueError("Refit can only be called if 'ensemble_size != 0'")
 
-        random_state = np.random.RandomState(self._seed)
+        random_state = check_random_state(self._seed)
         for identifier in self.models_:
             model = self.models_[identifier]
             # this updates the model inplace, it can then later be used in

--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -1,8 +1,9 @@
 import random
 from collections import Counter
-from typing import Any, Dict, List, Tuple, Union, Optional, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
+
 from sklearn.utils import check_random_state
 
 from autosklearn.constants import TASK_TYPES

--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -57,7 +57,7 @@ class EnsembleSelection(AbstractEnsemble):
         #   int - Deteriministic with succesive calls to fit
         #   RandomState - Successive calls to fit will produce differences
         #   None - Uses numpmys global singleton RandomState
-        # https://scikit-learn.org/0.24/common_pitfalls.html#controlling-randomness
+        # https://scikit-learn.org/stable/common_pitfalls.html#controlling-randomness
         self.random_state = random_state
 
     def __getstate__(self) -> Dict[str, Any]:

--- a/autosklearn/ensembles/ensemble_selection.py
+++ b/autosklearn/ensembles/ensemble_selection.py
@@ -1,8 +1,9 @@
 import random
 from collections import Counter
-from typing import Any, Dict, List, Tuple, Union, cast
+from typing import Any, Dict, List, Tuple, Union, Optional, cast
 
 import numpy as np
+from sklearn.utils import check_random_state
 
 from autosklearn.constants import TASK_TYPES
 from autosklearn.ensembles.abstract_ensemble import AbstractEnsemble
@@ -16,15 +17,46 @@ class EnsembleSelection(AbstractEnsemble):
         ensemble_size: int,
         task_type: int,
         metric: Scorer,
-        random_state: np.random.RandomState,
         bagging: bool = False,
         mode: str = 'fast',
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
     ) -> None:
+        """ An ensemble of selected algorithms
+
+        Fitting an EnsembleSelection generates an ensemble from the the models
+        generated during the search process. Can be further used for prediction.
+
+        Parameters
+        ----------
+        task_type: int
+            An identifier indicating which task is being performed.
+        metric: Scorer
+            The metric used to evaluate the models
+        bagging: bool = False
+            Whether to use bagging in ensemble selection
+        mode: str in ['fast', 'slow'] = 'fast'
+            Which kind of ensemble generation to use
+            *   'slow' - The original method used in Rich Caruana's ensemble selection.
+            *   'fast' - A faster version of Rich Caruanas' ensemble selection.
+
+        random_state: Optional[int | RandomState] = None
+            The random_state used for ensemble selection.
+            *   None - Uses numpy's default RandomState object
+            *   int - Successive calls to fit will produce the same results
+            *   RandomState - Truely random, each call to fit will produce
+                              different results, even with the same object.
+        """
         self.ensemble_size = ensemble_size
         self.task_type = task_type
         self.metric = metric
         self.bagging = bagging
         self.mode = mode
+
+        # Behaviour similar to sklearn
+        #   int - Deteriministic with succesive calls to fit
+        #   RandomState - Successive calls to fit will produce differences
+        #   None - Uses numpmys global singleton RandomState
+        # https://scikit-learn.org/0.24/common_pitfalls.html#controlling-randomness
         self.random_state = random_state
 
     def __getstate__(self) -> Dict[str, Any]:
@@ -84,6 +116,7 @@ class EnsembleSelection(AbstractEnsemble):
     ) -> None:
         """Fast version of Rich Caruana's ensemble selection method."""
         self.num_input_models_ = len(predictions)
+        rand = check_random_state(self.random_state)
 
         ensemble = []  # type: List[np.ndarray]
         trajectory = []
@@ -143,7 +176,9 @@ class EnsembleSelection(AbstractEnsemble):
                 )
 
             all_best = np.argwhere(losses == np.nanmin(losses)).flatten()
-            best = self.random_state.choice(all_best)
+
+            best = rand.choice(all_best)
+
             ensemble.append(predictions[best])
             trajectory.append(losses[best])
             order.append(best)

--- a/autosklearn/evaluation/abstract_evaluator.py
+++ b/autosklearn/evaluation/abstract_evaluator.py
@@ -46,7 +46,7 @@ class MyDummyClassifier(DummyClassifier):
     def __init__(
         self,
         config: Configuration,
-        random_state: np.random.RandomState,
+        random_state: Optional[Union[int, np.random.RandomState]],
         init_params: Optional[Dict[str, Any]] = None,
         dataset_properties: Dict[str, Any] = {},
         include: Optional[List[str]] = None,
@@ -102,7 +102,7 @@ class MyDummyRegressor(DummyRegressor):
     def __init__(
         self,
         config: Configuration,
-        random_state: np.random.RandomState,
+        random_state: Optional[Union[int, np.random.RandomState]],
         init_params: Optional[Dict[str, Any]] = None,
         dataset_properties: Dict[str, Any] = {},
         include: Optional[List[str]] = None,

--- a/autosklearn/metalearning/metafeatures/metafeatures.py
+++ b/autosklearn/metalearning/metafeatures/metafeatures.py
@@ -1106,9 +1106,11 @@ def calculate_all_metafeatures(X, y, categorical, dataset_name, logger,
                 X_transformed = check_array(X_transformed,
                                             force_all_finite=True,
                                             accept_sparse='csr')
-                rs = np.random.RandomState(42)
                 indices = np.arange(X_transformed.shape[0])
+
+                rs = np.random.RandomState(42)
                 rs.shuffle(indices)
+
                 # TODO Shuffle inplace
                 X_transformed = X_transformed[indices]
                 y_transformed = y[indices]

--- a/autosklearn/pipeline/base.py
+++ b/autosklearn/pipeline/base.py
@@ -8,7 +8,6 @@ import numpy as np
 import scipy.sparse
 
 from sklearn.pipeline import Pipeline
-from sklearn.utils.validation import check_random_state
 
 from .components.base import AutoSklearnChoice, AutoSklearnComponent
 import autosklearn.pipeline.create_searchspace_util
@@ -43,6 +42,7 @@ class BasePipeline(Pipeline):
         self.exclude = exclude if exclude is not None else {}
         self.dataset_properties = dataset_properties if \
             dataset_properties is not None else {}
+        self.random_state = random_state
 
         if steps is None:
             self.steps = self._get_pipeline_steps(dataset_properties=dataset_properties)
@@ -73,10 +73,6 @@ class BasePipeline(Pipeline):
 
         self.set_hyperparameters(self.config, init_params=init_params)
 
-        if random_state is None:
-            self.random_state = check_random_state(1)
-        else:
-            self.random_state = check_random_state(random_state)
         super().__init__(steps=self.steps)
 
         self._additional_run_info = {}

--- a/autosklearn/pipeline/classification.py
+++ b/autosklearn/pipeline/classification.py
@@ -308,7 +308,7 @@ class SimpleClassificationPipeline(BasePipeline, ClassifierMixin):
                     random_state=self.random_state)
             ],
             [
-                "balancing", Balancing()
+                "balancing", Balancing(random_state=self.random_state)
             ],
             [
                 "feature_preprocessor", FeaturePreprocessorChoice(

--- a/autosklearn/pipeline/classification.py
+++ b/autosklearn/pipeline/classification.py
@@ -1,26 +1,25 @@
 import copy
 from itertools import product
+from typing import Optional, Union
 
 import numpy as np
 
 from sklearn.base import ClassifierMixin
 
-from ConfigSpace.configuration_space import ConfigurationSpace
+from ConfigSpace.configuration_space import ConfigurationSpace, Configuration
 from ConfigSpace.forbidden import ForbiddenEqualsClause, ForbiddenAndConjunction
 
 from autosklearn.pipeline.components.data_preprocessing import DataPreprocessorChoice
 
-from autosklearn.pipeline.components import classification as \
-    classification_components
+from autosklearn.pipeline.components.classification import ClassifierChoice
 from autosklearn.pipeline.components.data_preprocessing.balancing.balancing import \
     Balancing
-from autosklearn.pipeline.components import feature_preprocessing as \
-    feature_preprocessing_components
+from autosklearn.pipeline.components.feature_preprocessing import FeaturePreprocessorChoice
 from autosklearn.pipeline.base import BasePipeline
 from autosklearn.pipeline.constants import SPARSE
 
 
-class SimpleClassificationPipeline(ClassifierMixin, BasePipeline):
+class SimpleClassificationPipeline(BasePipeline, ClassifierMixin):
     """This class implements the classification task.
 
     It implements a pipeline, which includes one preprocessing step and one
@@ -38,7 +37,7 @@ class SimpleClassificationPipeline(ClassifierMixin, BasePipeline):
     config : ConfigSpace.configuration_space.Configuration
         The configuration to evaluate.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : Optional[int | RandomState]
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance
@@ -68,17 +67,30 @@ class SimpleClassificationPipeline(ClassifierMixin, BasePipeline):
 
     """
 
-    def __init__(self, config=None, steps=None, dataset_properties=None,
-                 include=None, exclude=None, random_state=None,
-                 init_params=None):
+    def __init__(
+        self,
+        config: Optional[Configuration] = None,
+        steps=None,
+        dataset_properties=None,
+        include=None,
+        exclude=None,
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
+        init_params=None
+    ):
         self._output_dtype = np.int32
         if dataset_properties is None:
             dataset_properties = dict()
         if 'target_type' not in dataset_properties:
             dataset_properties['target_type'] = 'classification'
         super().__init__(
-            config, steps, dataset_properties, include, exclude,
-            random_state, init_params)
+            config=config,
+            steps=steps,
+            dataset_properties=dataset_properties,
+            include=include,
+            exclude=exclude,
+            random_state=random_state,
+            init_params=init_params
+        )
 
     def fit_transformer(self, X, y, fit_params=None):
 
@@ -290,16 +302,24 @@ class SimpleClassificationPipeline(ClassifierMixin, BasePipeline):
             default_dataset_properties.update(dataset_properties)
 
         steps.extend([
-            ["data_preprocessor",
-                DataPreprocessorChoice(dataset_properties=default_dataset_properties)],
-            ["balancing",
-                Balancing()],
-            ["feature_preprocessor",
-                feature_preprocessing_components.FeaturePreprocessorChoice(
-                    default_dataset_properties)],
-            ['classifier',
-                classification_components.ClassifierChoice(
-                    default_dataset_properties)]
+            [
+                "data_preprocessor", DataPreprocessorChoice(
+                    dataset_properties=default_dataset_properties,
+                    random_state=self.random_state)
+            ],
+            [
+                "balancing", Balancing()
+            ],
+            [
+                "feature_preprocessor", FeaturePreprocessorChoice(
+                    dataset_properties=default_dataset_properties,
+                    random_state=self.random_state)
+            ],
+            [
+                'classifier', ClassifierChoice(
+                    dataset_properties=default_dataset_properties,
+                    random_state=self.random_state)
+            ]
         ])
 
         return steps

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -4,8 +4,8 @@ import inspect
 import pkgutil
 import sys
 
+import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils import check_random_state
 
 from autosklearn.pipeline.constants import SPARSE
 
@@ -340,10 +340,7 @@ class AutoSklearnChoice(object):
         # self.configuration = self.get_hyperparameter_search_space(
         #     dataset_properties).get_default_configuration()
 
-        if random_state is None:
-            self.random_state = check_random_state(1)
-        else:
-            self.random_state = check_random_state(random_state)
+        self.random_state = random_state
 
         # Since the pipeline will initialize the hyperparameters, it is not
         # necessary to do this upon the construction of this object

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -4,7 +4,6 @@ import inspect
 import pkgutil
 import sys
 
-import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from autosklearn.pipeline.constants import SPARSE

--- a/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
@@ -17,8 +17,10 @@ class Balancing(AutoSklearnPreprocessingAlgorithm):
     def __init__(
         self,
         strategy: str = 'none',
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
     ) -> None:
         self.strategy = strategy
+        self.random_state = random_state
 
     def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None) -> 'Balancing':
         self.fitted_ = True

--- a/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
+++ b/autosklearn/pipeline/components/data_preprocessing/balancing/balancing.py
@@ -14,10 +14,11 @@ from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, SIGNED_
 
 
 class Balancing(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, strategy: str = 'none',
-                 random_state: Optional[np.random.RandomState] = None,):
+    def __init__(
+        self,
+        strategy: str = 'none',
+    ) -> None:
         self.strategy = strategy
-        self.random_state = random_state
 
     def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None) -> 'Balancing':
         self.fitted_ = True

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
@@ -14,9 +14,10 @@ from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self,
-                 random_state: Optional[np.random.RandomState] = None,
-                 ):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         self.random_state = random_state
 
     def fit(self, X: PIPELINE_DATA_DTYPE,

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/no_encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/no_encoding.py
@@ -10,7 +10,10 @@ from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class NoEncoding(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         pass
 
     def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/one_hot_encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/one_hot_encoding.py
@@ -15,7 +15,10 @@ from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class OneHotEncoder(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         self.random_state = random_state
 
     def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
+++ b/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
@@ -17,7 +17,10 @@ class CategoryShift(AutoSklearnPreprocessingAlgorithm):
     is not used, so to provide compatibility with sparse matrices.
     """
 
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         self.random_state = random_state
 
     def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/feature_type.py
+++ b/autosklearn/pipeline/components/data_preprocessing/feature_type.py
@@ -40,7 +40,7 @@ class FeatTypeSplit(AutoSklearnPreprocessingAlgorithm):
         dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
         include: Optional[Dict[str, str]] = None,
         exclude: Optional[Dict[str, str]] = None,
-        random_state: Optional[np.random.RandomState] = None,
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
         init_params: Optional[Dict[str, Any]] = None,
         feat_type: Optional[Dict[Union[str, int], str]] = None,
         force_sparse_output: bool = False,

--- a/autosklearn/pipeline/components/data_preprocessing/feature_type_categorical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/feature_type_categorical.py
@@ -39,24 +39,26 @@ class CategoricalPreprocessingPipeline(BasePipeline):
     config : ConfigSpace.configuration_space.Configuration
         The configuration to evaluate.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : Optional[int | RandomState]
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance
         used by `np.random`."""
 
     def __init__(self,
-                 config: Optional[Configuration] = None,
-                 steps: Optional[List[Tuple[str, BaseEstimator]]] = None,
-                 dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
-                 include: Optional[Dict[str, str]] = None,
-                 exclude: Optional[Dict[str, str]] = None,
-                 random_state: Optional[np.random.RandomState] = None,
-                 init_params: Optional[Dict[str, Any]] = None):
+        config: Optional[Configuration] = None,
+        steps: Optional[List[Tuple[str, BaseEstimator]]] = None,
+        dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
+        include: Optional[Dict[str, str]] = None,
+        exclude: Optional[Dict[str, str]] = None,
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
+        init_params: Optional[Dict[str, Any]] = None
+    ) -> None:
         self._output_dtype = np.int32
         super().__init__(
             config, steps, dataset_properties, include, exclude,
-            random_state, init_params)
+            random_state, init_params
+        )
 
     @staticmethod
     def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/feature_type_categorical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/feature_type_categorical.py
@@ -45,7 +45,8 @@ class CategoricalPreprocessingPipeline(BasePipeline):
         If None, the random number generator is the RandomState instance
         used by `np.random`."""
 
-    def __init__(self,
+    def __init__(
+        self,
         config: Optional[Configuration] = None,
         steps: Optional[List[Tuple[str, BaseEstimator]]] = None,
         dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,

--- a/autosklearn/pipeline/components/data_preprocessing/feature_type_numerical.py
+++ b/autosklearn/pipeline/components/data_preprocessing/feature_type_numerical.py
@@ -34,24 +34,27 @@ class NumericalPreprocessingPipeline(BasePipeline):
     config : ConfigSpace.configuration_space.Configuration
         The configuration to evaluate.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : Optional[int | RandomState]
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance
         used by `np.random`."""
 
-    def __init__(self,
-                 config: Optional[Configuration] = None,
-                 steps: Optional[List[Tuple[str, BaseEstimator]]] = None,
-                 dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
-                 include: Optional[Dict[str, str]] = None,
-                 exclude: Optional[Dict[str, str]] = None,
-                 random_state: Optional[np.random.RandomState] = None,
-                 init_params: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        config: Optional[Configuration] = None,
+        steps: Optional[List[Tuple[str, BaseEstimator]]] = None,
+        dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None,
+        include: Optional[Dict[str, str]] = None,
+        exclude: Optional[Dict[str, str]] = None,
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
+        init_params: Optional[Dict[str, Any]] = None
+    ) -> None:
         self._output_dtype = np.int32
         super().__init__(
             config, steps, dataset_properties, include, exclude,
-            random_state, init_params)
+            random_state, init_params
+        )
 
     @staticmethod
     def get_properties(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -18,7 +18,10 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
         numerical data and “missing_value” for strings or object data types.
     """
 
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         self.random_state = random_state
 
     def fit(self, X: PIPELINE_DATA_DTYPE,

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/numerical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/numerical_imputation.py
@@ -12,8 +12,11 @@ from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 class NumericalImputation(AutoSklearnPreprocessingAlgorithm):
 
-    def __init__(self, strategy: str = 'mean',
-                 random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        strategy: str = 'mean',
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         self.strategy = strategy
         self.random_state = random_state
 

--- a/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/minority_coalescer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/minority_coalescer.py
@@ -16,8 +16,11 @@ class MinorityCoalescer(AutoSklearnPreprocessingAlgorithm):
     """ Group together categories which occurence is less than a specified minimum fraction.
     """
 
-    def __init__(self, minimum_fraction: float = 0.01,
-                 random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        minimum_fraction: float = 0.01,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         self.minimum_fraction = minimum_fraction
 
     def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/no_coalescense.py
+++ b/autosklearn/pipeline/components/data_preprocessing/minority_coalescense/no_coalescense.py
@@ -11,7 +11,10 @@ from autosklearn.pipeline.constants import DENSE, SPARSE, UNSIGNED_DATA, INPUT
 
 
 class NoCoalescence(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         pass
 
     def fit(self, X: np.array, y: Optional[PIPELINE_DATA_DTYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 
@@ -13,7 +13,10 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 class Rescaling(object):
     # Rescaling does not support fit_transform (as of 0.19.1)!
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         self.preprocessor: Optional[BaseEstimator] = None
 
     def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/minmax.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/minmax.py
@@ -10,7 +10,7 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 
 class MinMaxScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(self, random_state: Optional[Union[int, np.random.RandomState]] = None):
         from sklearn.preprocessing import MinMaxScaler
         self.preprocessor = MinMaxScaler(copy=False)
 

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/normalize.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/normalize.py
@@ -10,7 +10,10 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 
 class NormalizerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         # Use custom implementation because sklearn implementation cannot
         # handle float32 input matrix
         from sklearn.preprocessing import Normalizer

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/power_transformer.py
@@ -10,7 +10,10 @@ from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorit
 
 
 class PowerTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
+    ) -> None:
         from sklearn.preprocessing import PowerTransformer
         self.preprocessor = PowerTransformer(copy=False)
 

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/quantile_transformer.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/quantile_transformer.py
@@ -15,8 +15,12 @@ from autosklearn.pipeline.components.base import \
 
 
 class QuantileTransformerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, n_quantiles: int, output_distribution: str,
-                 random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        n_quantiles: int,
+        output_distribution: str,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         from sklearn.preprocessing import QuantileTransformer
         self.n_quantiles = n_quantiles
         self.output_distribution = output_distribution

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/robust_scaler.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/robust_scaler.py
@@ -17,8 +17,12 @@ from autosklearn.pipeline.components.base import \
 
 
 class RobustScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, q_min: float, q_max: float,
-                 random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        q_min: float,
+        q_max: float,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         from sklearn.preprocessing import RobustScaler
         self.q_min = q_min
         self.q_max = q_max

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/standardize.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/standardize.py
@@ -15,7 +15,10 @@ from autosklearn.pipeline.components.base import \
 
 
 class StandardScalerComponent(Rescaling, AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         from sklearn.preprocessing import StandardScaler
         self.preprocessor = StandardScaler(copy=False)
 

--- a/autosklearn/pipeline/components/data_preprocessing/variance_threshold/variance_threshold.py
+++ b/autosklearn/pipeline/components/data_preprocessing/variance_threshold/variance_threshold.py
@@ -12,7 +12,10 @@ import sklearn.feature_selection
 
 
 class VarianceThreshold(AutoSklearnPreprocessingAlgorithm):
-    def __init__(self, random_state: Optional[np.random.RandomState] = None):
+    def __init__(
+        self,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
         # VarianceThreshold does not support fit_transform (as of 0.19.1)!
         self.random_state = random_state
 

--- a/autosklearn/pipeline/components/regression/mlp.py
+++ b/autosklearn/pipeline/components/regression/mlp.py
@@ -1,4 +1,3 @@
-import copy
 import numpy as np
 
 from ConfigSpace.configuration_space import ConfigurationSpace
@@ -120,7 +119,7 @@ class MLPRegressor(
                 learning_rate_init=self.learning_rate_init,
                 max_iter=n_iter,
                 shuffle=self.shuffle,
-                random_state=copy.copy(self.random_state),
+                random_state=self.random_state,
                 verbose=self.verbose,
                 warm_start=True,
                 early_stopping=self.early_stopping_val,

--- a/autosklearn/pipeline/regression.py
+++ b/autosklearn/pipeline/regression.py
@@ -1,5 +1,6 @@
 import copy
 from itertools import product
+from typing import Optional, Union
 
 import numpy as np
 from sklearn.base import RegressorMixin
@@ -9,7 +10,7 @@ from ConfigSpace.forbidden import ForbiddenEqualsClause, ForbiddenAndConjunction
 from autosklearn.pipeline.components.data_preprocessing import DataPreprocessorChoice
 
 
-from ConfigSpace.configuration_space import ConfigurationSpace
+from ConfigSpace.configuration_space import ConfigurationSpace, Configuration
 from autosklearn.pipeline.components import regression as \
     regression_components
 from autosklearn.pipeline.components import feature_preprocessing as \
@@ -36,7 +37,7 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
     config : ConfigSpace.configuration_space.Configuration
         The configuration to evaluate.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : Optional[int | RandomState]
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance
@@ -65,9 +66,16 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
     --------
 
     """
-    def __init__(self, config=None, steps=None, dataset_properties=None,
-                 include=None, exclude=None, random_state=None,
-                 init_params=None):
+    def __init__(
+        self,
+        config: Optional[Configuration] = None,
+        steps=None,
+        dataset_properties=None,
+        include=None,
+        exclude=None,
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
+        init_params=None
+    ):
         self._output_dtype = np.float32
         if dataset_properties is None:
             dataset_properties = dict()

--- a/autosklearn/pipeline/regression.py
+++ b/autosklearn/pipeline/regression.py
@@ -232,13 +232,27 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
             default_dataset_properties.update(dataset_properties)
 
         steps.extend([
-            ['data_preprocessor',
-                DataPreprocessorChoice(dataset_properties=default_dataset_properties)],
-            ['feature_preprocessor',
+            [
+                'data_preprocessor',
+                DataPreprocessorChoice(
+                    dataset_properties=default_dataset_properties,
+                    random_state=self.random_state
+                )
+            ],
+            [
+                'feature_preprocessor',
                 feature_preprocessing_components.FeaturePreprocessorChoice(
-                    default_dataset_properties)],
-            ['regressor',
-                regression_components.RegressorChoice(default_dataset_properties)]
+                    dataset_properties=default_dataset_properties,
+                    random_state=self.random_state
+                )
+            ],
+            [
+                'regressor',
+                regression_components.RegressorChoice(
+                    default_dataset_properties,
+                    random_state=self.random_state
+                )
+            ]
         ])
 
         return steps

--- a/autosklearn/pipeline/util.py
+++ b/autosklearn/pipeline/util.py
@@ -107,11 +107,12 @@ def _test_classifier(classifier, dataset='iris', sparse=False,
                                                    make_binary=make_binary)
 
     configuration_space = classifier.get_hyperparameter_search_space(
-        dataset_properties={'sparse': sparse})
-    default = configuration_space.get_default_configuration()
-    classifier = classifier(random_state=np.random.RandomState(1),
-                            **{hp_name: default[hp_name] for hp_name in
-                               default if default[hp_name] is not None})
+        dataset_properties={'sparse': sparse}
+    )
+    default_config = configuration_space.get_default_configuration()
+
+    classifier = classifier(random_state=0, **default_config)
+
     if hasattr(classifier, 'iterative_fit'):
         class counter(object):
             def __init__(self, func):
@@ -138,13 +139,13 @@ def _test_classifier_iterative_fit(classifier, dataset='iris', sparse=False):
     X_train, Y_train, X_test, Y_test = get_dataset(dataset=dataset,
                                                    make_sparse=sparse)
     configuration_space = classifier.get_hyperparameter_search_space(
-        dataset_properties={'sparse': sparse})
-    default = configuration_space.get_default_configuration()
-    classifier = classifier(random_state=np.random.RandomState(1),
-                            **{hp_name: default[hp_name] for hp_name in
-                               default if default[hp_name] is not None})
+        dataset_properties={'sparse': sparse}
+    )
+    default_config = configuration_space.get_default_configuration()
 
+    classifier = classifier(random_state=0, **default_config)
     classifier.iterative_fit(X_train, Y_train, n_iter=2, refit=True)
+
     iteration = 2
     while not classifier.configuration_fully_fitted():
         n_iter = int(2 ** iteration / 2)
@@ -165,10 +166,10 @@ def _test_classifier_predict_proba(classifier, dataset='iris', sparse=False,
                                                    make_multilabel=make_multilabel,
                                                    make_binary=make_binary)
     configuration_space = classifier.get_hyperparameter_search_space()
-    default = configuration_space.get_default_configuration()
-    classifier = classifier(random_state=np.random.RandomState(1),
-                            **{hp_name: default[hp_name] for hp_name in
-                               default})
+
+    default_config = configuration_space.get_default_configuration()
+    classifier = classifier(random_state=0, **default_config)
+
     predictor = classifier.fit(X_train, Y_train)
     predictions = predictor.predict_proba(X_test)
     return predictions, Y_test
@@ -181,11 +182,9 @@ def _test_preprocessing(Preprocessor, dataset='iris', make_sparse=False,
                                                    train_size_maximum=train_size_maximum)
     original_X_train = X_train.copy()
     configuration_space = Preprocessor.get_hyperparameter_search_space()
-    default = configuration_space.get_default_configuration()
+    default_config = configuration_space.get_default_configuration()
 
-    preprocessor = Preprocessor(random_state=np.random.RandomState(1),
-                                **{hp_name: default[hp_name] for hp_name in
-                                   default if default[hp_name] is not None})
+    preprocessor = Preprocessor(random_state=0, **default_config)
 
     transformer = preprocessor.fit(X_train, Y_train)
     return transformer.transform(X_train), original_X_train
@@ -200,10 +199,9 @@ class PreprocessingTestCase(unittest.TestCase):
         self.assertEqual(X_train.dtype, np.float32)
 
         configuration_space = Preprocessor.get_hyperparameter_search_space()
-        default = configuration_space.get_default_configuration()
-        preprocessor = Preprocessor(random_state=np.random.RandomState(1),
-                                    **{hp_name: default[hp_name] for hp_name in
-                                       default})
+        default_config = configuration_space.get_default_configuration()
+        preprocessor = Preprocessor(random_state=0, **default_config)
+
         preprocessor.fit(X_train, Y_train)
         preprocessor.transform(X_train)
         # self.assertEqual(Xt.dtype, np.float32)
@@ -212,10 +210,9 @@ class PreprocessingTestCase(unittest.TestCase):
         X_train, Y_train, X_test, Y_test = get_dataset(dataset, add_NaNs=add_NaNs)
         X_train = X_train.astype(np.float64)
         configuration_space = Preprocessor.get_hyperparameter_search_space()
-        default = configuration_space.get_default_configuration()
-        preprocessor = Preprocessor(random_state=np.random.RandomState(1),
-                                    **{hp_name: default[hp_name] for hp_name in
-                                       default})
+        default_config = configuration_space.get_default_configuration()
+
+        preprocessor = Preprocessor(random_state=0, **default_config)
         preprocessor.fit(X_train, Y_train)
         preprocessor.transform(X_train)
         # self.assertEqual(Xt.dtype, np.float64)
@@ -227,10 +224,9 @@ class PreprocessingTestCase(unittest.TestCase):
                                                            add_NaNs=add_NaNs)
             self.assertEqual(X_train.dtype, np.float32)
             configuration_space = Preprocessor.get_hyperparameter_search_space()
-            default = configuration_space.get_default_configuration()
-            preprocessor = Preprocessor(random_state=np.random.RandomState(1),
-                                        **{hp_name: default[hp_name] for hp_name
-                                           in default})
+            default_config = configuration_space.get_default_configuration()
+            preprocessor = Preprocessor(random_state=0, **default_config)
+
             preprocessor.fit(X_train, Y_train)
             preprocessor.transform(X_train)
             # self.assertEqual(Xt.dtype, np.float32)
@@ -241,10 +237,9 @@ class PreprocessingTestCase(unittest.TestCase):
                                                            add_NaNs=add_NaNs)
             X_train = X_train.astype(np.float64)
             configuration_space = Preprocessor.get_hyperparameter_search_space()
-            default = configuration_space.get_default_configuration()
-            preprocessor = Preprocessor(random_state=np.random.RandomState(1),
-                                        **{hp_name: default[hp_name] for hp_name
-                                           in default})
+            default_config = configuration_space.get_default_configuration()
+
+            preprocessor = Preprocessor(random_state=0, **default_config)
             preprocessor.fit(X_train, Y_train)
             preprocessor.transform(X_train)
             # self.assertEqual(Xt.dtype, np.float64)
@@ -254,10 +249,10 @@ def _test_regressor(Regressor, dataset='diabetes', sparse=False):
     X_train, Y_train, X_test, Y_test = get_dataset(dataset=dataset,
                                                    make_sparse=sparse)
     configuration_space = Regressor.get_hyperparameter_search_space()
-    default = configuration_space.get_default_configuration()
-    regressor = Regressor(random_state=np.random.RandomState(1),
-                          **{hp_name: default[hp_name] for hp_name in
-                             default})
+    default_config = configuration_space.get_default_configuration()
+
+    regressor = Regressor(random_state=0, **default_config)
+
     # Dumb incomplete hacky test to check that we do not alter the data
     X_train_hash = hash(str(X_train))
     X_test_hash = hash(str(X_test))
@@ -294,11 +289,10 @@ def _test_regressor_iterative_fit(Regressor, dataset='diabetes', sparse=False):
     X_train, Y_train, X_test, Y_test = get_dataset(dataset=dataset,
                                                    make_sparse=sparse)
     configuration_space = Regressor.get_hyperparameter_search_space(
-        dataset_properties={'sparse': sparse})
-    default = configuration_space.get_default_configuration()
-    regressor = Regressor(random_state=np.random.RandomState(1),
-                          **{hp_name: default[hp_name] for hp_name in
-                             default})
+        dataset_properties={'sparse': sparse}
+    )
+    default_config = configuration_space.get_default_configuration()
+    regressor = Regressor(random_state=0, **default_config)
 
     regressor.iterative_fit(X_train, Y_train, n_iter=2, refit=True)
     iteration = 2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    test

--- a/test/test_automl/test_automl.py
+++ b/test/test_automl/test_automl.py
@@ -58,6 +58,7 @@ def test_fit(dask_client):
 
     X_train, Y_train, X_test, Y_test = putil.get_dataset('iris')
     automl = autosklearn.automl.AutoML(
+        seed=0,
         time_left_for_this_task=30,
         per_run_time_limit=5,
         metric=accuracy,
@@ -212,8 +213,10 @@ def test_delete_non_candidate_models(dask_client):
         seed=seed,
         initial_configurations_via_metalearning=0,
         resampling_strategy='holdout',
-        include={'classifier': ['sgd'],
-                 'feature_preprocessor': ['no_preprocessing']},
+        include={
+            'classifier': ['sgd'],
+            'feature_preprocessor': ['no_preprocessing']
+        },
         metric=accuracy,
         dask_client=dask_client,
         # Force model to be deleted. That is, from 50 which is the
@@ -874,19 +877,16 @@ def data_test_model_predict_outsputs_correct_shapes():
     #
     #   tldr; thats why we use MyDummyX here instead of the default models
     #         from sklearn
-    def seed():
-        return np.random.RandomState(42)
-
     def classifier(X, y):
-        return MyDummyClassifier(config=1, random_state=seed()).fit(X, y)
+        return MyDummyClassifier(config=1, random_state=0).fit(X, y)
 
     def regressor(X, y):
-        return MyDummyRegressor(config=1, random_state=seed()).fit(X, y)
+        return MyDummyRegressor(config=1, random_state=0).fit(X, y)
 
     # How cross validation models are currently grouped together
     def voting_classifier(X, y):
         classifiers = [
-            MyDummyClassifier(config=1, random_state=seed()).fit(X, y)
+            MyDummyClassifier(config=1, random_state=0).fit(X, y)
             for _ in range(5)
         ]
         vc = VotingClassifier(estimators=None, voting='soft')
@@ -895,7 +895,7 @@ def data_test_model_predict_outsputs_correct_shapes():
 
     def voting_regressor(X, y):
         regressors = [
-            MyDummyRegressor(config=1, random_state=seed()).fit(X, y)
+            MyDummyRegressor(config=1, random_state=0).fit(X, y)
             for _ in range(5)
         ]
         vr = VotingRegressor(estimators=None)

--- a/test/test_ensemble_builder/test_ensemble_selection.py
+++ b/test/test_ensemble_builder/test_ensemble_selection.py
@@ -14,7 +14,7 @@ def testEnsembleSelection():
 
     ensemble = EnsembleSelection(ensemble_size=10,
                                  task_type=REGRESSION,
-                                 random_state=np.random.RandomState(0),
+                                 random_state=0,
                                  metric=root_mean_squared_error)
 
     # We create a problem such that we encourage the addition of members to the ensemble
@@ -56,7 +56,7 @@ def testPredict():
     # If none of the above is the case, predict() raises Error.
     ensemble = EnsembleSelection(ensemble_size=3,
                                  task_type=BINARY_CLASSIFICATION,
-                                 random_state=np.random.RandomState(0),
+                                 random_state=0,
                                  metric=accuracy,
                                  )
     # Test for case 1. Create (3, 2, 2) predictions.

--- a/test/test_evaluation/test_abstract_evaluator.py
+++ b/test/test_evaluation/test_abstract_evaluator.py
@@ -262,7 +262,7 @@ class AbstractEvaluatorTest(unittest.TestCase):
             )
             ae.model = sklearn.dummy.DummyClassifier()
 
-            rs = np.random.RandomState()
+            rs = np.random.RandomState(1)
             ae.Y_optimization = rs.rand(33, 3)
             predictions_ensemble = rs.rand(33, 3)
             predictions_test = rs.rand(25, 3)

--- a/test/test_evaluation/test_dummy_pipelines.py
+++ b/test/test_evaluation/test_dummy_pipelines.py
@@ -20,7 +20,7 @@ def test_dummy_pipeline(task_type):
     else:
         pytest.fail(task_type)
 
-    estimator = estimator_class(config=1, random_state=np.random.RandomState(42))
+    estimator = estimator_class(config=1, random_state=0)
     X, y = data_maker()
     estimator.fit(X, y)
     check_is_fitted(estimator)

--- a/test/test_evaluation/test_test_evaluator.py
+++ b/test/test_evaluation/test_test_evaluator.py
@@ -143,7 +143,7 @@ class FunctionsTest(unittest.TestCase):
                    'f1_macro': 0.0341005967604433,
                    'f1_micro': 0.040000000000000036,
                    'f1_weighted': 0.039693094629155934,
-                   'log_loss': 0.148586485311389,
+                   'log_loss': 0.1560370981693268,
                    'precision_macro': 0.03703703703703709,
                    'precision_micro': 0.040000000000000036,
                    'precision_weighted': 0.03555555555555556,

--- a/test/test_evaluation/test_test_evaluator.py
+++ b/test/test_evaluation/test_test_evaluator.py
@@ -143,7 +143,7 @@ class FunctionsTest(unittest.TestCase):
                    'f1_macro': 0.0341005967604433,
                    'f1_micro': 0.040000000000000036,
                    'f1_weighted': 0.039693094629155934,
-                   'log_loss': 0.1560370981693268,
+                   'log_loss': 0.13966929787769913,
                    'precision_macro': 0.03703703703703709,
                    'precision_micro': 0.040000000000000036,
                    'precision_weighted': 0.03555555555555556,

--- a/test/test_evaluation/test_train_evaluator.py
+++ b/test/test_evaluation/test_train_evaluator.py
@@ -2281,7 +2281,7 @@ class FunctionsTest(unittest.TestCase):
             'f1_macro': 0.032036613272311221,
             'f1_micro': 0.030303030303030276,
             'f1_weighted': 0.030441716940572849,
-            'log_loss': 0.06569589991969141,
+            'log_loss': 0.06376745642134637,
             'precision_macro': 0.02777777777777779,
             'precision_micro': 0.030303030303030276,
             'precision_weighted': 0.027777777777777901,
@@ -2351,7 +2351,7 @@ class FunctionsTest(unittest.TestCase):
         )
         info = read_queue(self.queue)
         self.assertEqual(len(info), 1)
-        self.assertAlmostEqual(info[0]['loss'], 0.030303030303030276, places=3)
+        self.assertAlmostEqual(info[0]['loss'], 0.06060606060606055, places=3)
         self.assertEqual(info[0]['status'], StatusType.SUCCESS)
         self.assertNotIn('bac_metric', info[0]['additional_run_info'])
 
@@ -2434,7 +2434,7 @@ class FunctionsTest(unittest.TestCase):
         )
         info = read_queue(self.queue)
         self.assertEqual(len(info), 1)
-        self.assertAlmostEqual(info[0]['loss'], 0.030303030303030276)
+        self.assertAlmostEqual(info[0]['loss'], 0.06060606060606055)
 
     def test_eval_holdout_budget_mixed_subsample(self):
         configuration = get_configuration_space(
@@ -2518,7 +2518,7 @@ class FunctionsTest(unittest.TestCase):
             'f1_macro': 0.052793650793650775,
             'f1_micro': 0.04999999999999997,
             'f1_weighted': 0.050090909090909096,
-            'log_loss': 0.12640966003295034,
+            'log_loss': 0.12108563414774837,
             'precision_macro': 0.04963636363636359,
             'precision_micro': 0.04999999999999997,
             'precision_weighted': 0.045757575757575664,

--- a/test/test_evaluation/test_train_evaluator.py
+++ b/test/test_evaluation/test_train_evaluator.py
@@ -2281,7 +2281,7 @@ class FunctionsTest(unittest.TestCase):
             'f1_macro': 0.032036613272311221,
             'f1_micro': 0.030303030303030276,
             'f1_weighted': 0.030441716940572849,
-            'log_loss': 0.06731761928478425,
+            'log_loss': 0.06569589991969141,
             'precision_macro': 0.02777777777777779,
             'precision_micro': 0.030303030303030276,
             'precision_weighted': 0.027777777777777901,
@@ -2351,7 +2351,7 @@ class FunctionsTest(unittest.TestCase):
         )
         info = read_queue(self.queue)
         self.assertEqual(len(info), 1)
-        self.assertAlmostEqual(info[0]['loss'], 0.06060606060606055, places=3)
+        self.assertAlmostEqual(info[0]['loss'], 0.030303030303030276, places=3)
         self.assertEqual(info[0]['status'], StatusType.SUCCESS)
         self.assertNotIn('bac_metric', info[0]['additional_run_info'])
 
@@ -2434,9 +2434,7 @@ class FunctionsTest(unittest.TestCase):
         )
         info = read_queue(self.queue)
         self.assertEqual(len(info), 1)
-        self.assertAlmostEqual(info[0]['loss'], 0.06060606060606055)
-        self.assertEqual(info[0]['status'], StatusType.SUCCESS)
-        self.assertNotIn('bac_metric', info[0]['additional_run_info'])
+        self.assertAlmostEqual(info[0]['loss'], 0.030303030303030276)
 
     def test_eval_holdout_budget_mixed_subsample(self):
         configuration = get_configuration_space(
@@ -2520,7 +2518,7 @@ class FunctionsTest(unittest.TestCase):
             'f1_macro': 0.052793650793650775,
             'f1_micro': 0.04999999999999997,
             'f1_weighted': 0.050090909090909096,
-            'log_loss': 0.12033827614970506,
+            'log_loss': 0.12640966003295034,
             'precision_macro': 0.04963636363636359,
             'precision_micro': 0.04999999999999997,
             'precision_weighted': 0.045757575757575664,

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -78,7 +78,7 @@ class BaseClassificationComponentTest(unittest.TestCase):
             return
 
         for _ in range(2):
-            predictions, targets =  _test_classifier_predict_proba(
+            predictions, targets = _test_classifier_predict_proba(
                 dataset="iris", classifier=self.module
             )
             self.assertAlmostEqual(

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -224,7 +224,7 @@ class BaseClassificationComponentTest(unittest.TestCase):
 
     def test_module_idempotent(self):
         """ Fitting twice with the same config gives the same model params.
-        
+
             This is only valid when the random_state passed is an int. If a
             RandomState object is passed then repeated calls to fit will have
             different results. See the section on "Controlling Randomness" in the
@@ -291,14 +291,7 @@ class BaseClassificationComponentTest(unittest.TestCase):
         sampled = [configuration_space.sample_configuration() for _ in range(2)]
 
         for seed, config in enumerate([default] + sampled):
-            model_args = {
-                'random_state': seed,  # This must be an int, see test doc
-                ** {
-                    hp_name: config[hp_name]
-                    for hp_name in config
-                    if config[hp_name] is not None
-                }
-            }
+            model_args = {"random_state": seed, **config}
             classifier = classifier_cls(**model_args)
 
             # Get the parameters on the first and second fit with config params

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -282,7 +282,7 @@ class BaseClassificationComponentTest(unittest.TestCase):
             return model.estimator.get_params()
 
         # We ignore certain keys when comparing
-        param_keys_ignored = ['base_estimator', *self.res.get('ignore_hps', [])]
+        param_keys_ignored = ['base_estimator']
 
         # We use the default config + sampled ones
         configuration_space = classifier_cls.get_hyperparameter_search_space()

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -77,14 +77,15 @@ class BaseClassificationComponentTest(unittest.TestCase):
         if self.__class__ == BaseClassificationComponentTest:
             return
 
-        for i in range(2):
-            predictions, targets = \
-                _test_classifier_predict_proba(dataset="iris",
-                                               classifier=self.module)
-            self.assertAlmostEqual(self.res["default_iris_proba"],
-                                   sklearn.metrics.log_loss(targets, predictions),
-                                   places=self.res.get(
-                                           "default_iris_proba_places", 7))
+        for _ in range(2):
+            predictions, targets =  _test_classifier_predict_proba(
+                dataset="iris", classifier=self.module
+            )
+            self.assertAlmostEqual(
+                self.res["default_iris_proba"],
+                sklearn.metrics.log_loss(targets, predictions),
+                places=self.res.get("default_iris_proba_places", 7)
+            )
 
     def test_default_iris_sparse(self):
 
@@ -296,7 +297,14 @@ class BaseClassificationComponentTest(unittest.TestCase):
 
             # Get the parameters on the first and second fit with config params
             params_first = fitted_params(classifier)
+            if hasattr(classifier.estimator, 'random_state'):
+                rs_1 = classifier.random_state
+                rs_estimator_1 = classifier.estimator.random_state
+
             params_second = fitted_params(classifier)
+            if hasattr(classifier.estimator, 'random_state'):
+                rs_2 = classifier.random_state
+                rs_estimator_2 = classifier.estimator.random_state
 
             # An acceptable error occured, skip to next sample
             if params_first is None or params_second is None:
@@ -311,3 +319,8 @@ class BaseClassificationComponentTest(unittest.TestCase):
             # They should have equal parameters
             self.assertEqual(params_first, params_second,
                              f"Failed with model args {model_args}")
+            if hasattr(classifier.estimator, 'random_state'):
+                assert all([
+                    seed == random_state
+                    for random_state in [rs_1, rs_estimator_1, rs_2, rs_estimator_2]
+                ])

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -1,3 +1,5 @@
+from typing import Optional, Dict
+
 import unittest
 
 from autosklearn.pipeline.util import _test_classifier, \
@@ -221,70 +223,98 @@ class BaseClassificationComponentTest(unittest.TestCase):
             return
 
     def test_module_idempotent(self):
+        """ Fitting twice with the same config gives the same model params.
+        
+            This is only valid when the random_state passed is an int. If a
+            RandomState object is passed then repeated calls to fit will have
+            different results. See the section on "Controlling Randomness" in the
+            sklearn docs.
 
+            https://scikit-learn.org/0.24/common_pitfalls.html#controlling-randomness
+        """
         if self.__class__ == BaseClassificationComponentTest:
             return
 
-        def check_classifier(cls):
-            X = np.array([[0, 0], [0, 1], [1, 0], [1, 1],
-                          [0, 0], [0, 1], [1, 0], [1, 1],
-                          [0, 0], [0, 1], [1, 0], [1, 1],
-                          [0, 0], [0, 1], [1, 0], [1, 1]])
-            y = np.array([0, 1, 1, 0,
-                          0, 1, 1, 0,
-                          0, 1, 1, 0,
-                          0, 1, 1, 0])
-            params = []
+        classifier_cls = self.module
 
-            for i in range(2):
-                try:
-                    classifier.fit(X, y)
-                except ValueError as e:
-                    if (
-                        isinstance(e.args[0], str)
-                    ) and (
-                        "Numerical problems in QDA" in e.args[0]
-                    ):
-                        continue
-                    elif (
-                        "BaseClassifier in AdaBoostClassifier ensemble is "
-                        "worse than random, ensemble can not be fit." in e.args[0]
-                    ):
-                        continue
-                    else:
-                        raise e
-                except UnboundLocalError as e:
-                    if "local variable 'raw_predictions_val' referenced before assignment" in \
-                            e.args[0]:
-                        continue
+        X = np.array([
+            [0, 0], [0, 1], [1, 0], [1, 1],
+            [0, 0], [0, 1], [1, 0], [1, 1],
+            [0, 0], [0, 1], [1, 0], [1, 1],
+            [0, 0], [0, 1], [1, 0], [1, 1],
+        ])
+        y = np.array([
+            0, 1, 1, 0,
+            0, 1, 1, 0,
+            0, 1, 1, 0,
+            0, 1, 1, 0,
+        ])
 
-                p = classifier.estimator.get_params()
-                if 'random_state' in p:
-                    del p['random_state']
-                if 'base_estimator' in p:
-                    del p['base_estimator']
-                for ignore_hp in self.res.get('ignore_hps', []):
-                    del p[ignore_hp]
-                params.append(p)
+        # There are certain errors we ignore so we wrap this in a function
+        def fitted_params(model) -> Optional[Dict]:
+            """
+            Returns the params if fitted successfully, else None if an
+            acceptable error occurs
+            """
+            # We are okay with Numerical in Quadractic disciminant analysis
+            def is_QDA_error(err):
+                return "Numerical problems in QDA" in err.args[0]
 
-                if i > 0:
-                    self.assertEqual(
-                        params[-1],
-                        params[0],
-                    )
+            # We are okay if the BaseClassifier in AdaBoostClassifier is worse
+            # than random so no ensemble can be fit
+            def is_AdaBoostClassifier_error(err):
+                return ("BaseClassifier in AdaBoostClassifier ensemble is worse"
+                        + " than random, ensemble can not be fit." in err.args[0])
 
-        classifier = self.module
-        configuration_space = classifier.get_hyperparameter_search_space()
+            def is_unset_param_raw_predictions_val_error(err):
+                return ("local variable 'raw_predictions_val' referenced before"
+                        + " assignment" in err.args[0])
+
+            try:
+                model.fit(X.copy(), y.copy())
+            except ValueError as e:
+                if is_AdaBoostClassifier_error(e) or is_QDA_error(e):
+                    return None
+            except UnboundLocalError as e:
+                if is_unset_param_raw_predictions_val_error(e):
+                    return None
+
+            return model.estimator.get_params()
+
+        # We ignore certain keys when comparing
+        param_keys_ignored = ['base_estimator', *self.res.get('ignore_hps', [])]
+
+        # We use the default config + sampled ones
+        configuration_space = classifier_cls.get_hyperparameter_search_space()
+
         default = configuration_space.get_default_configuration()
-        classifier = classifier(random_state=np.random.RandomState(1),
-                                **{hp_name: default[hp_name] for hp_name in
-                                   default if default[hp_name] is not None})
-        check_classifier(classifier)
+        sampled = [configuration_space.sample_configuration() for _ in range(2)]
 
-        for i in range(5):
-            classifier = self.module
-            config = configuration_space.sample_configuration()
-            classifier = classifier(random_state=np.random.RandomState(1),
-                                    **{hp_name: config[hp_name] for hp_name in
-                                       config if config[hp_name] is not None})
-            check_classifier(classifier)
+        for seed, config in enumerate([default] + sampled):
+            model_args = {
+                'random_state': seed,  # This must be an int, see test doc
+                ** {
+                    hp_name: config[hp_name]
+                    for hp_name in config
+                    if config[hp_name] is not None
+                }
+            }
+            classifier = classifier_cls(**model_args)
+
+            # Get the parameters on the first and second fit with config params
+            params_first = fitted_params(classifier)
+            params_second = fitted_params(classifier)
+
+            # An acceptable error occured, skip to next sample
+            if params_first is None or params_second is None:
+                continue
+
+            # Remove keys we don't wish to include in the comparison
+            for params in [params_first, params_second]:
+                for key in param_keys_ignored:
+                    if key in params:
+                        del params[key]
+
+            # They should have equal parameters
+            self.assertEqual(params_first, params_second,
+                             f"Failed with model args {model_args}")

--- a/test/test_pipeline/components/classification/test_extra_trees.py
+++ b/test/test_pipeline/components/classification/test_extra_trees.py
@@ -12,15 +12,15 @@ class ExtraTreesComponentTest(BaseClassificationComponentTest):
     res = dict()
     res["default_iris"] = 0.96
     res["iris_n_calls"] = 9
-    res["default_iris_iterative"] = 0.96
-    res["default_iris_proba"] = 0.10456064854241846
+    res["default_iris_iterative"] = res['default_iris']
+    res["default_iris_proba"] = 0.10053485167017469
     res["default_iris_sparse"] = 0.74
-    res["default_digits"] = 0.9156041287188829
+    res["default_digits"] = 0.9216757741347905
     res["digits_n_calls"] = 9
-    res["default_digits_iterative"] = 0.9156041287188829
+    res["default_digits_iterative"] = res['default_digits']
     res["default_digits_iterative_places"] = 3
     res["default_digits_binary"] = 0.994535519125683
-    res["default_digits_multilabel"] = 0.9983251633986928
+    res["default_digits_multilabel"] = 0.9983621593291405
     res["default_digits_multilabel_proba"] = 0.997710730679746
 
     sk_mod = sklearn.ensemble.ExtraTreesClassifier

--- a/test/test_pipeline/components/classification/test_mlp.py
+++ b/test/test_pipeline/components/classification/test_mlp.py
@@ -10,19 +10,19 @@ class MLPComponentTest(BaseClassificationComponentTest):
     __test__ = True
 
     res = dict()
-    res["default_iris"] = 0.62
+    res["default_iris"] = 0.98
     res["iris_n_calls"] = 7
-    res["iris_iterative_n_iter"] = 98
+    res["iris_iterative_n_iter"] = 94
     res["default_iris_iterative"] = res["default_iris"]
-    res["default_iris_proba"] = 1.360589495897293
-    res["default_iris_sparse"] = 0.22
-    res["default_digits"] = 0.6095931997571342
+    res["default_iris_proba"] = 0.647786774635315
+    res["default_iris_sparse"] = 0.42
+    res["default_digits"] = 0.8099574984820886
     res["digits_n_calls"] = 7
-    res["digits_iterative_n_iter"] = 107
+    res["digits_iterative_n_iter"] = 124
     res["default_digits_iterative"] = res["default_digits"]
-    res["default_digits_binary"] = 0.9896782027929569
-    res["default_digits_multilabel"] = 0.8318638108383578
-    res["default_digits_multilabel_proba"] = 0.6948680429155812
+    res["default_digits_binary"] = 0.99210686095932
+    res["default_digits_multilabel"] = 0.8083000396415946
+    res["default_digits_multilabel_proba"] = 0.8096624850657109
 
     sk_mod = sklearn.neural_network.MLPClassifier
     module = MLPClassifier

--- a/test/test_pipeline/components/classification/test_mlp.py
+++ b/test/test_pipeline/components/classification/test_mlp.py
@@ -6,7 +6,22 @@ from .test_base import BaseClassificationComponentTest
 
 
 class MLPComponentTest(BaseClassificationComponentTest):
-
+    # NOTE: `default_iris_proba_places`
+    #
+    # Github runners seem to indeterministicly fail `test_default_iris_proba`
+    # meaning 'default_irish_proba_places' needs to be set.
+    # There are known differences to occur on different platforms.
+    # https://github.com/scikit-learn/scikit-learn/issues/13108#issuecomment-461696681
+    #
+    # We are assuming results are deterministic on a given platform as locally
+    # there is no randomness i.e. performing the same test 100 times yeilds the
+    # same predictions 100 times.
+    #
+    # Github runners indicate that they run on microsoft Azure with DS2-v2.
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#cloud-hosts-for-github-hosted-runners
+    #
+    # These seem to have consistent CPU's so I'm unsure what the underlying reason
+    # for this to randomly fail only sometimes on Github runners
     __test__ = True
 
     res = dict()
@@ -15,6 +30,7 @@ class MLPComponentTest(BaseClassificationComponentTest):
     res["iris_iterative_n_iter"] = 94
     res["default_iris_iterative"] = res["default_iris"]
     res["default_iris_proba"] = 0.647786774635315
+    res["default_iris_proba_places"] = 6
     res["default_iris_sparse"] = 0.42
     res["default_digits"] = 0.8099574984820886
     res["digits_n_calls"] = 7

--- a/test/test_pipeline/components/classification/test_passive_aggressive.py
+++ b/test/test_pipeline/components/classification/test_passive_aggressive.py
@@ -11,20 +11,20 @@ class PassiveAggressiveComponentTest(BaseClassificationComponentTest):
     __test__ = True
 
     res = dict()
-    res["default_iris"] = 0.92
-    res["iris_n_calls"] = 5
-    res["default_iris_iterative"] = 0.92
-    res["iris_iterative_n_iter"] = 32
-    res["default_iris_proba"] = 0.29271032477461295
-    res["default_iris_sparse"] = 0.4
-    res["default_digits"] = 0.9156041287188829
+    res["default_iris"] = 0.98
+    res["iris_n_calls"] = 6
+    res["default_iris_iterative"] = res['default_iris']
+    res["iris_iterative_n_iter"] = 64
+    res["default_iris_proba"] = 0.27840521921952033
+    res["default_iris_sparse"] = 0.48
+    res["default_digits"] = 0.9162112932604736
     res["digits_n_calls"] = 6
-    res["default_digits_iterative"] = 0.9156041287188829
+    res["default_digits_iterative"] = res['default_digits']
     res["digits_iterative_n_iter"] = 64
-    res["default_digits_binary"] = 0.9927140255009107
-    res["default_digits_multilabel"] = 0.90997912489192
+    res["default_digits_binary"] = 0.99210686095932
+    res["default_digits_multilabel"] = 0.910908768565592
     res["default_digits_multilabel_proba"] = 1.0
-    res['ignore_hps'] = ['max_iter']
+    #res['ignore_hps'] = ['max_iter']
 
     sk_mod = sklearn.linear_model.PassiveAggressiveClassifier
     module = PassiveAggressive

--- a/test/test_pipeline/components/classification/test_passive_aggressive.py
+++ b/test/test_pipeline/components/classification/test_passive_aggressive.py
@@ -24,7 +24,6 @@ class PassiveAggressiveComponentTest(BaseClassificationComponentTest):
     res["default_digits_binary"] = 0.99210686095932
     res["default_digits_multilabel"] = 0.910908768565592
     res["default_digits_multilabel_proba"] = 1.0
-    #res['ignore_hps'] = ['max_iter']
 
     sk_mod = sklearn.linear_model.PassiveAggressiveClassifier
     module = PassiveAggressive

--- a/test/test_pipeline/components/classification/test_random_forest.py
+++ b/test/test_pipeline/components/classification/test_random_forest.py
@@ -13,15 +13,14 @@ class RandomForestComponentTest(BaseClassificationComponentTest):
     res = dict()
     res["default_iris"] = 0.96
     res["iris_n_calls"] = 9
-    res["default_iris_iterative"] = 0.95999999999999996
-    res["default_iris_proba"] = 0.09922562116542713
+    res["default_iris_iterative"] = res['default_iris']
+    res["default_iris_proba"] = 0.0996785324703419
     res["default_iris_sparse"] = 0.85999999999999999
-    # TODO find source of discrepancy!
-    res["default_digits"] = 0.9058894960534305
+    res["default_digits"] = 0.8998178506375227
     res["digits_n_calls"] = 9
-    res["default_digits_iterative"] = 0.9058894960534305
-    res["default_digits_binary"] = 0.9914996964177292
-    res["default_digits_multilabel"] = 0.9957676902536715
+    res["default_digits_iterative"] = res['default_digits']
+    res["default_digits_binary"] = 0.9896782027929569
+    res["default_digits_multilabel"] = 0.9973653110879388
     res["default_digits_multilabel_proba"] = 0.9965660960196189
 
     sk_mod = sklearn.ensemble.RandomForestClassifier

--- a/test/test_pipeline/components/classification/test_sgd.py
+++ b/test/test_pipeline/components/classification/test_sgd.py
@@ -11,16 +11,16 @@ class SGDComponentTest(BaseClassificationComponentTest):
     res = dict()
     res["default_iris"] = 0.69999999999999996
     res["iris_n_calls"] = 9
-    res["default_iris_iterative"] = 0.7
-    res["default_iris_proba"] = 0.599538539014923
+    res["default_iris_iterative"] = res['default_iris']
+    res["default_iris_proba"] = 0.5996114465819011
     res["default_iris_sparse"] = 0.54
-    res["default_digits"] = 0.9234972677595629
+    res["default_digits"] = 0.9198542805100182
     res["digits_n_calls"] = 7
-    res["default_digits_iterative"] = 0.9234972677595629
-    res["default_digits_binary"] = 0.9933211900425015
+    res["default_digits_iterative"] = res['default_digits']
+    res["default_digits_binary"] = 0.9951426836672739
     res["default_digits_multilabel"] = -1
     res["default_digits_multilabel_proba"] = -1
-    res['ignore_hps'] = ['max_iter']
+    #res['ignore_hps'] = ['max_iter']
 
     sk_mod = sklearn.linear_model.SGDClassifier
     module = SGD

--- a/test/test_pipeline/components/classification/test_sgd.py
+++ b/test/test_pipeline/components/classification/test_sgd.py
@@ -20,7 +20,6 @@ class SGDComponentTest(BaseClassificationComponentTest):
     res["default_digits_binary"] = 0.9951426836672739
     res["default_digits_multilabel"] = -1
     res["default_digits_multilabel_proba"] = -1
-    #res['ignore_hps'] = ['max_iter']
 
     sk_mod = sklearn.linear_model.SGDClassifier
     module = SGD

--- a/test/test_pipeline/components/data_preprocessing/test_balancing.py
+++ b/test/test_pipeline/components/data_preprocessing/test_balancing.py
@@ -97,7 +97,7 @@ class BalancingComponentTest(unittest.TestCase):
 
                 model_args = {
                     "random_state": 1,
-                    "include":{
+                    "include": {
                         'classifier': [name],
                         'feature_preprocessor': ['no_preprocessing']
                     }

--- a/test/test_pipeline/components/data_preprocessing/test_one_hot_encoding.py
+++ b/test/test_pipeline/components/data_preprocessing/test_one_hot_encoding.py
@@ -36,12 +36,9 @@ class OneHotEncoderTest(unittest.TestCase):
         transformations = []
         for i in range(2):
             configuration_space = OneHotEncoder.get_hyperparameter_search_space()
-            default = configuration_space.get_default_configuration()
+            default_config = configuration_space.get_default_configuration()
 
-            preprocessor = OneHotEncoder(
-                random_state=1,
-                **{hp_name: default[hp_name] for hp_name in default if default[hp_name] is not None}
-                )
+            preprocessor = OneHotEncoder(random_state=1, **default_config)
 
             transformer = preprocessor.fit(self.X_train.copy())
             Xt = transformer.transform(self.X_train.copy())
@@ -68,13 +65,9 @@ class OneHotEncoderTest(unittest.TestCase):
 
         for i in range(2):
             configuration_space = OneHotEncoder.get_hyperparameter_search_space()
-            default = configuration_space.get_default_configuration()
+            default_config = configuration_space.get_default_configuration()
 
-            preprocessor = OneHotEncoder(random_state=1,
-                                         **{hp_name: default[hp_name] for
-                                            hp_name in
-                                            default if
-                                            default[hp_name] is not None})
+            preprocessor = OneHotEncoder(random_state=1, **default_config)
 
             transformer = preprocessor.fit(self.X_train.copy())
             Xt = transformer.transform(self.X_train.copy())

--- a/test/test_pipeline/components/feature_preprocessing/test_random_trees_embedding.py
+++ b/test/test_pipeline/components/feature_preprocessing/test_random_trees_embedding.py
@@ -12,7 +12,7 @@ class RandomTreesEmbeddingComponentTest(unittest.TestCase):
     def test_default_configuration(self):
         transformation, original = _test_preprocessing(RandomTreesEmbedding)
         self.assertEqual(transformation.shape[0], original.shape[0])
-        self.assertEqual(transformation.shape[1], 216)
+        self.assertEqual(transformation.shape[1], 218)
         self.assertIsInstance(original, np.ndarray)
         self.assertTrue(scipy.sparse.issparse(transformation))
         self.assertTrue(all(transformation.data == 1))

--- a/test/test_pipeline/components/regression/test_adaboost.py
+++ b/test/test_pipeline/components/regression/test_adaboost.py
@@ -10,13 +10,13 @@ class AdaBoostComponentTest(BaseRegressionComponentTest):
     __test__ = True
 
     res = dict()
-    res["default_boston"] = 0.60525743737887405
+    res["default_boston"] = 0.5951486466070626
     res["default_boston_iterative"] = None
-    res["default_boston_sparse"] = 0.22111559712318207
+    res["default_boston_sparse"] = 0.18067558132702222
     res["default_boston_iterative_sparse"] = None
-    res["default_diabetes"] = 0.25129853514492517
+    res["default_diabetes"] = 0.250565253614339
     res["default_diabetes_iterative"] = None
-    res["default_diabetes_sparse"] = 0.09251669463036594
+    res["default_diabetes_sparse"] = 0.09126705185668416
     res["default_diabetes_iterative_sparse"] = None
 
     sk_mod = sklearn.ensemble.AdaBoostRegressor

--- a/test/test_pipeline/components/regression/test_base.py
+++ b/test/test_pipeline/components/regression/test_base.py
@@ -277,7 +277,7 @@ class BaseRegressionComponentTest(unittest.TestCase):
             self.assertEqual(params_first, params_second,
                              f"Failed with model args {model_args}")
             if (
-                hasattr(regressor.estimator, 'random_state') 
+                hasattr(regressor.estimator, 'random_state')
                 and not isinstance(regressor, LibSVM_SVR)
             ):
                 # sklearn.svm.SVR has it as an attribute but does not use it and

--- a/test/test_pipeline/components/regression/test_base.py
+++ b/test/test_pipeline/components/regression/test_base.py
@@ -6,6 +6,7 @@ import sklearn.metrics
 from autosklearn.pipeline.util import _test_regressor, \
     _test_regressor_iterative_fit
 from autosklearn.pipeline.constants import SPARSE
+from autosklearn.pipeline.components.regression.libsvm_svr import LibSVM_SVR
 
 
 class BaseRegressionComponentTest(unittest.TestCase):
@@ -25,21 +26,21 @@ class BaseRegressionComponentTest(unittest.TestCase):
         if self.__class__ == BaseRegressionComponentTest:
             return
 
-        for i in range(2):
-            predictions, targets, n_calls = \
-                _test_regressor(dataset="boston",
-                                Regressor=self.module)
+        for _ in range(2):
+            predictions, targets, n_calls = _test_regressor(
+                dataset="boston", Regressor=self.module
+            )
 
             if "default_boston_le_ge" in self.res:
                 # Special treatment for Gaussian Process Regression
                 self.assertLessEqual(
-                    sklearn.metrics.r2_score(y_true=targets,
-                                             y_pred=predictions),
-                    self.res["default_boston_le_ge"][0])
+                    sklearn.metrics.r2_score(y_true=targets, y_pred=predictions),
+                    self.res["default_boston_le_ge"][0]
+                )
                 self.assertGreaterEqual(
-                    sklearn.metrics.r2_score(y_true=targets,
-                                             y_pred=predictions),
-                    self.res["default_boston_le_ge"][1])
+                    sklearn.metrics.r2_score(y_true=targets, y_pred=predictions),
+                    self.res["default_boston_le_ge"][1]
+                )
             else:
                 score = sklearn.metrics.r2_score(targets, predictions)
                 fixture = self.res["default_boston"]
@@ -226,7 +227,7 @@ class BaseRegressionComponentTest(unittest.TestCase):
         if self.__class__ == BaseRegressionComponentTest:
             return
 
-        classifier_cls = self.module
+        regressor_cls = self.module
 
         X = np.array([
             [0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5],
@@ -245,18 +246,26 @@ class BaseRegressionComponentTest(unittest.TestCase):
         param_keys_ignored = ['base_estimator']
 
         # We use the default config + sampled ones
-        configuration_space = classifier_cls.get_hyperparameter_search_space()
+        configuration_space = regressor_cls.get_hyperparameter_search_space()
 
         default = configuration_space.get_default_configuration()
         sampled = [configuration_space.sample_configuration() for _ in range(2)]
 
         for seed, config in enumerate([default] + sampled):
             model_args = {"random_state": seed, **config}
-            classifier = classifier_cls(**model_args)
+            regressor = regressor_cls(**model_args)
 
             # Get the parameters on the first and second fit with config params
-            params_first = classifier.fit(X.copy(), y.copy()).estimator.get_params()
-            params_second = classifier.fit(X.copy(), y.copy()).estimator.get_params()
+            # Also compare their random state
+            params_first = regressor.fit(X.copy(), y.copy()).estimator.get_params()
+            if hasattr(regressor.estimator, 'random_state'):
+                rs_1 = regressor.random_state
+                rs_estimator_1 = regressor.estimator.random_state
+
+            params_second = regressor.fit(X.copy(), y.copy()).estimator.get_params()
+            if hasattr(regressor.estimator, 'random_state'):
+                rs_2 = regressor.random_state
+                rs_estimator_2 = regressor.estimator.random_state
 
             # Remove keys we don't wish to include in the comparison
             for params in [params_first, params_second]:
@@ -267,3 +276,13 @@ class BaseRegressionComponentTest(unittest.TestCase):
             # They should have equal parameters
             self.assertEqual(params_first, params_second,
                              f"Failed with model args {model_args}")
+            if (
+                hasattr(regressor.estimator, 'random_state') 
+                and not isinstance(regressor, LibSVM_SVR)
+            ):
+                # sklearn.svm.SVR has it as an attribute but does not use it and
+                # defaults it to None, even if a value is passed in
+                assert all([
+                    seed == random_state
+                    for random_state in [rs_1, rs_estimator_1, rs_2, rs_estimator_2]
+                ])

--- a/test/test_pipeline/components/regression/test_base.py
+++ b/test/test_pipeline/components/regression/test_base.py
@@ -215,7 +215,7 @@ class BaseRegressionComponentTest(unittest.TestCase):
 
     def test_module_idempotent(self):
         """ Fitting twice with the same config gives the same model params.
-        
+
             This is only valid when the random_state passed is an int. If a
             RandomState object is passed then repeated calls to fit will have
             different results. See the section on "Controlling Randomness" in the
@@ -242,7 +242,7 @@ class BaseRegressionComponentTest(unittest.TestCase):
         ])
 
         # We ignore certain keys when comparing
-        param_keys_ignored = ['base_estimator', *self.res.get('ignore_hps', [])]
+        param_keys_ignored = ['base_estimator']
 
         # We use the default config + sampled ones
         configuration_space = classifier_cls.get_hyperparameter_search_space()

--- a/test/test_pipeline/components/regression/test_base.py
+++ b/test/test_pipeline/components/regression/test_base.py
@@ -44,6 +44,7 @@ class BaseRegressionComponentTest(unittest.TestCase):
                 score = sklearn.metrics.r2_score(targets, predictions)
                 fixture = self.res["default_boston"]
                 if score < -1e10:
+                    print(f"score = {score}, fixture = {fixture}")
                     score = np.log(-score)
                     fixture = np.log(-fixture)
                 self.assertAlmostEqual(
@@ -71,6 +72,7 @@ class BaseRegressionComponentTest(unittest.TestCase):
             fixture = self.res["default_boston_iterative"]
 
             if score < -1e10:
+                print(f"score = {score}, fixture = {fixture}")
                 score = np.log(-score)
                 fixture = np.log(-fixture)
 
@@ -249,14 +251,7 @@ class BaseRegressionComponentTest(unittest.TestCase):
         sampled = [configuration_space.sample_configuration() for _ in range(2)]
 
         for seed, config in enumerate([default] + sampled):
-            model_args = {
-                'random_state': seed,  # This must be an int, see test doc
-                ** {
-                    hp_name: config[hp_name]
-                    for hp_name in config
-                    if config[hp_name] is not None
-                }
-            }
+            model_args = {"random_state": seed, **config}
             classifier = classifier_cls(**model_args)
 
             # Get the parameters on the first and second fit with config params

--- a/test/test_pipeline/components/regression/test_extra_trees.py
+++ b/test/test_pipeline/components/regression/test_extra_trees.py
@@ -10,16 +10,16 @@ class ExtraTreesComponentTest(BaseRegressionComponentTest):
     __test__ = True
 
     res = dict()
-    res["default_boston"] = 0.8547046708967643
+    res["default_boston"] = 0.8539264243687228
     res["boston_n_calls"] = 9
-    res["default_boston_iterative"] = 0.8547046708967643
-    res["default_boston_sparse"] = 0.419556142451604
-    res["default_boston_iterative_sparse"] = 0.419556142451604
-    res["default_diabetes"] = 0.39073511653135706
+    res["default_boston_iterative"] = res['default_boston']
+    res["default_boston_sparse"] = 0.411211701806908
+    res["default_boston_iterative_sparse"] = res['default_boston_sparse']
+    res["default_diabetes"] = 0.3885150255877827
     res["diabetes_n_calls"] = 9
-    res["default_diabetes_iterative"] = 0.39073511653135706
-    res["default_diabetes_sparse"] = 0.24547114408164694
-    res["default_diabetes_iterative_sparse"] = 0.24547114408164694
+    res["default_diabetes_iterative"] = res['default_diabetes']
+    res["default_diabetes_sparse"] = 0.2422804139169642
+    res["default_diabetes_iterative_sparse"] = res['default_diabetes_sparse']
 
     sk_mod = sklearn.ensemble.ExtraTreesRegressor
     module = ExtraTreesRegressor

--- a/test/test_pipeline/components/regression/test_gaussian_process.py
+++ b/test/test_pipeline/components/regression/test_gaussian_process.py
@@ -16,7 +16,7 @@ class GaussianProcessComponentTest(BaseRegressionComponentTest):
     res["default_boston_iterative"] = None
     res["default_boston_sparse"] = None
     res["default_boston_iterative_sparse"] = None
-    res["default_diabetes"] = -7.4131230585194885e-06
+    res["default_diabetes"] = -0.017256687184589836
     res["default_diabetes_iterative"] = None
     res["default_diabetes_sparse"] = None
     res["default_diabetes_iterative_sparse"] = None

--- a/test/test_pipeline/components/regression/test_mlp.py
+++ b/test/test_pipeline/components/regression/test_mlp.py
@@ -6,12 +6,29 @@ from .test_base import BaseRegressionComponentTest
 
 
 class MLPComponentTest(BaseRegressionComponentTest):
+    # NOTE: `default_boston`
+    #
+    # Github runners seem to indeterministicly fail `test_boston`
+    # meaning 'default_irish_proba_places' needs to be set.
+    # There are known differences to occur on different platforms.
+    # https://github.com/scikit-learn/scikit-learn/issues/13108#issuecomment-461696681
+    #
+    # We are assuming results are deterministic on a given platform as locally
+    # there is no randomness i.e. performing the same test 100 times yeilds the
+    # same predictions 100 times.
+    #
+    # Github runners indicate that they run on microsoft Azure with DS2-v2.
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#cloud-hosts-for-github-hosted-runners
+    #
+    # These seem to have consistent CPU's so I'm unsure what the underlying reason
+    # for this to randomly fail only sometimes on Github runners
+    __test__ = True
 
     __test__ = True
 
     res = dict()
     res["default_boston"] = 0.2750079862455884
-    res["default_boston_places"] = 4
+    res["default_boston_places"] = 3
     res["boston_n_calls"] = 8
     res["boston_iterative_n_iter"] = 236
     res["default_boston_iterative"] = res["default_boston"]

--- a/test/test_pipeline/components/regression/test_mlp.py
+++ b/test/test_pipeline/components/regression/test_mlp.py
@@ -10,21 +10,21 @@ class MLPComponentTest(BaseRegressionComponentTest):
     __test__ = True
 
     res = dict()
-    res["default_boston"] = 0.3622815479003514
+    res["default_boston"] = 0.2750079862455884
     res["default_boston_places"] = 4
     res["boston_n_calls"] = 8
-    res["boston_iterative_n_iter"] = 161
+    res["boston_iterative_n_iter"] = 236
     res["default_boston_iterative"] = res["default_boston"]
     res["default_boston_iterative_places"] = 1
-    res["default_boston_sparse"] = -0.4663396612593085
+    res["default_boston_sparse"] = -0.10972947168054104
     res["default_boston_sparse_places"] = 6
     res["default_boston_iterative_sparse"] = res["default_boston_sparse"]
     res["default_boston_iterative_sparse_places"] = 6
-    res["default_diabetes"] = 0.33660371480430984
+    res["default_diabetes"] = 0.35917389841850555
     res["diabetes_n_calls"] = 9
-    res["diabetes_iterative_n_iter"] = 106
+    res["diabetes_iterative_n_iter"] = 435
     res["default_diabetes_iterative"] = res["default_diabetes"]
-    res["default_diabetes_sparse"] = 0.033787581215897866
+    res["default_diabetes_sparse"] = 0.25573903970369427
     res["default_diabetes_iterative_sparse"] = res["default_diabetes_sparse"]
 
     sk_mod = sklearn.neural_network.MLPRegressor

--- a/test/test_pipeline/components/regression/test_random_forests.py
+++ b/test/test_pipeline/components/regression/test_random_forests.py
@@ -9,16 +9,16 @@ class RandomForestComponentTest(BaseRegressionComponentTest):
     __test__ = True
 
     res = dict()
-    res["default_boston"] = 0.841295107582696
+    res["default_boston"] = 0.8410063895401654
     res["boston_n_calls"] = 9
-    res["default_boston_iterative"] = 0.841295107582696
-    res["default_boston_sparse"] = 0.4256329804087612
-    res["default_boston_iterative_sparse"] = 0.4256329804087612
-    res["default_diabetes"] = 0.3438707361168547
+    res["default_boston_iterative"] = res['default_boston']
+    res["default_boston_sparse"] = 0.4194462097407078
+    res["default_boston_iterative_sparse"] = res['default_boston_sparse']
+    res["default_diabetes"] = 0.3496051170409269
     res["diabetes_n_calls"] = 9
-    res["default_diabetes_iterative"] = 0.3438707361168547
-    res["default_diabetes_sparse"] = 0.24330715569007455
-    res["default_diabetes_iterative_sparse"] = 0.24330715569007455
+    res["default_diabetes_iterative"] = res['default_diabetes']
+    res["default_diabetes_sparse"] = 0.2383300978781976
+    res["default_diabetes_iterative_sparse"] = res['default_diabetes_sparse']
 
     sk_mod = sklearn.ensemble.RandomForestRegressor
     module = RandomForest

--- a/test/test_pipeline/components/regression/test_sgd.py
+++ b/test/test_pipeline/components/regression/test_sgd.py
@@ -10,16 +10,16 @@ class SGDComponentTest(BaseRegressionComponentTest):
     # Values are extremely bad because the invscaling does not drop the
     # learning rate aggressively enough!
     res = dict()
-    res["default_boston"] = -3.7203740888187194e+28
+    res["default_boston"] = -1.1811672998629865e+28
     res["boston_n_calls"] = 6
-    res["default_boston_iterative"] = -3.7203740888187194e+28
-    res["default_boston_sparse"] = -2.5490406459756767e+28
-    res["default_boston_iterative_sparse"] = -2.5490406459756767e+28
-    res["default_diabetes"] = 0.2731178369559112
+    res["default_boston_iterative"] = res['default_boston']
+    res["default_boston_sparse"] = -1.1518512489347601e+28
+    res["default_boston_iterative_sparse"] = res['default_boston_sparse']
+    res["default_diabetes"] = 0.27420813549185374
     res["diabetes_n_calls"] = 10
-    res["default_diabetes_iterative"] = 0.2731178369559112
-    res["default_diabetes_sparse"] = 0.03484084539994714
-    res["default_diabetes_iterative_sparse"] = 0.03484084539994714
+    res["default_diabetes_iterative"] = res['default_diabetes']
+    res["default_diabetes_sparse"] = 0.034801785011824404
+    res["default_diabetes_iterative_sparse"] = res['default_diabetes_sparse']
 
     sk_mod = sklearn.linear_model.SGDRegressor
     module = SGD

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -780,7 +780,10 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         This method tests that the set hyperparameters actually create objects
         that comply with the given configuration. It iterates trough the pipeline to
         make sure we did not miss a step, but also checks at the end that every
-        configuration from Config was checked
+        configuration from Config was checked.
+
+        Also considers random_state and ensures pipeline steps correctly recieve
+        the right random_state
         """
 
         all_combinations = list(itertools.product([True, False], repeat=4))
@@ -791,8 +794,9 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                 'multiclass': multiclass,
                 'signed': signed,
             }
+            random_state = 1
             cls = SimpleClassificationPipeline(
-                random_state=1,
+                random_state=random_state,
                 dataset_properties=dataset_properties,
             )
             cs = cls.get_hyperparameter_search_space()
@@ -814,6 +818,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                             'data_preprocessor:__choice__', step, config_dict
                         )
                     )
+                    self.assertEqual(step.random_state, random_state)
                 elif name == 'balancing':
                     keys_checked.extend(
                         self._test_set_hyperparameter_component(
@@ -827,12 +832,14 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                             'feature_preprocessor:__choice__', step, config_dict
                         )
                     )
+                    self.assertEqual(step.random_state, random_state)
                 elif name == 'classifier':
                     keys_checked.extend(
                         self._test_set_hyperparameter_choice(
                             'classifier:__choice__', step, config_dict
                         )
                     )
+                    self.assertEqual(step.random_state, random_state)
                 else:
                     raise ValueError("Found another type of step! Need to update this check")
 

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -352,7 +352,6 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                     check_is_fitted(step)
 
             try:
-                print(cls.steps)
                 cls.fit(X_train, Y_train)
 
                 # After fit, all components should be tagged as fitted

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -142,7 +142,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
     def test_default_configuration(self):
         for i in range(2):
             X_train, Y_train, X_test, Y_test = get_dataset(dataset='iris')
-            auto = SimpleClassificationPipeline()
+            auto = SimpleClassificationPipeline(random_state=1)
             auto = auto.fit(X_train, Y_train)
             predictions = auto.predict(X_test)
             self.assertAlmostEqual(0.96, sklearn.metrics.accuracy_score(predictions, Y_test))
@@ -150,9 +150,10 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
 
     def test_default_configuration_multilabel(self):
         for i in range(2):
-            dataset_properties = {'multilabel': True}
             classifier = SimpleClassificationPipeline(
-                dataset_properties=dataset_properties)
+                random_state=1,
+                dataset_properties={'multilabel': True}
+            )
             cs = classifier.get_hyperparameter_search_space()
             default = cs.get_default_configuration()
             X_train, Y_train, X_test, Y_test = get_dataset(dataset='iris',
@@ -167,14 +168,19 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
 
     def test_default_configuration_iterative_fit(self):
         classifier = SimpleClassificationPipeline(
-            include={'classifier': ['random_forest'],
-                     'feature_preprocessor': ['no_preprocessing']})
+            random_state=1,
+            include={
+                'classifier': ['random_forest'],
+                'feature_preprocessor': ['no_preprocessing']
+            }
+        )
         X_train, Y_train, X_test, Y_test = get_dataset(dataset='iris')
         classifier.fit_transformer(X_train, Y_train)
         for i in range(1, 11):
             classifier.iterative_fit(X_train, Y_train)
-            self.assertEqual(classifier.steps[-1][-1].choice.estimator.n_estimators,
-                             i)
+            self.assertEqual(
+                classifier.steps[-1][-1].choice.estimator.n_estimators, i
+            )
 
     def test_repr(self):
         representation = repr(SimpleClassificationPipeline())
@@ -233,6 +239,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
     def test_configurations_categorical_data(self):
         cs = SimpleClassificationPipeline(
             dataset_properties={'sparse': False},
+            random_state=1,
             include={
                 'feature_preprocessor': ['no_preprocessing'],
                 'classifier': ['sgd', 'adaboost']

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -212,8 +212,8 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         self._test_configurations(configurations_space=cs, data=data)
 
     def test_configurations(self):
-        cs = SimpleClassificationPipeline().get_hyperparameter_search_space()
-
+        cls = SimpleClassificationPipeline()
+        cs = cls.get_hyperparameter_search_space()
         self._test_configurations(configurations_space=cs)
 
     def test_configurations_signed_data(self):
@@ -300,8 +300,6 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         limit = 3072 * 1024 * 1024
         resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
 
-        print(configurations_space)
-
         for i in range(10):
             config = configurations_space.sample_configuration()
             config._populate_values()
@@ -329,8 +327,6 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                         config[restrict_parameter] is not None:
                     config._values[restrict_parameter] = restrict_to
 
-            print(config)
-
             if data is None:
                 X_train, Y_train, X_test, Y_test = get_dataset(
                     dataset='digits', make_sparse=make_sparse, add_NaNs=True)
@@ -341,9 +337,11 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                 data['Y_test'].copy()
 
             init_params_ = copy.deepcopy(init_params)
-            cls = SimpleClassificationPipeline(random_state=1,
-                                               dataset_properties=dataset_properties,
-                                               init_params=init_params_,)
+            cls = SimpleClassificationPipeline(
+                random_state=1,
+                dataset_properties=dataset_properties,
+                init_params=init_params_,
+            )
             cls.set_hyperparameters(config, init_params=init_params_)
 
             # First make sure that for this configuration, setting the parameters
@@ -354,6 +352,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                     check_is_fitted(step)
 
             try:
+                print(cls.steps)
                 cls.fit(X_train, Y_train)
 
                 # After fit, all components should be tagged as fitted

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -559,6 +559,9 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         that comply with the given configuration. It iterates trough the pipeline to
         make sure we did not miss a step, but also checks at the end that every
         configuration from Config was checked
+
+        Also considers random_state and ensures pipeline steps correctly recieve
+        the right random_state
         """
 
         all_combinations = list(itertools.product([True, False], repeat=4))
@@ -569,8 +572,9 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                 'multiclass': multiclass,
                 'signed': signed,
             }
+            random_state = 1
             auto = SimpleRegressionPipeline(
-                random_state=1,
+                random_state=random_state,
                 dataset_properties=dataset_properties,
             )
             cs = auto.get_hyperparameter_search_space()
@@ -592,25 +596,21 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                             'data_preprocessor:__choice__', step, config_dict
                         )
                     )
-                elif name == 'balancing':
-                    keys_checked.extend(
-                        self._test_set_hyperparameter_component(
-                            'balancing',
-                            step, config_dict
-                        )
-                    )
+                    self.assertEqual(step.random_state, random_state)
                 elif name == 'feature_preprocessor':
                     keys_checked.extend(
                         self._test_set_hyperparameter_choice(
                             'feature_preprocessor:__choice__', step, config_dict
                         )
                     )
+                    self.assertEqual(step.random_state, random_state)
                 elif name == 'regressor':
                     keys_checked.extend(
                         self._test_set_hyperparameter_choice(
                             'regressor:__choice__', step, config_dict
                         )
                     )
+                    self.assertEqual(step.random_state, random_state)
                 else:
                     raise ValueError("Found another type of step! Need to update this check"
                                      " {}. ".format(name)

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -166,8 +166,10 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                 X_test = data['X_test'].copy()
                 data['Y_test'].copy()
 
-            cls = SimpleRegressionPipeline(random_state=1,
-                                           dataset_properties=dataset_properties)
+            cls = SimpleRegressionPipeline(
+                random_state=1,
+                dataset_properties=dataset_properties
+            )
             cls.set_hyperparameters(config)
 
             # First make sure that for this configuration, setting the parameters
@@ -247,7 +249,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
     def test_default_configuration(self):
         for i in range(2):
             X_train, Y_train, X_test, Y_test = get_dataset(dataset='diabetes')
-            auto = SimpleRegressionPipeline()
+            auto = SimpleRegressionPipeline(random_state=1)
             auto = auto.fit(X_train, Y_train)
             predictions = auto.predict(copy.deepcopy(X_test))
             # The lower the worse
@@ -258,8 +260,12 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
 
     def test_default_configuration_iterative_fit(self):
         regressor = SimpleRegressionPipeline(
-            include={'regressor': ['random_forest'],
-                     'feature_preprocessor': ['no_preprocessing']})
+            random_state=1,
+            include={
+                'regressor': ['random_forest'],
+                'feature_preprocessor': ['no_preprocessing']
+            }
+        )
         X_train, Y_train, X_test, Y_test = get_dataset(dataset='boston')
         regressor.fit_transformer(X_train, Y_train)
         for i in range(1, 11):
@@ -283,42 +289,53 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         self.assertEqual(len(forbiddens), 35)
 
     def test_get_hyperparameter_search_space_include_exclude_models(self):
-        cs = SimpleRegressionPipeline(
-            include={'regressor': ['random_forest']}).get_hyperparameter_search_space()
+        regressor = SimpleRegressionPipeline(
+            include={'regressor': ['random_forest']}
+        )
+        cs = regressor.get_hyperparameter_search_space()
         self.assertEqual(
             cs.get_hyperparameter('regressor:__choice__'),
             CategoricalHyperparameter('regressor:__choice__', ['random_forest']),
-            )
+        )
 
         # TODO add this test when more than one regressor is present
-        cs = SimpleRegressionPipeline(exclude={'regressor': ['random_forest']}).\
-            get_hyperparameter_search_space()
+        regressor = SimpleRegressionPipeline(
+            exclude={'regressor': ['random_forest']}
+        )
+        cs = regressor.get_hyperparameter_search_space()
         self.assertNotIn('random_forest', str(cs))
 
-        cs = SimpleRegressionPipeline(include={'feature_preprocessor': ['pca']}).\
-            get_hyperparameter_search_space()
+        regressor = SimpleRegressionPipeline(
+            include={'feature_preprocessor': ['pca']}
+        )
+        cs = regressor.get_hyperparameter_search_space()
         self.assertEqual(cs.get_hyperparameter(
             'feature_preprocessor:__choice__'),
             CategoricalHyperparameter('feature_preprocessor:__choice__', ['pca']))
 
-        cs = SimpleRegressionPipeline(
-            exclude={'feature_preprocessor': ['no_preprocessing']}).\
-            get_hyperparameter_search_space()
+        regressor = SimpleRegressionPipeline(
+            exclude={'feature_preprocessor': ['no_preprocessing']}
+        )
+        cs = regressor.get_hyperparameter_search_space()
         self.assertNotIn('no_preprocessing', str(cs))
 
     def test_get_hyperparameter_search_space_preprocessor_contradicts_default_classifier(
-            self):
-        cs = SimpleRegressionPipeline(include={'feature_preprocessor': ['densifier']},
-                                      dataset_properties={'sparse': True}).\
-            get_hyperparameter_search_space()
+        self
+    ):
+        regressor = SimpleRegressionPipeline(
+            include={'feature_preprocessor': ['densifier']},
+            dataset_properties={'sparse': True}
+        )
+        cs = regressor.get_hyperparameter_search_space()
         self.assertEqual(
             cs.get_hyperparameter('regressor:__choice__').default_value,
             'gradient_boosting'
         )
 
-        cs = SimpleRegressionPipeline(
-            include={'feature_preprocessor': ['nystroem_sampler']}).\
-            get_hyperparameter_search_space()
+        regressor = SimpleRegressionPipeline(
+            include={'feature_preprocessor': ['nystroem_sampler']}
+        )
+        cs = regressor.get_hyperparameter_search_space()
         self.assertEqual(
             cs.get_hyperparameter('regressor:__choice__').default_value,
             'sgd'
@@ -385,7 +402,11 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         include = {'regressor': ['decision_tree']}
         cs = SimpleRegressionPipeline(include=include).get_hyperparameter_search_space()
         default = cs.get_default_configuration()
-        regressor = SimpleRegressionPipeline(default, include=include)
+        regressor = SimpleRegressionPipeline(
+            config=default,
+            random_state=1,
+            include=include
+        )
 
         X_train, Y_train, X_test, Y_test = get_dataset(dataset='boston')
         regressor.fit(X_train, Y_train)
@@ -401,12 +422,19 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
     def test_predict_batched_sparse(self):
         dataset_properties = {'sparse': True}
         include = {'regressor': ['decision_tree']}
-        cs = SimpleRegressionPipeline(dataset_properties=dataset_properties,
-                                      include=include).get_hyperparameter_search_space()
+
+        cs = SimpleRegressionPipeline(
+            dataset_properties=dataset_properties,
+            include=include
+        ).get_hyperparameter_search_space()
+
         default = cs.get_default_configuration()
-        regressor = SimpleRegressionPipeline(default,
-                                             dataset_properties=dataset_properties,
-                                             include=include)
+        regressor = SimpleRegressionPipeline(
+            config=default,
+            random_state=1,
+            dataset_properties=dataset_properties,
+            include=include
+        )
 
         X_train, Y_train, X_test, Y_test = get_dataset(dataset='boston',
                                                        make_sparse=True)
@@ -434,7 +462,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
 
     def test_pipeline_clonability(self):
         X_train, Y_train, X_test, Y_test = get_dataset(dataset='boston')
-        auto = SimpleRegressionPipeline()
+        auto = SimpleRegressionPipeline(random_state=1)
         auto = auto.fit(X_train, Y_train)
         auto_clone = clone(auto)
         auto_clone_params = auto_clone.get_params()


### PR DESCRIPTION
Previously in PR #1226

# Fixes
* Issue #1209 - `test_model_idemponteness` was failing 
    * Tests using RandomState  and calling `fit()` twice were unaware of [sklearn's contract on determinism](https://scikit-learn.org/stable/common_pitfalls.html#controlling-randomness).
* Iterative algorithms no longer have different results when fit normally or through iterative fits
    * Fixed by using integer random_state as opposed to RandomState object
* Pipeline steps now correctly receive `random_state`
   * Pipeline steps were previously not recieving the components `random_state` on construction

Most of these issues were fixed by following paths along which random_state was passed down

# Major Changes
* Pipeline steps should now be deterministic
* Auto-sklearn now respects [sklearn's contract](https://scikit-learn.org/stable/common_pitfalls.html#controlling-randomness) for `random_state`

# Minor Changes
* Tests for random_state correctly being set in pipeline steps
* Updates test values for components with new seeds and re-align iterative with non iterative results
* Removes 'max_iter' being hyperparameters ignored during idempotent tests
* Updated parameter types
* A little bit of code documentation
* Code cleanup