### PR TITLE
Black format checker

### DIFF
--- a/.github/workflows/black_checker.yml
+++ b/.github/workflows/black_checker.yml
@@ -1,0 +1,39 @@
+name: black-format-check
+
+on: [push, pull_request]
+
+env:
+  #If STRICT is set to true, it will fail on black check fail
+  STRICT: false
+
+jobs:
+
+  black-format-check:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.7"
+
+    - name: Install black
+      run: |
+        pip install black
+
+    - name: Run Black Check
+      run: |
+        if ${{ env.STRICT }}; then
+          black --check --diff --line-length 100 ./autosklearn
+          black --check --diff --line-length 100 ./test
+        else
+          # We capture output and always return true
+          output_src=$(black --check --diff --line-length 100 ./autosklearn) || true
+          echo $output_src
+
+          output_test=$(black --check --diff --line-length 100 ./test) || true
+          echo $output_test
+        fi

--- a/.github/workflows/black_checker.yml
+++ b/.github/workflows/black_checker.yml
@@ -26,14 +26,5 @@ jobs:
 
     - name: Run Black Check
       run: |
-        if ${{ env.STRICT }}; then
-          black --check --diff --line-length 100 ./autosklearn
-          black --check --diff --line-length 100 ./test
-        else
-          # We capture output and always return true
-          output_src=$(black --check --diff --line-length 100 ./autosklearn) || true
-          echo $output_src
-
-          output_test=$(black --check --diff --line-length 100 ./test) || true
-          echo $output_test
-        fi
+        black --check --diff --line-length 100 ./autosklearn || ! $STRICT
+        black --check --diff --line-length 100 ./test || ! $STRICT

--- a/.github/workflows/black_checker.yml
+++ b/.github/workflows/black_checker.yml
@@ -28,3 +28,4 @@ jobs:
       run: |
         black --check --diff --line-length 100 ./autosklearn || ! $STRICT
         black --check --diff --line-length 100 ./test || ! $STRICT
+        black --check --diff --line-length 100 ./examples|| ! $STRICT


### PR DESCRIPTION
Adds a format checker to conform to the black format code style with a line length of 100. Does not fail if black fails unless a variable `STRICT` is set to true in `.github/workflows/black_checker.yml`.