### PR TITLE
Docker installation update

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -169,7 +169,7 @@ To start a Jupyter notebook, you could instead run e.g.:
 
 .. code:: bash
 
-    docker run -it -v $PWD:/opt/nb -p 8888:8888 mfeurer/auto-sklearn:master /bin/bash -c "mkdir -p /opt/nb && jupyter notebook --notebook-dir=/opt/nb --ip='0.0.0.0' --port=8888 --no-browser --allow-root"
+    docker run -it -v ${PWD}:/opt/nb -p 8888:8888 mfeurer/auto-sklearn:master /bin/bash -c "mkdir -p /opt/nb && jupyter notebook --notebook-dir=/opt/nb --ip='0.0.0.0' --port=8888 --no-browser --allow-root"
 
 Alternatively, it is possible to use the development version of auto-sklearn by replacing all
 occurences of ``master`` by ``development``.


### PR DESCRIPTION
Updates the command basedon [this comment](https://github.com/automl/auto-sklearn/issues/320#issuecomment-723574933) so it should work for Linux and Windows users. Unix systems should be able to identify that in the full string `$PWD:/opt/nb` that `$PWD` is the environment variable. If it's broken on Windows and requires the `${}` escape then it seems Windows does not recognize it.

Before as just `$PWD`:

`docker run -it -v $PWD:/opt/nb -p 8888:8888 mfeurer/auto-sklearn:master /bin/bash -c "mkdir -p /opt/nb && jupyter notebook --notebook-dir=/opt/nb --ip='0.0.0.0' --port=8888 --no-browser --allow-root"`

After as `${PWD}`:

`docker run -it -v ${PWD}:/opt/nb -p 8888:8888 mfeurer/auto-sklearn:master /bin/bash -c "mkdir -p /opt/nb && jupyter notebook --notebook-dir=/opt/nb --ip='0.0.0.0' --port=8888 --no-browser --allow-root"`
