### PR TITLE
added python 3.10 to versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         use-conda: [true, false]
         use-dist: [false]
         include:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,13 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         use-conda: [true, false]
         use-dist: [false]
         include:
-          - python-version: 3.8
+          - python-version: '3.8'
             code-cov: true
-          - python-version: 3.7
+          - python-version: '3.7'
             use-conda: false
             use-dist: true
       fail-fast: false


### PR DESCRIPTION
Add Python 3.10 to the test matrix.

Need to use quotes around version such as `'3.10'` as `3.10` gets converted to `3.1`