### PR TITLE
Updates pip install instructions

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -31,7 +31,7 @@ You can install *auto-sklearn* with `pip` in the usual manner:
 
 .. code:: bash
 
-    pip install auto-sklearn
+    pip3 install auto-sklearn
 
 We recommend installing *auto-sklearn* into a
 `virtual environment <https://docs.python-guide.org/dev/virtualenvs/>`_

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -27,24 +27,18 @@ check the Section `Windows/OSX compatibility`_.
 Installing auto-sklearn
 =======================
 
-Please install all dependencies manually with:
+You can install *auto-sklearn* with `pip` in the usual manner:
 
 .. code:: bash
 
-    curl https://raw.githubusercontent.com/automl/auto-sklearn/master/requirements.txt | xargs -n 1 -L 1 pip3 install
-
-Then install *auto-sklearn*:
-
-.. code:: bash
-
-    pip3 install auto-sklearn
+    pip install auto-sklearn
 
 We recommend installing *auto-sklearn* into a
 `virtual environment <https://docs.python-guide.org/dev/virtualenvs/>`_
 or an
 `Anaconda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_.
 
-If the ``pip3`` installation command fails, make sure you have the `System requirements`_ installed correctly.
+If the ``pip`` installation command fails, make sure you have the `System requirements`_ installed correctly.
 
 Ubuntu installation
 ===================

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -38,7 +38,7 @@ We recommend installing *auto-sklearn* into a
 or an
 `Anaconda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_.
 
-If the ``pip`` installation command fails, make sure you have the `System requirements`_ installed correctly.
+If the ``pip3`` installation command fails, make sure you have the `System requirements`_ installed correctly.
 
 Ubuntu installation
 ===================


### PR DESCRIPTION
Previously we had a longer install process but due to the introduction of pre-built wheels, we can install auto-sklearn with a simple `pip install auto-sklearn`.