### PR TITLE
Clearup warnings

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -690,7 +690,7 @@ class AutoML(BaseEstimator):
         self._logger.debug('Starting to print environment information')
         self._logger.debug('  Python version: %s', sys.version.split('\n'))
         try:
-            self._logger.debug('  Distribution: %s', distro.linux_distribution())
+            self._logger.debug(f'\tDistribution: {distro.id()}-{distro.version()}-{distro.name()}')
         except AttributeError:
             pass
 

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 import copy
+import distro
 import io
 import json
 import platform
@@ -689,11 +690,10 @@ class AutoML(BaseEstimator):
         self._logger.debug('Starting to print environment information')
         self._logger.debug('  Python version: %s', sys.version.split('\n'))
         try:
-            self._logger.debug('  Distribution: %s', platform.linux_distribution())
+            self._logger.debug('  Distribution: %s', distro.linux_distribution())
         except AttributeError:
-            # platform.linux_distribution() was removed in Python3.8
-            # We should move to the distro package as soon as it supports Windows and OSX
             pass
+
         self._logger.debug('  System: %s', platform.system())
         self._logger.debug('  Machine: %s', platform.machine())
         self._logger.debug('  Platform: %s', platform.platform())

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -228,7 +228,7 @@ class AutoSklearnEstimator(BaseEstimator):
         Attributes
         ----------
 
-        cv_results\_ : dict of numpy (masked) ndarrays
+        cv_results_ : dict of numpy (masked) ndarrays
             A dict with keys as column headers and values as columns, that can be
             imported into a pandas ``DataFrame``.
 

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -234,7 +234,7 @@ class AutoSklearnEstimator(BaseEstimator):
 
             Not all keys returned by scikit-learn are supported yet.
 
-        performance_over_time\_ : pandas.core.frame.DataFrame
+        performance_over_time_ : pandas.core.frame.DataFrame
             A ``DataFrame`` containing the models performance over time data. Can be
             used for plotting directly. Please refer to the example
             :ref:`Train and Test Inputs <sphx_glr_examples_40_advanced_example_pandas_train_test.py>`.

--- a/autosklearn/metalearning/metafeatures/metafeatures.py
+++ b/autosklearn/metalearning/metafeatures/metafeatures.py
@@ -184,7 +184,7 @@ class MissingValues(HelperFunction):
     def _calculate_sparse(self, X, y, logger, categorical):
         data = [True if not np.isfinite(x) else False for x in X.data]
         missing = X.__class__((data, X.indices, X.indptr), shape=X.shape,
-                              dtype=np.bool)
+                              dtype=bool)
         return missing
 
 

--- a/autosklearn/metalearning/metalearning/meta_base.py
+++ b/autosklearn/metalearning/metalearning/meta_base.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import numpy as np
 import pandas as pd
 
@@ -39,7 +41,7 @@ class MetaBase(object):
 
         aslib_reader = aslib_simple.AlgorithmSelectionProblem(self.aslib_directory)
         self.metafeatures = aslib_reader.metafeatures
-        self.algorithm_runs = aslib_reader.algorithm_runs
+        self.algorithm_runs: OrderedDict[str, pd.DataFrame] = aslib_reader.algorithm_runs
         self.configurations = aslib_reader.configurations
 
         configurations = dict()
@@ -65,7 +67,7 @@ class MetaBase(object):
             self.metafeatures.drop(name.lower(), inplace=True)
         self.metafeatures = self.metafeatures.append(metafeatures)
 
-        runs = pd.Series([], name=name, dtype=object)
+        runs = pd.Series([], name=name, dtype=float)
         for metric in self.algorithm_runs.keys():
             self.algorithm_runs[metric].append(runs)
 

--- a/autosklearn/metalearning/metalearning/meta_base.py
+++ b/autosklearn/metalearning/metalearning/meta_base.py
@@ -65,7 +65,7 @@ class MetaBase(object):
             self.metafeatures.drop(name.lower(), inplace=True)
         self.metafeatures = self.metafeatures.append(metafeatures)
 
-        runs = pd.Series([], name=name)
+        runs = pd.Series([], name=name, dtype=object)
         for metric in self.algorithm_runs.keys():
             self.algorithm_runs[metric].append(runs)
 

--- a/autosklearn/metalearning/optimizers/metalearn_optimizer/metalearner.py
+++ b/autosklearn/metalearning/optimizers/metalearn_optimizer/metalearner.py
@@ -111,7 +111,8 @@ class MetaLearningOptimizer(object):
                 except KeyError:
                     # TODO should I really except this?
                     self.logger.info("Could not find runs for instance %s" % task_id)
-                    runs[task_id] = pd.Series([], name=task_id, dtype=object)
+                    runs[task_id] = pd.Series([], name=task_id, dtype=np.float64)
+
             runs = pd.DataFrame(runs)
 
             kND.fit(all_other_metafeatures, runs)

--- a/autosklearn/metalearning/optimizers/metalearn_optimizer/metalearner.py
+++ b/autosklearn/metalearning/optimizers/metalearn_optimizer/metalearner.py
@@ -111,7 +111,7 @@ class MetaLearningOptimizer(object):
                 except KeyError:
                     # TODO should I really except this?
                     self.logger.info("Could not find runs for instance %s" % task_id)
-                    runs[task_id] = pd.Series([], name=task_id)
+                    runs[task_id] = pd.Series([], name=task_id, dtype=object)
             runs = pd.DataFrame(runs)
 
             kND.fit(all_other_metafeatures, runs)

--- a/autosklearn/metrics/__init__.py
+++ b/autosklearn/metrics/__init__.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from functools import partial
+from itertools import product
 from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 import numpy as np
@@ -278,16 +279,14 @@ median_absolute_error = make_scorer('median_absolute_error',
                                     optimum=0,
                                     worst_possible_result=MAXINT,
                                     greater_is_better=False)
-r2 = make_scorer('r2',
-                 sklearn.metrics.r2_score)
+
+r2 = make_scorer('r2', sklearn.metrics.r2_score)
 
 # Standard Classification Scores
 accuracy = make_scorer('accuracy',
                        sklearn.metrics.accuracy_score)
 balanced_accuracy = make_scorer('balanced_accuracy',
                                 sklearn.metrics.balanced_accuracy_score)
-f1 = make_scorer('f1',
-                 sklearn.metrics.f1_score)
 
 # Score functions that need decision values
 roc_auc = make_scorer('roc_auc',
@@ -297,10 +296,20 @@ roc_auc = make_scorer('roc_auc',
 average_precision = make_scorer('average_precision',
                                 sklearn.metrics.average_precision_score,
                                 needs_threshold=True)
-precision = make_scorer('precision',
-                        sklearn.metrics.precision_score)
-recall = make_scorer('recall',
-                     sklearn.metrics.recall_score)
+
+# NOTE: zero_division
+#
+#   Specified as the explicit default, see sklearn docs:
+#   https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html#sklearn-metrics-precision-score
+precision = make_scorer(
+    'precision', partial(sklearn.metrics.precision_score, zero_division=0)
+)
+recall = make_scorer(
+    'recall', partial(sklearn.metrics.recall_score, zero_division=0)
+)
+f1 = make_scorer(
+    'f1', partial(sklearn.metrics.f1_score, zero_division=0)
+)
 
 # Score function for probabilistic classification
 log_loss = make_scorer('log_loss',
@@ -312,29 +321,37 @@ log_loss = make_scorer('log_loss',
 # TODO what about mathews correlation coefficient etc?
 
 
-REGRESSION_METRICS = dict()
-for scorer in [mean_absolute_error, mean_squared_error, root_mean_squared_error,
-               mean_squared_log_error, median_absolute_error, r2]:
-    REGRESSION_METRICS[scorer.name] = scorer
+REGRESSION_METRICS = {
+    scorer.name: scorer
+    for scorer in [
+        mean_absolute_error, mean_squared_error, root_mean_squared_error,
+        mean_squared_log_error, median_absolute_error, r2
+    ]
+}
 
-CLASSIFICATION_METRICS = dict()
+CLASSIFICATION_METRICS = {
+    scorer.name: scorer
+    for scorer in [
+        accuracy, balanced_accuracy, roc_auc, average_precision, log_loss
+    ]
+}
 
-for scorer in [accuracy, balanced_accuracy, roc_auc, average_precision,
-               log_loss]:
-    CLASSIFICATION_METRICS[scorer.name] = scorer
-
-for name, metric in [('precision', sklearn.metrics.precision_score),
-                     ('recall', sklearn.metrics.recall_score),
-                     ('f1', sklearn.metrics.f1_score)]:
-    globals()[name] = make_scorer(name, metric)
-    CLASSIFICATION_METRICS[name] = globals()[name]
-    for average in ['macro', 'micro', 'samples', 'weighted']:
-        qualified_name = '{0}_{1}'.format(name, average)
-        globals()[qualified_name] = make_scorer(qualified_name,
-                                                partial(metric,
-                                                        pos_label=None,
-                                                        average=average))
-        CLASSIFICATION_METRICS[qualified_name] = globals()[qualified_name]
+# NOTE: zero_division
+#
+#   Specified as the explicit default, see sklearn docs:
+#   https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html#sklearn-metrics-precision-score
+for (base_name, sklearn_metric), average in product(
+    [
+        ('precision', sklearn.metrics.precision_score),
+        ('recall', sklearn.metrics.recall_score),
+        ('f1', sklearn.metrics.f1_score),
+    ],
+    ['macro', 'micro', 'samples', 'weighted']
+):
+    name = f'{base_name}_{average}'
+    CLASSIFICATION_METRICS[name] = make_scorer(
+        name, partial(sklearn_metric, pos_label=None, average=average, zero_division=0)
+    )
 
 
 def calculate_score(

--- a/autosklearn/metrics/__init__.py
+++ b/autosklearn/metrics/__init__.py
@@ -349,9 +349,11 @@ for (base_name, sklearn_metric), average in product(
     ['macro', 'micro', 'samples', 'weighted']
 ):
     name = f'{base_name}_{average}'
-    CLASSIFICATION_METRICS[name] = make_scorer(
+    scorer = make_scorer(
         name, partial(sklearn_metric, pos_label=None, average=average, zero_division=0)
     )
+    globals()[name] = scorer  # Adds scorer to the module scope
+    CLASSIFICATION_METRICS[name] = scorer
 
 
 def calculate_score(

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -10,6 +10,7 @@ from sklearn.exceptions import ConvergenceWarning
 
 from autosklearn.pipeline.constants import SPARSE
 
+
 def find_components(package, directory, base_class):
     components = OrderedDict()
 

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -152,6 +152,7 @@ class IterativeComponent(AutoSklearnComponent):
         while not self.configuration_fully_fitted():
             n_iter = int(2 ** iteration / 2)
             self.iterative_fit(X, y, n_iter=n_iter, refit=False)
+            iteration += 1
 
         return self
 
@@ -172,6 +173,7 @@ class IterativeComponentWithSampleWeight(AutoSklearnComponent):
         while not self.configuration_fully_fitted():
             n_iter = int(2 ** iteration / 2)
             self.iterative_fit(X, y, n_iter=n_iter, refit=False, sample_weight=sample_weight)
+            iteration += 1
 
         return self
 

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -3,8 +3,10 @@ import importlib
 import inspect
 import pkgutil
 import sys
+import warnings
 
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.exceptions import ConvergenceWarning
 
 from autosklearn.pipeline.constants import SPARSE
 
@@ -145,12 +147,21 @@ class AutoSklearnComponent(BaseEstimator):
 
 class IterativeComponent(AutoSklearnComponent):
     def fit(self, X, y, sample_weight=None):
-        self.iterative_fit(X, y, n_iter=2, refit=True)
-        iteration = 2
-        while not self.configuration_fully_fitted():
-            n_iter = int(2 ** iteration / 2)
-            self.iterative_fit(X, y, n_iter=n_iter, refit=False)
-            iteration += 1
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', category=ConvergenceWarning,
+                message="Stochastic Optimizer: Maximum iterations (2) reached"
+                        " and the optimization hasn't converged yet."
+            )
+
+            self.iterative_fit(X, y, n_iter=2, refit=True)
+
+            iteration = 2
+            while not self.configuration_fully_fitted():
+                n_iter = int(2 ** iteration / 2)
+                self.iterative_fit(X, y, n_iter=n_iter, refit=False)
+                iteration += 1
+
         return self
 
     @staticmethod
@@ -162,15 +173,27 @@ class IterativeComponent(AutoSklearnComponent):
 
 
 class IterativeComponentWithSampleWeight(AutoSklearnComponent):
+
     def fit(self, X, y, sample_weight=None):
-        self.iterative_fit(
-            X, y, n_iter=2, refit=True, sample_weight=sample_weight
-        )
-        iteration = 2
-        while not self.configuration_fully_fitted():
-            n_iter = int(2 ** iteration / 2)
-            self.iterative_fit(X, y, n_iter=n_iter, sample_weight=sample_weight)
-            iteration += 1
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', category=ConvergenceWarning,
+                message="Stochastic Optimizer: Maximum iterations (2) reached"
+                        " and the optimization hasn't converged yet."
+            )
+
+            self.iterative_fit(
+                X, y, n_iter=2, refit=True, sample_weight=sample_weight
+            )
+
+            iteration = 2
+            while not self.configuration_fully_fitted():
+                n_iter = int(2 ** iteration / 2)
+                self.iterative_fit(
+                    X, y, n_iter=n_iter, refit=False, sample_weight=sample_weight
+                )
+                iteration += 1
+
         return self
 
     @staticmethod

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -147,21 +147,7 @@ class AutoSklearnComponent(BaseEstimator):
 
 class IterativeComponent(AutoSklearnComponent):
     def fit(self, X, y, sample_weight=None):
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', category=ConvergenceWarning,
-                message="Stochastic Optimizer: Maximum iterations (2) reached"
-                        " and the optimization hasn't converged yet."
-            )
-
-            self.iterative_fit(X, y, n_iter=2, refit=True)
-
-            iteration = 2
-            while not self.configuration_fully_fitted():
-                n_iter = int(2 ** iteration / 2)
-                self.iterative_fit(X, y, n_iter=n_iter, refit=False)
-                iteration += 1
-
+        self.iterative_fit(X, y, n_iter=self.get_max_iter(), refit=True)
         return self
 
     @staticmethod
@@ -175,25 +161,9 @@ class IterativeComponent(AutoSklearnComponent):
 class IterativeComponentWithSampleWeight(AutoSklearnComponent):
 
     def fit(self, X, y, sample_weight=None):
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', category=ConvergenceWarning,
-                message="Stochastic Optimizer: Maximum iterations (2) reached"
-                        " and the optimization hasn't converged yet."
-            )
-
-            self.iterative_fit(
-                X, y, n_iter=2, refit=True, sample_weight=sample_weight
-            )
-
-            iteration = 2
-            while not self.configuration_fully_fitted():
-                n_iter = int(2 ** iteration / 2)
-                self.iterative_fit(
-                    X, y, n_iter=n_iter, refit=False, sample_weight=sample_weight
-                )
-                iteration += 1
-
+        self.iterative_fit(
+            X, y, n_iter=self.get_max_iter(), refit=True, sample_weight=sample_weight
+        )
         return self
 
     @staticmethod

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -3,10 +3,8 @@ import importlib
 import inspect
 import pkgutil
 import sys
-import warnings
 
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.exceptions import ConvergenceWarning
 
 from autosklearn.pipeline.constants import SPARSE
 
@@ -146,8 +144,15 @@ class AutoSklearnComponent(BaseEstimator):
 
 
 class IterativeComponent(AutoSklearnComponent):
+
     def fit(self, X, y, sample_weight=None):
-        self.iterative_fit(X, y, n_iter=self.get_max_iter(), refit=True)
+        self.iterative_fit(X, y, n_iter=2, refit=True)
+
+        iteration = 2
+        while not self.configuration_fully_fitted():
+            n_iter = int(2 ** iteration / 2)
+            self.iterative_fit(X, y, n_iter=n_iter, refit=False)
+
         return self
 
     @staticmethod
@@ -161,9 +166,13 @@ class IterativeComponent(AutoSklearnComponent):
 class IterativeComponentWithSampleWeight(AutoSklearnComponent):
 
     def fit(self, X, y, sample_weight=None):
-        self.iterative_fit(
-            X, y, n_iter=self.get_max_iter(), refit=True, sample_weight=sample_weight
-        )
+        self.iterative_fit(X, y, n_iter=2, refit=True, sample_weight=sample_weight)
+
+        iteration = 2
+        while not self.configuration_fully_fitted():
+            n_iter = int(2 ** iteration / 2)
+            self.iterative_fit(X, y, n_iter=n_iter, refit=False, sample_weight=sample_weight)
+
         return self
 
     @staticmethod

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
@@ -29,7 +29,7 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
             self.preprocessor.fit(X, y)
             return self
         else:
-            # TODO spare_encoding of negative labels
+            # TODO sparse_encoding of negative labels
             #
             #   The next step in the pipeline relies on positive labels
             #   Given a categorical column [[0], [-1]], the next step will fail

--- a/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
+++ b/autosklearn/pipeline/components/data_preprocessing/categorical_encoding/encoding.py
@@ -27,7 +27,14 @@ class OrdinalEncoding(AutoSklearnPreprocessingAlgorithm):
                 categories='auto', handle_unknown='use_encoded_value', unknown_value=-1,
             )
             self.preprocessor.fit(X, y)
-        return self
+            return self
+        else:
+            # TODO spare_encoding of negative labels
+            #
+            #   The next step in the pipeline relies on positive labels
+            #   Given a categorical column [[0], [-1]], the next step will fail
+            #   unless we can fix this encoding
+            return self
 
     def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
         if scipy.sparse.issparse(X):

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -38,8 +38,18 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
 
         number_kinds = ("i", "u", "f")
         if kind in number_kinds:
-            unique = np.unique(X.data) if isinstance(X, spmatrix) else np.unique(X)
-            fill_value = min(min(unique), 0)
+
+            if isinstance(X, spmatrix):
+                # TODO negative labels
+                #
+                #   Previously this was the behaviour and went
+                #   unnoticed. Imputing negative labels results in
+                #   the cateogircal shift step failing as the ordinal
+                #   encoder can't fix negative labels.
+                #   This is here to document the behaviour explicitly
+                fill_value = 0
+            else:
+                fill_value = min(np.unique(X)) - 1
         else:
             fill_value = None  # use the default of SimpleImputer
 

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -35,14 +35,12 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
             # Series, sparse and numpy have dtype
             # Only DataFrame does not
             kind = X.dtype.kind
+
         if kind in ("i", "u", "f"):
             # We do not want to impute a category with the default
             # value (0 is the default) in case such default is in the
             # train data already!
-            fill_value = 0
-            unique = np.unique(X)
-            while fill_value in unique:
-                fill_value -= 1
+            fill_value = min(np.unique(X)) - 1
 
         self.preprocessor = sklearn.impute.SimpleImputer(
             strategy='constant', copy=False, fill_value=fill_value)

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -29,7 +29,6 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
             y: Optional[PIPELINE_DATA_DTYPE] = None) -> 'CategoricalImputation':
         import sklearn.impute
 
-        fill_value = None
         if hasattr(X, 'columns'):
             kind = X[X.columns[-1]].dtype.kind
         else:
@@ -37,15 +36,18 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
             # Only DataFrame does not
             kind = X.dtype.kind
 
-        if kind in ("i", "u", "f"):
+        number_kinds = ("i", "u", "f")
+        if kind in number_kinds:
             # We do not want to impute a category with the default
-            # value (0 is the default) in case such default is in the
-            # train data already!
-            if issparse(X):
-                # X.data doesn't return 0's
-                fill_value = min([*X.data, 0]) - 1
-            else:
-                fill_value = min(np.unique(X)) - 1
+            # value (0 is the default).
+            # Hence we take one greater than the max
+            unique = np.unique([*X.data, 0]) if issparse(X) else np.unique(X)
+            print(unique)
+            fill_value = min(unique) - 1
+        else:
+            fill_value = None
+
+        print(fill_value)
 
         self.preprocessor = sklearn.impute.SimpleImputer(
             strategy='constant', copy=False, fill_value=fill_value)

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional, Tuple, Union
 from ConfigSpace.configuration_space import ConfigurationSpace
 
 import numpy as np
+from scipy.sparse import issparse
 
 from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
@@ -40,7 +41,11 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
             # We do not want to impute a category with the default
             # value (0 is the default) in case such default is in the
             # train data already!
-            fill_value = min(np.unique(X)) - 1
+            if issparse(X):
+                fill_value = min(np.unique(X)) - 1
+            else:
+                # X.data doesn't return 0's
+                fill_value = min([*X.data, 0]) - 1
 
         self.preprocessor = sklearn.impute.SimpleImputer(
             strategy='constant', copy=False, fill_value=fill_value)

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -42,10 +42,10 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
             # value (0 is the default) in case such default is in the
             # train data already!
             if issparse(X):
-                fill_value = min(np.unique(X)) - 1
-            else:
                 # X.data doesn't return 0's
                 fill_value = min([*X.data, 0]) - 1
+            else:
+                fill_value = min(np.unique(X)) - 1
 
         self.preprocessor = sklearn.impute.SimpleImputer(
             strategy='constant', copy=False, fill_value=fill_value)

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -36,9 +36,10 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
             # Only DataFrame does not
             kind = X.dtype.kind
 
+        fill_value: Optional[int] = None
+
         number_kinds = ("i", "u", "f")
         if kind in number_kinds:
-
             if isinstance(X, spmatrix):
                 # TODO negative labels
                 #
@@ -50,8 +51,6 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
                 fill_value = 0
             else:
                 fill_value = min(np.unique(X)) - 1
-        else:
-            fill_value = None  # use the default of SimpleImputer
 
         self.preprocessor = sklearn.impute.SimpleImputer(
             strategy='constant', copy=False, fill_value=fill_value

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Tuple, Union
 from ConfigSpace.configuration_space import ConfigurationSpace
 
 import numpy as np
-from scipy.sparse import issparse
+from scipy.sparse import spmatrix
 
 from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
@@ -38,19 +38,14 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
 
         number_kinds = ("i", "u", "f")
         if kind in number_kinds:
-            # We do not want to impute a category with the default
-            # value (0 is the default).
-            # Hence we take one greater than the max
-            unique = np.unique([*X.data, 0]) if issparse(X) else np.unique(X)
-            print(unique)
-            fill_value = min(unique) - 1
+            unique = np.unique(X.data) if isinstance(X, spmatrix) else np.unique(X)
+            fill_value = min(min(unique), 0)
         else:
-            fill_value = None
-
-        print(fill_value)
+            fill_value = None  # use the default of SimpleImputer
 
         self.preprocessor = sklearn.impute.SimpleImputer(
-            strategy='constant', copy=False, fill_value=fill_value)
+            strategy='constant', copy=False, fill_value=fill_value
+        )
         self.preprocessor.fit(X)
         return self
 

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
@@ -11,15 +11,6 @@ from sklearn.exceptions import NotFittedError
 from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 
-IGNORED_WARNINGS = [
-    # The QuantileTransformerComponent is created before knowing the number of samples
-    # and so the search space includes n_quantiles which can be too large
-    (
-        UserWarning,
-        r'n_quantiles \(\d+\) is greater than the total number of samples \(\d+\)'
-    )
-]
-
 
 class Rescaling(object):
     # Rescaling does not support fit_transform (as of 0.19.1)!
@@ -38,11 +29,7 @@ class Rescaling(object):
         if self.preprocessor is None:
             raise NotFittedError()
 
-        with warnings.catch_warnings():
-            for category, message in IGNORED_WARNINGS:
-                warnings.filterwarnings('ignore', category=category, message=message)
-
-            self.preprocessor.fit(X)
+        self.preprocessor.fit(X)
 
         return self
 
@@ -51,11 +38,7 @@ class Rescaling(object):
         if self.preprocessor is None:
             raise NotFittedError()
 
-        with warnings.catch_warnings():
-            for category, message in IGNORED_WARNINGS:
-                warnings.filterwarnings('ignore', category=category, message=message)
-
-            transformed_X = self.preprocessor.transform(X)
+        transformed_X = self.preprocessor.transform(X)
 
         return transformed_X
 

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
@@ -1,5 +1,4 @@
 from typing import Optional, Union
-import warnings
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
@@ -20,6 +20,7 @@ IGNORED_WARNINGS = [
     )
 ]
 
+
 class Rescaling(object):
     # Rescaling does not support fit_transform (as of 0.19.1)!
     def __init__(

--- a/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
+++ b/autosklearn/pipeline/components/data_preprocessing/rescaling/abstract_rescaling.py
@@ -1,4 +1,5 @@
 from typing import Optional, Union
+import warnings
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 
@@ -10,6 +11,14 @@ from sklearn.exceptions import NotFittedError
 from autosklearn.pipeline.base import DATASET_PROPERTIES_TYPE, PIPELINE_DATA_DTYPE
 from autosklearn.pipeline.components.base import AutoSklearnPreprocessingAlgorithm
 
+IGNORED_WARNINGS = [
+    # The QuantileTransformerComponent is created before knowing the number of samples
+    # and so the search space includes n_quantiles which can be too large
+    (
+        UserWarning,
+        r'n_quantiles \(\d+\) is greater than the total number of samples \(\d+\)'
+    )
+]
 
 class Rescaling(object):
     # Rescaling does not support fit_transform (as of 0.19.1)!
@@ -19,17 +28,35 @@ class Rescaling(object):
     ) -> None:
         self.preprocessor: Optional[BaseEstimator] = None
 
-    def fit(self, X: PIPELINE_DATA_DTYPE, y: Optional[PIPELINE_DATA_DTYPE] = None
-            ) -> 'AutoSklearnPreprocessingAlgorithm':
+    def fit(
+        self,
+        X: PIPELINE_DATA_DTYPE,
+        y: Optional[PIPELINE_DATA_DTYPE] = None
+    ) -> 'AutoSklearnPreprocessingAlgorithm':
+
         if self.preprocessor is None:
             raise NotFittedError()
-        self.preprocessor.fit(X)
+
+        with warnings.catch_warnings():
+            for category, message in IGNORED_WARNINGS:
+                warnings.filterwarnings('ignore', category=category, message=message)
+
+            self.preprocessor.fit(X)
+
         return self
 
     def transform(self, X: PIPELINE_DATA_DTYPE) -> PIPELINE_DATA_DTYPE:
+
         if self.preprocessor is None:
-            raise NotImplementedError()
-        return self.preprocessor.transform(X)
+            raise NotFittedError()
+
+        with warnings.catch_warnings():
+            for category, message in IGNORED_WARNINGS:
+                warnings.filterwarnings('ignore', category=category, message=message)
+
+            transformed_X = self.preprocessor.transform(X)
+
+        return transformed_X
 
     @staticmethod
     def get_hyperparameter_search_space(dataset_properties: Optional[DATASET_PROPERTIES_TYPE] = None

--- a/autosklearn/pipeline/components/feature_preprocessing/kitchen_sinks.py
+++ b/autosklearn/pipeline/components/feature_preprocessing/kitchen_sinks.py
@@ -1,3 +1,6 @@
+from typing import Optional, Union
+
+from numpy.random import RandomState
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter, \
     UniformIntegerHyperparameter
@@ -8,13 +11,23 @@ from autosklearn.pipeline.constants import SPARSE, DENSE, UNSIGNED_DATA, INPUT
 
 class RandomKitchenSinks(AutoSklearnPreprocessingAlgorithm):
 
-    def __init__(self, gamma, n_components, random_state=None):
-        """ Parameters:
+    def __init__(
+        self,
+        gamma: float,
+        n_components: int,
+        random_state: Optional[Union[int, RandomState]] = None
+    ) -> None:
+        """
+        Parameters
+        ----------
         gamma: float
-               Parameter of the rbf kernel to be approximated exp(-gamma * x^2)
+            Parameter of the rbf kernel to be approximated exp(-gamma * x^2)
 
         n_components: int
-               Number of components (output dimensionality) used to approximate the kernel
+            Number of components (output dimensionality) used to approximate the kernel
+
+        random_state: Optional[int | RandomState]
+            The random state to pass to the underlying estimator
         """
         self.gamma = gamma
         self.n_components = n_components
@@ -27,7 +40,10 @@ class RandomKitchenSinks(AutoSklearnPreprocessingAlgorithm):
         self.gamma = float(self.gamma)
 
         self.preprocessor = sklearn.kernel_approximation.RBFSampler(
-            self.gamma, self.n_components, self.random_state)
+            gamma=self.gamma,
+            n_components=self.n_components,
+            random_state=self.random_state
+        )
         self.preprocessor.fit(X)
         return self
 

--- a/autosklearn/pipeline/components/regression/gaussian_process.py
+++ b/autosklearn/pipeline/components/regression/gaussian_process.py
@@ -1,11 +1,9 @@
-import warnings
-
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter
-from sklearn.exceptions import ConvergenceWarning
 
 from autosklearn.pipeline.components.base import AutoSklearnRegressionAlgorithm
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, PREDICTIONS
+
 
 class GaussianProcess(AutoSklearnRegressionAlgorithm):
     def __init__(self, alpha, thetaL, thetaU, random_state=None):

--- a/autosklearn/pipeline/components/regression/gaussian_process.py
+++ b/autosklearn/pipeline/components/regression/gaussian_process.py
@@ -19,6 +19,7 @@ IGNORED_WARNINGS = [
     )
 ]
 
+
 class GaussianProcess(AutoSklearnRegressionAlgorithm):
     def __init__(self, alpha, thetaL, thetaU, random_state=None):
         self.alpha = alpha

--- a/autosklearn/pipeline/components/regression/gaussian_process.py
+++ b/autosklearn/pipeline/components/regression/gaussian_process.py
@@ -7,19 +7,6 @@ from sklearn.exceptions import ConvergenceWarning
 from autosklearn.pipeline.components.base import AutoSklearnRegressionAlgorithm
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, PREDICTIONS
 
-IGNORED_WARNINGS = [
-    # Guassian process issues a convergence warning if it's not fitted for very
-    # long which we can't control during tests. We assume the user does not need
-    # the multiple warnings either.
-    (
-        ConvergenceWarning,
-        (r'The optimal value found for dimension \d+ of parameter length_scale '
-         r'is close to the specified lower bound .+\. Decreasing the bound and '
-         r'calling fit again may find a better value\.')
-    )
-]
-
-
 class GaussianProcess(AutoSklearnRegressionAlgorithm):
     def __init__(self, alpha, thetaL, thetaU, random_state=None):
         self.alpha = alpha
@@ -52,11 +39,8 @@ class GaussianProcess(AutoSklearnRegressionAlgorithm):
             random_state=self.random_state,
             normalize_y=True
         )
-        with warnings.catch_warnings():
-            for category, message in IGNORED_WARNINGS:
-                warnings.filterwarnings('ignore', category=category, message=message)
 
-            self.estimator.fit(X, y)
+        self.estimator.fit(X, y)
 
         return self
 

--- a/autosklearn/util/data.py
+++ b/autosklearn/util/data.py
@@ -53,7 +53,7 @@ def convert_to_bin(Ycont: List, nval: int, verbose: bool = True) -> List:
     Ybin = [[0] * nval for x in range(len(Ycont))]
     for i in range(len(Ybin)):
         line = Ybin[i]
-        line[np.int(Ycont[i])] = 1
+        line[int(Ycont[i])] = 1
         Ybin[i] = line
     return Ybin
 

--- a/examples/20_basic/example_multilabel_classification.py
+++ b/examples/20_basic/example_multilabel_classification.py
@@ -30,7 +30,7 @@ X, y = sklearn.datasets.fetch_openml(data_id=40594, return_X_y=True, as_frame=Fa
 # More information on: https://scikit-learn.org/stable/modules/multiclass.html
 y[y == 'TRUE'] = 1
 y[y == 'FALSE'] = 0
-y = y.astype(np.int)
+y = y.astype(int)
 
 # Using type of target is a good way to make sure your data
 # is properly formatted

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 setuptools
 typing_extensions
+distro
 
 numpy>=1.9.0
 scipy>=1.7.0

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -636,7 +636,7 @@ def test_classification_pandas_support(tmp_dir, dask_client):
     )
 
     # Drop NAN!!
-    X = X.dropna('columns')
+    X = X.dropna(axis='columns')
 
     # This test only make sense if input is dataframe
     assert isinstance(X, pd.DataFrame)

--- a/test/test_data/test_target_validator.py
+++ b/test/test_data/test_target_validator.py
@@ -67,7 +67,7 @@ def input_data_targettest(request):
             y = y.dropna()
             y.replace('FALSE', 0, inplace=True)
             y.replace('TRUE', 1, inplace=True)
-            y = y.astype(np.int)
+            y = y.astype(int)
         return y
     elif 'sparse' in request.param:
         # We expect the names to be of the type sparse_csc_nonan

--- a/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
@@ -158,7 +158,7 @@ def test_missing_values(sparse_data):
         X, y, logging.getLogger('Meta'), categorical)
     assert sparse.issparse(mf.value)
     assert mf.value.shape == X.shape
-    assert mf.value.dtype == np.bool
+    assert mf.value.dtype == bool
     assert 0 == np.sum(mf.value.data)
 
 

--- a/test/test_metric/test_metrics.py
+++ b/test/test_metric/test_metrics.py
@@ -387,7 +387,7 @@ class TestMetric(unittest.TestCase):
         # labels predicted in y_pred and the number of labels in y_true.
         # This triggers several warnings but we are aware.
         #
-        # TODO convert to pytest with fixture 
+        # TODO convert to pytest with fixture
         #
         #   This test should be parameterized so we can identify which metrics
         #   cause which warning specifically and rectify if needed.

--- a/test/test_metric/test_metrics.py
+++ b/test/test_metric/test_metrics.py
@@ -392,9 +392,7 @@ class TestMetric(unittest.TestCase):
         #   This test should be parameterized so we can identify which metrics
         #   cause which warning specifically and rectify if needed.
         ignored_warnings = [
-            (UserWarning, 'y_pred contains classes not in y_true'),
-            (UndefinedMetricWarning, 'Recall is ill-defined and being set to 0.0'),
-            (UndefinedMetricWarning, 'Precision is ill-defined and being set to 0.0')
+            (UserWarning, 'y_pred contains classes not in y_true')
         ]
 
         for metric, scorer in autosklearn.metrics.CLASSIFICATION_METRICS.items():
@@ -459,9 +457,7 @@ class TestMetric(unittest.TestCase):
                 [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
             )
 
-            # See note at top of test
             with warnings.catch_warnings():
-
                 for category, message in ignored_warnings:
                     warnings.filterwarnings(
                         'ignore', category=category, message=message

--- a/test/test_metric/test_metrics.py
+++ b/test/test_metric/test_metrics.py
@@ -1,9 +1,11 @@
 import unittest
+import warnings
 
 import pytest
 
 import numpy as np
 import sklearn.metrics
+from sklearn.exceptions import UndefinedMetricWarning
 
 import autosklearn.metrics
 
@@ -381,6 +383,19 @@ class TestMetric(unittest.TestCase):
             self.assertLess(current_score, previous_score)
 
     def test_classification_multiclass(self):
+        # The last check in this test has a mismatch between the number of
+        # labels predicted in y_pred and the number of labels in y_true.
+        # This triggers several warnings but we are aware.
+        #
+        # TODO convert to pytest with fixture 
+        #
+        #   This test should be parameterized so we can identify which metrics
+        #   cause which warning specifically and rectify if needed.
+        ignored_warnings = [
+            (UserWarning, 'y_pred contains classes not in y_true'),
+            (UndefinedMetricWarning, 'Recall is ill-defined and being set to 0.0'),
+            (UndefinedMetricWarning, 'Precision is ill-defined and being set to 0.0')
+        ]
 
         for metric, scorer in autosklearn.metrics.CLASSIFICATION_METRICS.items():
             # Skip functions not applicable for multiclass classification.
@@ -388,27 +403,51 @@ class TestMetric(unittest.TestCase):
                           'precision', 'recall', 'f1', 'precision_samples',
                           'recall_samples', 'f1_samples']:
                 continue
-            y_true = np.array([0.0, 0.0, 1.0, 1.0, 2.0])
-            y_pred = np.array([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0],
-                              [0.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+            y_true = np.array(
+                [0.0, 0.0, 1.0, 1.0, 2.0]
+            )
+
+            y_pred = np.array([
+                [1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ])
             previous_score = scorer._optimum
             current_score = scorer(y_true, y_pred)
             self.assertAlmostEqual(current_score, previous_score)
 
-            y_pred = np.array([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0],
-                              [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+            y_pred = np.array([
+                [1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ])
             previous_score = current_score
             current_score = scorer(y_true, y_pred)
             self.assertLess(current_score, previous_score)
 
-            y_pred = np.array([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0],
-                              [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+            y_pred = np.array([
+                [0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0]
+            ])
             previous_score = current_score
             current_score = scorer(y_true, y_pred)
             self.assertLess(current_score, previous_score)
 
-            y_pred = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0],
-                              [1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+            y_pred = np.array([
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0]
+            ])
             previous_score = current_score
             current_score = scorer(y_true, y_pred)
             self.assertLess(current_score, previous_score)
@@ -419,8 +458,17 @@ class TestMetric(unittest.TestCase):
                 [1.0, 0.0, 0.0], [1.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
             )
-            score = scorer(y_true, y_pred)
-            self.assertTrue(np.isfinite(score))
+
+            # See note at top of test
+            with warnings.catch_warnings():
+
+                for category, message in ignored_warnings:
+                    warnings.filterwarnings(
+                        'ignore', category=category, message=message
+                    )
+
+                score = scorer(y_true, y_pred)
+                self.assertTrue(np.isfinite(score))
 
     def test_classification_multilabel(self):
 

--- a/test/test_metric/test_metrics.py
+++ b/test/test_metric/test_metrics.py
@@ -5,7 +5,6 @@ import pytest
 
 import numpy as np
 import sklearn.metrics
-from sklearn.exceptions import UndefinedMetricWarning
 
 import autosklearn.metrics
 

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -172,16 +172,18 @@ class BaseClassificationComponentTest(unittest.TestCase):
         if not self.module.get_properties()["handles_multilabel"]:
             return
 
-        for i in range(2):
-            predictions, targets, _ = \
-                _test_classifier(classifier=self.module,
-                                 dataset='digits',
-                                 make_multilabel=True)
-            self.assertAlmostEqual(self.res["default_digits_multilabel"],
-                                   sklearn.metrics.precision_score(
-                                       targets, predictions, average='macro'),
-                                   places=self.res.get(
-                                           "default_digits_multilabel_places", 7))
+        for _ in range(2):
+            predictions, targets, _ =  _test_classifier(
+                classifier=self.module, dataset='digits', make_multilabel=True
+            )
+
+            score = sklearn.metrics.precision_score(
+                targets, predictions, average='macro', zero_division=0
+            )
+            self.assertAlmostEqual(
+                self.res["default_digits_multilabel"], score,
+                places=self.res.get("default_digits_multilabel_places", 7)
+            )
 
     def test_default_digits_multilabel_predict_proba(self):
 

--- a/test/test_pipeline/components/classification/test_base.py
+++ b/test/test_pipeline/components/classification/test_base.py
@@ -173,7 +173,7 @@ class BaseClassificationComponentTest(unittest.TestCase):
             return
 
         for _ in range(2):
-            predictions, targets, _ =  _test_classifier(
+            predictions, targets, _ = _test_classifier(
                 classifier=self.module, dataset='digits', make_multilabel=True
             )
 

--- a/test/test_pipeline/components/data_preprocessing/test_categorical_imputation.py
+++ b/test/test_pipeline/components/data_preprocessing/test_categorical_imputation.py
@@ -74,5 +74,5 @@ def test_default_sparse(input_data_imputation):
     Y = CategoricalImputation().fit_transform(X)
     Y = Y.todense()
 
-    assert np.array_equal(Y == -1, mask)
-    assert np.array_equal(Y != -1, ~mask)
+    np.testing.assert_equal(Y == 0, mask)
+    np.testing.assert_equal(Y != 0, ~mask)

--- a/test/test_pipeline/components/data_preprocessing/test_categorical_imputation.py
+++ b/test/test_pipeline/components/data_preprocessing/test_categorical_imputation.py
@@ -34,16 +34,15 @@ def test_default_imputation(input_data_imputation, categorical):
         X = X.astype('str').astype('object')
         X[mask] = np.nan
     else:
-        imputation_value = min(np.unique(X)) - 1
-
+        imputation_value = 0
     Y = CategoricalImputation().fit_transform(X.copy())
-
-    assert np.array_equal(Y == imputation_value, mask)
-    assert np.array_equal(Y != imputation_value, ~mask)
+    assert ((np.argwhere(Y == imputation_value) == np.argwhere(mask)).all())
+    assert ((np.argwhere(Y != imputation_value) == np.argwhere(np.logical_not(mask))).all())
 
 
 @pytest.mark.parametrize('format_type', ('numpy', 'pandas'))
 def test_nonzero_numerical_imputation(format_type):
+
     # First try with an array with 0 as only valid category. The imputation should
     # happen with -1
     X = np.full(fill_value=np.nan, shape=(10, 10))
@@ -70,9 +69,8 @@ def test_nonzero_numerical_imputation(format_type):
 @pytest.mark.parametrize('input_data_imputation', ('numpy'), indirect=True)
 def test_default_sparse(input_data_imputation):
     X, mask = input_data_imputation
-    X = sparse.csr_matrix(X)
+    X = sparse.csc_matrix(X)
     Y = CategoricalImputation().fit_transform(X)
     Y = Y.todense()
-
-    assert np.array_equal(Y == -1, mask)
-    assert np.array_equal(Y != -1, ~mask)
+    assert (np.argwhere(Y == 0) == np.argwhere(mask)).all()
+    assert (np.argwhere(Y != 0) == np.argwhere(np.logical_not(mask))).all()

--- a/test/test_pipeline/components/data_preprocessing/test_categorical_imputation.py
+++ b/test/test_pipeline/components/data_preprocessing/test_categorical_imputation.py
@@ -34,15 +34,16 @@ def test_default_imputation(input_data_imputation, categorical):
         X = X.astype('str').astype('object')
         X[mask] = np.nan
     else:
-        imputation_value = 0
+        imputation_value = min(np.unique(X)) - 1
+
     Y = CategoricalImputation().fit_transform(X.copy())
-    assert ((np.argwhere(Y == imputation_value) == np.argwhere(mask)).all())
-    assert ((np.argwhere(Y != imputation_value) == np.argwhere(np.logical_not(mask))).all())
+
+    assert np.array_equal(Y == imputation_value, mask)
+    assert np.array_equal(Y != imputation_value, ~mask)
 
 
 @pytest.mark.parametrize('format_type', ('numpy', 'pandas'))
 def test_nonzero_numerical_imputation(format_type):
-
     # First try with an array with 0 as only valid category. The imputation should
     # happen with -1
     X = np.full(fill_value=np.nan, shape=(10, 10))
@@ -69,8 +70,9 @@ def test_nonzero_numerical_imputation(format_type):
 @pytest.mark.parametrize('input_data_imputation', ('numpy'), indirect=True)
 def test_default_sparse(input_data_imputation):
     X, mask = input_data_imputation
-    X = sparse.csc_matrix(X)
+    X = sparse.csr_matrix(X)
     Y = CategoricalImputation().fit_transform(X)
     Y = Y.todense()
-    assert (np.argwhere(Y == 0) == np.argwhere(mask)).all()
-    assert (np.argwhere(Y != 0) == np.argwhere(np.logical_not(mask))).all()
+
+    assert np.array_equal(Y == -1, mask)
+    assert np.array_equal(Y != -1, ~mask)

--- a/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_categorical.py
+++ b/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_categorical.py
@@ -107,4 +107,3 @@ class CategoricalPreprocessingPipelineTest(unittest.TestCase):
     def test_transform_with_sparse_column_with_negative_labels(self):
         X = sparse.csr_matrix([[0], [-1]])
         CategoricalPreprocessingPipeline().fit_transform(X)
-

--- a/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_categorical.py
+++ b/test/test_pipeline/components/data_preprocessing/test_data_preprocessing_categorical.py
@@ -2,6 +2,8 @@ import unittest
 import numpy as np
 from scipy import sparse
 
+import pytest
+
 from autosklearn.pipeline.components.data_preprocessing.feature_type_categorical \
     import CategoricalPreprocessingPipeline
 
@@ -97,3 +99,12 @@ class CategoricalPreprocessingPipelineTest(unittest.TestCase):
         # Consistency check:
         Y2t = CPPL.transform(X)
         np.testing.assert_array_equal(Y1t, Y2t)
+
+    @pytest.mark.xfail(reason=(
+        "Encoding step does not support sparse matrices to convert negative labels to"
+        " positive ones as it does with non-sparse matrices"
+    ))
+    def test_transform_with_sparse_column_with_negative_labels(self):
+        X = sparse.csr_matrix([[0], [-1]])
+        CategoricalPreprocessingPipeline().fit_transform(X)
+

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -70,6 +70,7 @@ ignored_warnings = [
     ),
 ]
 
+
 class DummyClassifier(AutoSklearnClassificationAlgorithm):
     @staticmethod
     def get_properties(dataset_properties=None):

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -6,6 +6,7 @@ import tempfile
 import traceback
 import unittest
 import unittest.mock
+import warnings
 
 from joblib import Memory
 import numpy as np
@@ -17,6 +18,7 @@ import sklearn.model_selection
 import sklearn.ensemble
 import sklearn.svm
 from sklearn.utils.validation import check_is_fitted
+from sklearn.exceptions import ConvergenceWarning
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
@@ -31,6 +33,42 @@ from autosklearn.pipeline.util import get_dataset
 from autosklearn.pipeline.constants import \
     DENSE, SPARSE, UNSIGNED_DATA, PREDICTIONS, SIGNED_DATA, INPUT
 
+ignored_warnings = [
+    (
+        UserWarning, (  # From QuantileTransformer
+            r"n_quantiles \(\d+\) is greater than the total number of samples \(\d+\)\."
+            r" n_quantiles is set to n_samples\."
+        )
+    ),
+    (
+        UserWarning, (  # From FastICA
+            r"n_components is too large: it will be set to \d+"
+        )
+
+    ),
+    (
+        ConvergenceWarning, (  # From Liblinear
+            r"Liblinear failed to converge, increase the number of iterations\."
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From SGD
+            r"Maximum number of iteration reached before convergence\. Consider increasing"
+            r" max_iter to improve the fit\."
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From MLP
+            r"Stochastic Optimizer: Maximum iterations \(\d+\) reached and the"
+            r" optimization hasn't converged yet\."
+        )
+    ),
+    (
+        UserWarning, (  # From LDA (Linear Discriminant Analysis)
+            r"Variables are collinear"
+        )
+    ),
+]
 
 class DummyClassifier(AutoSklearnClassificationAlgorithm):
     @staticmethod
@@ -359,7 +397,11 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                     check_is_fitted(step)
 
             try:
-                cls.fit(X_train, Y_train)
+                with warnings.catch_warnings():
+                    for category, message in ignored_warnings:
+                        warnings.filterwarnings('ignore', category=category, message=message)
+
+                    cls.fit(X_train, Y_train)
 
                 # After fit, all components should be tagged as fitted
                 # by sklearn. Check is fitted raises an exception if that

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -32,14 +32,30 @@ from autosklearn.pipeline.constants import SPARSE, DENSE, SIGNED_DATA, UNSIGNED_
 
 ignored_warnings = [
     (
-        ConvergenceWarning, (  # Gaussian processes iterative fit issues this warning
-            r"The optimal value found for dimension \d+ of parameter \w+ is"
-            r" close to the specified upper bound \d+\.\d+\. Increasing the"
-            r" bound and calling fit again may find a better value\."
+        UserWarning, (  # From QuantileTransformer
+            r"n_quantiles \(\d+\) is greater than the total number of samples \(\d+\)\."
+            r" n_quantiles is set to n_samples\."
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From GaussianProcesses
+            r"The optimal value found for dimension \d+ of parameter \w+ is close"
+            r" to the specified (upper|lower) bound .*(Increasing|Decreasing) the bound"
+            r" and calling fit again may find a better value."
+        )
+    ),
+    (
+        UserWarning, (  # From FastICA
+            r"n_components is too large: it will be set to \d+"
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From SGD
+            r"Maximum number of iteration reached before convergence\. Consider increasing"
+            r" max_iter to improve the fit\."
         )
     ),
 ]
-
 
 class SimpleRegressionPipelineTest(unittest.TestCase):
     _multiprocess_can_split_ = True

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -40,6 +40,7 @@ ignored_warnings = [
     ),
 ]
 
+
 class SimpleRegressionPipelineTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 
@@ -145,7 +146,6 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         limit = 3072 * 1024 * 1024
         resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
 
-
         configurations_space.seed(1)
 
         for i in range(10):
@@ -190,7 +190,6 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                 with self.assertRaisesRegex(sklearn.exceptions.NotFittedError,
                                             "instance is not fitted yet"):
                     check_is_fitted(step)
-
 
             try:
                 with warnings.catch_warnings():

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -57,6 +57,7 @@ ignored_warnings = [
     ),
 ]
 
+
 class SimpleRegressionPipelineTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 


### PR DESCRIPTION
This PR attempts to clear up some warnings that appear in the Github actions [tests](https://github.com/automl/auto-sklearn/runs/3537886422?check_suite_focus=true). Warnings that could be considered harmful are left in and documented here.

This PR description will updated as progress is made and sources of the warnings identified.

Some of the warnings are easy fixes and just warnings about future API changes. Other warnings we are aware of and ignore such as for IterativeAlgorithms in which they don't converge as we are manually iterating.

# Potential problem warnings:
* Illuminates underlying issue that we don't consider datasets with unique labels throughout the codebase 
```
 test/test_evaluation/test_train_evaluator.py::TestTrainEvaluator::test_datasets
test/test_evaluation/test_train_evaluator.py::TestTrainEvaluator::test_datasets
  /usr/share/miniconda/envs/testenv/lib/python3.8/site-packages/sklearn/model_selection/_split.py:666: UserWarning: The least populated class in y has only 1 members, which is less than n_splits=2.
    warnings.warn(("The least populated class in y has only %d"
```

* Uncertain what this means for metafeatures
```

test/test_metalearning/pyMetaLearn/test_meta_features.py::test_calculate_all_metafeatures_multilabel[pandas]
test/test_metalearning/pyMetaLearn/test_meta_features.py::test_calculate_all_metafeatures_multilabel[numpy]
  /usr/share/miniconda/envs/testenv/lib/python3.8/site-packages/numpy/lib/nanfunctions.py:1670: RuntimeWarning: Degrees of freedom <= 0 for slice.
    var = nanvar(a, axis=axis, dtype=dtype, out=out, ddof=ddof,

test/test_metalearning/pyMetaLearn/test_meta_features.py::test_calculate_all_metafeatures_multilabel[pandas]
test/test_metalearning/pyMetaLearn/test_meta_features.py::test_calculate_all_metafeatures_multilabel[numpy]
  /home/runner/work/auto-sklearn/auto-sklearn/autosklearn/metalearning/metafeatures/metafeatures.py:474: RuntimeWarning: Mean of empty slice
    mean = np.nanmean(values)
```

* QDA might be being used incorrectly
```
test/test_pipeline/test_classification.py: 3 warnings
test/test_pipeline/components/classification/test_qda.py: 36 warnings
  /usr/share/miniconda/envs/testenv/lib/python3.8/site-packages/sklearn/discriminant_analysis.py:808: UserWarning: Variables are collinear
    warnings.warn("Variables are collinear")
```

* Clustering metrics may be being misused, the continuous labels are likely just floats such as `1.0` or `0.0` as labels but the warning seems to indicate something doesn't like multiclass problems. 
```
test/test_pipeline/test_classification.py: 51 warnings
  /usr/share/miniconda/envs/testenv/lib/python3.8/site-packages/sklearn/metrics/cluster/_supervised.py:58: UserWarning: Clustering metrics expects discrete values but received continuous values for label, and multiclass values for target
    warnings.warn(msg, UserWarning)
```

* It seems two or three regression algorithms are producing large numbers somewhere and causing overflows which probably ruins their performance. Converting these tests to be pytests with fixtures would help illuminate which algorithms are causing these overflows.
```
test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations
test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations
test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations_signed_data
test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations_signed_data
test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations_signed_data
  /usr/share/miniconda/envs/testenv/lib/python3.8/site-packages/numpy/core/_methods.py:233: RuntimeWarning: overflow encountered in multiply
    x = um.multiply(x, x, out=x)

test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations
test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations
test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations_signed_data
test/test_pipeline/test_regression.py::SimpleRegressionPipelineTest::test_configurations_signed_data
  /usr/share/miniconda/envs/testenv/lib/python3.8/site-packages/numpy/core/_methods.py:244: RuntimeWarning: overflow encountered in reduce
    ret = umr_sum(x, axis, dtype, out, keepdims=keepdims, where=where)
```

* LDA seems to be getting something it doesn't like during it's fitting process
```
test/test_pipeline/components/classification/test_lda.py::LDAComponentTest::test_module_idempotent
  /usr/share/miniconda/envs/testenv/lib/python3.8/site-packages/sklearn/discriminant_analysis.py:480: RuntimeWarning: invalid value encountered in true_divide
    self.explained_variance_ratio_ = (S**2 / np.sum(
```

* Same with some feature processor
```
test/test_pipeline/components/feature_preprocessing/test_select_rates_regression.py::SelectRegressionRatesComponentTest::test_default_configuration
test/test_pipeline/components/feature_preprocessing/test_select_rates_regression.py::SelectRegressionRatesComponentTest::test_default_configuration
  /usr/share/miniconda/envs/testenv/lib/python3.8/site-packages/sklearn/feature_selection/_univariate_selection.py:302: RuntimeWarning: invalid value encountered in true_divide
    corr /= X_norms
```

* More invalid values encountered
```
test/test_pipeline/test_classification.py::SimpleClassificationPipelineTest::test_configurations_signed_data
  /opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/site-packages/sklearn/decomposition/_fastica.py:60: RuntimeWarning: invalid value encountered in sqrt
    return np.linalg.multi_dot([u * (1. / np.sqrt(s)), u.T, W])
```
