### PR TITLE
Updated to use full paths in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,11 @@ extras_reqs={
     "docs": ["sphinx", "sphinx-gallery", "sphinx_bootstrap_theme", "numpydoc"],
 }
 
-with open("autosklearn/__version__.py") as fh:
+with open(os.path.join(HERE, 'autosklearn', '__version__.py')) as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")
 
 
-with open('README.md') as fh:
+with open(os.path.join(HERE, 'README.md')) as fh:
     long_description = fh.read()
 
 


### PR DESCRIPTION
This PR updates the relative paths in `setup.py` to use aboslute paths for version and README.md, as was already being done for the `requirements.txt` file.

I ran into errors with automlbenchmark because of this.