### PR TITLE
Update swig docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,7 @@ RUN apt install -y python3-dev python3-pip
 RUN pip3 install --upgrade setuptools
 RUN apt install -y build-essential
 
-# https://github.com/automl/auto-sklearn/issues/314
-RUN apt install -y swig3.0
-RUN ln -s /usr/bin/swig3.0 /usr/bin/swig
+RUN apt install -y swig
 
 # Copy the checkout autosklearn version for installation
 ADD . /auto-sklearn/

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -84,9 +84,7 @@ following:
 1. Check if you can use a pre-compiled version of the pyrfr to avoid compiling it yourself. We
    provide pre-compiled versions of the pyrfr on `pypi <https://pypi.org/project/pyrfr/#files>`_.
 2. Check if the dependencies specified under :ref:`installation` are correctly installed,
-   especially that you have ``swig`` and a ``C++`` compiler. If you are using an older version of
-   the pyrfr (``<=0.8.0``) the dependency on SWIG as stricter and you actually need SWIG3 to
-   compile the pyrfr.
+   especially that you have ``swig`` and a ``C++`` compiler.
 3. If you are not yet using Conda, consider using it; it simplifies installation of the correct
    dependencies.
 4. Install correct build dependencies before installing the pyrfr, you can check the following

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -19,7 +19,7 @@ In case you try to install Auto-sklearn on a system where no wheel files for the
 are provided (see `here <https://pypi.org/project/pyrfr/#files>`_ for available wheels) you also
 need:
 
-* SWIG (version 3.0.* is required; >=4.0.0 is not supported) (`get SWIG here <http://www.swig.org/survey.html>`_).
+* SWIG (`get SWIG here <http://www.swig.org/survey.html>`_).
 
 For an explanation of missing Microsoft Windows and MAC OSX support please
 check the Section `Windows/OSX compatibility`_.


### PR DESCRIPTION
This PR updates the docs to reflect that `pyrfr` now works with that latest swig version `SWIG 4.0.2` and no extra installation step is required to specifically link to `SWIG 3.0.0`