### PR TITLE
Changes show_models() function to return a dictionary of models in ensemble

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1833,53 +1833,120 @@ class AutoML(BaseEstimator):
 
         return self.ensemble_.get_models_with_weights(self.models_)
 
-    def show_models(self):
-        """ Returns a dictionary containing models and their information
-            where model_id/run_id is the key """
+    def show_models(self) -> Dict[int, Any]:
+        """ Returns a dictionary containing dictionaries of ensemble models only.
 
-        ensemble_dict={} 
-        
+        Any model can be accessed by giving its ``model_id`` as key.
+
+        A model dictionary contains the following:
+
+        * ``"model_id"`` - The id given to a model by ``autosklearn``.
+        * ``"rank"`` - The rank of the model based on it's ``"cost"``.
+        * ``"cost"`` - The loss of the model on the validation set.
+        * ``"ensemble_weight"`` - The weight given to the model in the ensemble.
+        * ``"data_preprocessor"`` - The preprocessor used on the data.
+        * ``"balancing"`` - The balancing used on the data (for classification).
+        * ``"feature_preprocessor"`` - The preprocessor for features types.
+        * ``"classifier"`` or ``"regressor"`` - The autosklearn wrapped classifier or regressor.
+        * ``"sklearn_classifier"`` or ``"sklearn_regressor"`` - The sklearn classifier or regressor.
+
+        **Example**
+
+        .. code-block:: python
+
+            import sklearn.datasets
+            import sklearn.metrics
+            import autosklearn.regression
+
+            X, y = sklearn.datasets.load_diabetes(return_X_y=True)
+
+            automl = autosklearn.regression.AutoSklearnRegressor(
+                time_left_for_this_task=120
+                )
+            automl.fit(X_train, y_train, dataset_name='diabetes')
+
+            ensemble_dict = automl.show_models()
+            print(ensemble_dict)
+
+        Output:
+
+        .. code-block:: text
+
+            {
+                25: {'model_id': 25.0,
+                     'rank': 1,
+                     'cost': 0.43667876507897496,
+                     'ensemble_weight': 0.38,
+                     'data_preprocessor': <autosklearn.pipeline.components.data_preprocessing....>,
+                     'feature_preprocessor': <autosklearn.pipeline.components....>,
+                     'regressor': <autosklearn.pipeline.components.regression....>,
+                     'sklearn_regressor': SGDRegressor(alpha=0.0006517033225329654,...)
+                    },
+                6: {'model_id': 6.0,
+                    'rank': 2,
+                    'cost': 0.4550418898836528,
+                    'ensemble_weight': 0.3,
+                    'data_preprocessor': <autosklearn.pipeline.components.data_preprocessing....>,
+                    'feature_preprocessor': <autosklearn.pipeline.components....>,
+                    'regressor': <autosklearn.pipeline.components.regression....>,
+                    'sklearn_regressor': ARDRegression(alpha_1=0.0003701926442639788,...)
+                    }...
+            }
+
+        Returns
+        -------
+        Dict(int, Any) : dictionary of length = number of models in the ensemble
+            A dictionary of models in the ensemble, where ``model_id`` is the key.
+
+        """
+
+        ensemble_dict = {}
+
         def has_key(rv, key):
             return rv.additional_info and key in rv.additional_info
-        
-        table_dict={}
+
+        table_dict = {}
         for rkey, rval in self.runhistory_.data.items():
             if has_key(rval, 'num_run'):
-                table_dict[rval.additional_info['num_run']]={
-                        'model_id': rval.additional_info['num_run'],
-                        'cost': rval.cost}
-                
+                model_id = rval.additional_info['num_run']
+                table_dict[model_id] = {
+                        'model_id': model_id,
+                        'cost': rval.cost
+                        }
+
         for i, weight in enumerate(self.ensemble_.weights_):
             (_, model_id, _) = self.ensemble_.identifiers_[i]
-            table_dict[model_id]['ensemble_weight']=weight
-        
-        table=pd.DataFrame.from_dict(table_dict, orient='index')
-        table.sort_values(by='cost', inplace=True)
-        table['rank']=range(1,len(table)+1)
+            table_dict[model_id]['ensemble_weight'] = weight
 
+        table = pd.DataFrame.from_dict(table_dict, orient='index')
+        table.sort_values(by='cost', inplace=True)
+
+        rank = 1  # Initializing rank for the first model
         for (_, model_id, _), model in self.models_.items():
-            model_dict={} #Empty model dictionary
-                
-            #Inserting rank and ensemble weight
-            model_dict['model_id']=table.loc[model_id]['model_id']
-            model_dict['rank']=table.loc[model_id]['rank']
-            model_dict['ensemble_weight']=table.loc[model_id]['ensemble_weight']
-            
-            # The steps in the models pipeline will be saved in the dictionary as follows: 
-            # 'data_preprocessing': DataPreprocessor,
+            model_dict = {}  # Declaring model dictionary
+
+            # Inserting model_id, rank, cost and ensemble weight
+            model_dict['model_id'] = table.loc[model_id]['model_id']
+            model_dict['rank'] = rank
+            model_dict['cost'] = table.loc[model_id]['cost']
+            model_dict['ensemble_weight'] = table.loc[model_id]['ensemble_weight']
+            rank += 1  # Incrementing rank by 1 for the next model
+
+            # The steps in the models pipeline will be saved in the dictionary as follows:
+            # 'data_preprocessor': DataPreprocessor,
             # 'balancing': Balancing,
             # 'feature_preprocessor': FeaturePreprocessorChoice,
-            # 'classifier': ClassifierChoice -> autosklearn wrapped model
-            for step in model.steps:
-                model_dict[step[0]]=step[1]
-            
-            #Adding sklearn model to the model dictionary
-            model_dict['sklearn_model']=model.steps[-1][1].choice.estimator
-            
-            #Adding model to ensemble dictionary
+            # 'classifier'/'regressor': ClassifierChoice/RegressorChoice (autosklearn wrapped model)
+            steps = dict(model.steps)
+            model_dict.update(steps)
+
+            # Adding sklearn model to the model dictionary
+            model_type, autosklearn_wrapped_model = model.steps[-1]
+            model_dict[f'sklearn_{model_type}'] = autosklearn_wrapped_model.choice.estimator
+
+            # Insterting model_dict in the ensemble dictionary
             ensemble_dict[model_id] = model_dict
         return ensemble_dict
-        
 
     def _create_search_space(self, tmp_dir, backend, datamanager,
                              include=None,

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1914,6 +1914,10 @@ class AutoML(BaseEstimator):
                         'cost': rval.cost
                         }
 
+        # Check if dictionary is empty
+        if not table_dict:
+            raise RuntimeError('No model found. Try increasing \'time_left_for_this_task\'.')
+
         for i, weight in enumerate(self.ensemble_.weights_):
             (_, model_id, _) = self.ensemble_.identifiers_[i]
             table_dict[model_id]['ensemble_weight'] = weight

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1844,8 +1844,8 @@ class AutoML(BaseEstimator):
         * ``"rank"`` - The rank of the model based on it's ``"cost"``.
         * ``"cost"`` - The loss of the model on the validation set.
         * ``"ensemble_weight"`` - The weight given to the model in the ensemble.
-        * ``"voting_model"`` - The ``VotingX`` model (only for 'cv' resampling).
-        * ``"estimators"`` - List of dicts of models in the ``VotingX`` (only for 'cv' resampling).
+        * ``"voting_model"`` - The ``cv_voting_ensemble`` model (for 'cv' resampling).
+        * ``"estimators"`` - List of models (dicts) in ``cv_voting_ensemble`` (for 'cv' resampling).
         * ``"data_preprocessor"`` - The preprocessor used on the data.
         * ``"balancing"`` - The balancing used on the data (for classification).
         * ``"feature_preprocessor"`` - The preprocessor for features types.
@@ -1951,15 +1951,13 @@ class AutoML(BaseEstimator):
             # For 'cv' (cross validation) strategy
             if is_cv:
                 # Voting model created by cross validation
-                VotingX = model
-                model_dict['voting_model'] = VotingX
+                cv_voting_ensemble = model
+                model_dict['voting_model'] = cv_voting_ensemble
 
                 # List of models, each trained on one cv fold
                 cv_models = []
-                for cv_model in VotingX.estimators_:
-                    estimator = {}
-                    steps = dict(cv_model.steps)
-                    estimator.update(steps)
+                for cv_model in cv_voting_ensemble.estimators_:
+                    estimator = dict(cv_model.steps)
 
                     # Adding sklearn model to the model dictionary
                     model_type, autosklearn_wrapped_model = cv_model.steps[-1]

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -492,9 +492,9 @@ class AutoSklearnEstimator(BaseEstimator):
         return self.automl_.score(X, y)
 
     def show_models(self):
-        """ Returns a dictionary containing dictionaries of ensemble models only.
+        """ Returns a dictionary containing dictionaries of ensemble models.
 
-        Any model can be accessed by giving its ``model_id`` as key.
+        Each model in the ensemble can be accessed by giving its ``model_id`` as key.
 
         A model dictionary contains the following:
 
@@ -502,6 +502,8 @@ class AutoSklearnEstimator(BaseEstimator):
         * ``"rank"`` - The rank of the model based on it's ``"cost"``.
         * ``"cost"`` - The loss of the model on the validation set.
         * ``"ensemble_weight"`` - The weight given to the model in the ensemble.
+        * ``"voting_model"`` - The ``VotingX`` model (only for 'cv' resampling).
+        * ``"estimators"`` - List of dicts of models in the ``VotingX`` (only for 'cv' resampling).
         * ``"data_preprocessor"`` - The preprocessor used on the data.
         * ``"balancing"`` - The balancing used on the data (for classification).
         * ``"feature_preprocessor"`` - The preprocessor for features types.

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -492,13 +492,72 @@ class AutoSklearnEstimator(BaseEstimator):
         return self.automl_.score(X, y)
 
     def show_models(self):
-        """Return a representation of the final ensemble found by auto-sklearn.
+        """ Returns a dictionary containing dictionaries of ensemble models only.
+
+        Any model can be accessed by giving its ``model_id`` as key.
+
+        A model dictionary contains the following:
+
+        * ``"model_id"`` - The id given to a model by ``autosklearn``.
+        * ``"rank"`` - The rank of the model based on it's ``"cost"``.
+        * ``"cost"`` - The loss of the model on the validation set.
+        * ``"ensemble_weight"`` - The weight given to the model in the ensemble.
+        * ``"data_preprocessor"`` - The preprocessor used on the data.
+        * ``"balancing"`` - The balancing used on the data (for classification).
+        * ``"feature_preprocessor"`` - The preprocessor for features types.
+        * ``"classifier"`` or ``"regressor"`` - The autosklearn wrapped classifier or regressor.
+        * ``"sklearn_classifier"`` or ``"sklearn_regressor"`` - The sklearn classifier or regressor.
+
+        **Example**
+
+        .. code-block:: python
+
+            import sklearn.datasets
+            import sklearn.metrics
+            import autosklearn.regression
+
+            X, y = sklearn.datasets.load_diabetes(return_X_y=True)
+
+            automl = autosklearn.regression.AutoSklearnRegressor(
+                time_left_for_this_task=120
+                )
+            automl.fit(X_train, y_train, dataset_name='diabetes')
+
+            ensemble_dict = automl.show_models()
+            print(ensemble_dict)
+
+        Output:
+
+        .. code-block:: text
+
+            {
+                25: {'model_id': 25.0,
+                     'rank': 1,
+                     'cost': 0.43667876507897496,
+                     'ensemble_weight': 0.38,
+                     'data_preprocessor': <autosklearn.pipeline.components.data_preprocessing....>,
+                     'feature_preprocessor': <autosklearn.pipeline.components....>,
+                     'regressor': <autosklearn.pipeline.components.regression....>,
+                     'sklearn_regressor': SGDRegressor(alpha=0.0006517033225329654,...)
+                    },
+                6: {'model_id': 6.0,
+                    'rank': 2,
+                    'cost': 0.4550418898836528,
+                    'ensemble_weight': 0.3,
+                    'data_preprocessor': <autosklearn.pipeline.components.data_preprocessing....>,
+                    'feature_preprocessor': <autosklearn.pipeline.components....>,
+                    'regressor': <autosklearn.pipeline.components.regression....>,
+                    'sklearn_regressor': ARDRegression(alpha_1=0.0003701926442639788,...)
+                    }...
+            }
 
         Returns
         -------
-        str
+        Dict(int, Any) : dictionary of length = number of models in the ensemble
+            A dictionary of models in the ensemble, where ``model_id`` is the key.
 
         """
+
         return self.automl_.show_models()
 
     def get_models_with_weights(self):

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -502,8 +502,8 @@ class AutoSklearnEstimator(BaseEstimator):
         * ``"rank"`` - The rank of the model based on it's ``"cost"``.
         * ``"cost"`` - The loss of the model on the validation set.
         * ``"ensemble_weight"`` - The weight given to the model in the ensemble.
-        * ``"voting_model"`` - The ``VotingX`` model (only for 'cv' resampling).
-        * ``"estimators"`` - List of dicts of models in the ``VotingX`` (only for 'cv' resampling).
+        * ``"voting_model"`` - The ``cv_voting_ensemble`` model (for 'cv' resampling).
+        * ``"estimators"`` - List of models (dicts) in ``cv_voting_ensemble`` (for 'cv' resampling).
         * ``"data_preprocessor"`` - The preprocessor used on the data.
         * ``"balancing"`` - The balancing used on the data (for classification).
         * ``"feature_preprocessor"`` - The preprocessor for features types.

--- a/examples/20_basic/example_classification.py
+++ b/examples/20_basic/example_classification.py
@@ -7,6 +7,8 @@ Classification
 The following example shows how to fit a simple classification model with
 *auto-sklearn*.
 """
+from pprint import pprint
+
 import sklearn.datasets
 import sklearn.metrics
 
@@ -42,7 +44,7 @@ print(automl.leaderboard())
 # Print the final ensemble constructed by auto-sklearn
 # ====================================================
 
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 
 ###########################################################################
 # Get the Score of the final ensemble

--- a/examples/20_basic/example_multilabel_classification.py
+++ b/examples/20_basic/example_multilabel_classification.py
@@ -8,6 +8,7 @@ problem. Details on multilabel classification can be found
 `here <https://scikit-learn.org/stable/modules/multiclass.html>`_.
 """
 import numpy as np
+from pprint import pprint
 
 import sklearn.datasets
 import sklearn.metrics
@@ -65,7 +66,7 @@ print(automl.leaderboard())
 # Print the final ensemble constructed by auto-sklearn
 # ====================================================
 
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 
 ############################################################################
 # Print statistics about the auto-sklearn run

--- a/examples/20_basic/example_multioutput_regression.py
+++ b/examples/20_basic/example_multioutput_regression.py
@@ -8,6 +8,7 @@ The following example shows how to fit a multioutput regression model with
 *auto-sklearn*.
 """
 import numpy as numpy
+from pprint import pprint
 
 from sklearn.datasets import make_regression
 from sklearn.metrics import r2_score
@@ -46,7 +47,7 @@ print(automl.leaderboard())
 # Print the final ensemble constructed by auto-sklearn
 # ====================================================
 
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 
 ###########################################################################
 # Get the Score of the final ensemble

--- a/examples/20_basic/example_regression.py
+++ b/examples/20_basic/example_regression.py
@@ -7,6 +7,8 @@ Regression
 The following example shows how to fit a simple regression model with
 *auto-sklearn*.
 """
+from pprint import pprint
+
 import sklearn.datasets
 import sklearn.metrics
 
@@ -43,7 +45,7 @@ print(automl.leaderboard())
 # Print the final ensemble constructed by auto-sklearn
 # ====================================================
 
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 
 #####################################
 # Get the Score of the final ensemble

--- a/examples/40_advanced/example_get_pipeline_components.py
+++ b/examples/40_advanced/example_get_pipeline_components.py
@@ -62,8 +62,15 @@ print("Accuracy score:{}".format(
 # `Ensemble Selection <https://www.cs.cornell.edu/~alexn/papers/shotgun.icml04.revised.rev2.pdf>`_
 # to construct ensembles in a post-hoc fashion. The ensemble is a linear
 # weighting of all models constructed during the hyperparameter optimization.
-# This prints the final ensemble. It is a list of tuples, each tuple being
-# the model weight in the ensemble and the model itself.
+# This prints the final ensemble. It is a dictionary where ``model_id`` of
+# each model is a key, and its value is a dictionary containing information
+# of that model. A model's dict contains its ``'model_id'``, ``'rank'``,
+# ``'cost'``, ``'ensemble_weight'``, and the model itself. The model is
+# given by the ``'data_preprocessor'``, ``'feature_preprocessor'``,
+# ``'regressor'/'classifier'`` and ``'sklearn_regressor'/'sklearn_classifier'``
+# entries. But for the ``'cv'`` resampling strategy, the same for each cv
+# model is stored in the ``'estimators'`` list in the dict, along with the
+# ``'voting_model'``.
 
 print(automl.show_models())
 

--- a/examples/40_advanced/example_get_pipeline_components.py
+++ b/examples/40_advanced/example_get_pipeline_components.py
@@ -14,6 +14,8 @@ Auto-sklearn is a wrapper on top of
 the sklearn models. This example illustrates how to interact
 with the sklearn components directly, in this case a PCA preprocessor.
 """
+from pprint import pprint
+
 import sklearn.datasets
 import sklearn.metrics
 
@@ -63,7 +65,7 @@ print("Accuracy score:{}".format(
 # to construct ensembles in a post-hoc fashion. The ensemble is a linear
 # weighting of all models constructed during the hyperparameter optimization.
 # This prints the final ensemble. It is a dictionary where ``model_id`` of
-# each model is a key, and its value is a dictionary containing information
+# each model is a key, and value is a dictionary containing information
 # of that model. A model's dict contains its ``'model_id'``, ``'rank'``,
 # ``'cost'``, ``'ensemble_weight'``, and the model itself. The model is
 # given by the ``'data_preprocessor'``, ``'feature_preprocessor'``,
@@ -72,7 +74,7 @@ print("Accuracy score:{}".format(
 # model is stored in the ``'estimators'`` list in the dict, along with the
 # ``'voting_model'``.
 
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 
 ###########################################################################
 # Report statistics about the search

--- a/examples/40_advanced/example_interpretable_models.py
+++ b/examples/40_advanced/example_interpretable_models.py
@@ -7,6 +7,8 @@ Interpretable models
 The following example shows how to inspect the models which *auto-sklearn*
 optimizes over and how to restrict them to an interpretable subset.
 """
+from pprint import pprint
+
 import autosklearn.classification
 import sklearn.datasets
 import sklearn.metrics
@@ -70,7 +72,7 @@ automl.fit(X_train, y_train, dataset_name='breast_cancer')
 # Print the final ensemble constructed by auto-sklearn
 # ====================================================
 
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 
 ###########################################################################
 # Get the Score of the final ensemble

--- a/examples/60_search/example_random_search.py
+++ b/examples/60_search/example_random_search.py
@@ -12,6 +12,7 @@ SMAC, as demonstrated in the example below. Furthermore, the example also demons
 as yet another alternative optimizatino strategy.
 Both examples are intended to show how the optimization strategy in *auto-sklearn* can be adapted.
 """  # noqa (links are too long)
+from pprint import pprint
 
 import sklearn.model_selection
 import sklearn.datasets
@@ -75,7 +76,7 @@ automl.fit(X_train, y_train, dataset_name='breast_cancer')
 print('#' * 80)
 print('Results for ROAR.')
 # Print the final ensemble constructed by auto-sklearn via ROAR.
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 predictions = automl.predict(X_test)
 # Print statistics about the auto-sklearn run such as number of
 # iterations, number of models failed with a time out.
@@ -129,7 +130,7 @@ print('#' * 80)
 print('Results for random search.')
 
 # Print the final ensemble constructed by auto-sklearn via random search.
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 
 # Print statistics about the auto-sklearn run such as number of
 # iterations, number of models failed with a time out.

--- a/examples/60_search/example_sequential.py
+++ b/examples/60_search/example_sequential.py
@@ -8,6 +8,7 @@ ensembles in parallel. However, it is also possible to run the two processes
 sequentially. The example below shows how to first fit the models and build the
 ensembles afterwards.
 """
+from pprint import pprint
 
 import sklearn.model_selection
 import sklearn.datasets
@@ -48,7 +49,7 @@ automl.fit_ensemble(y_train, ensemble_size=50)
 # Print the final ensemble constructed by auto-sklearn
 # ====================================================
 
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 
 ############################################################################
 # Get the Score of the final ensemble

--- a/examples/60_search/example_successive_halving.py
+++ b/examples/60_search/example_successive_halving.py
@@ -14,7 +14,7 @@ It uses Successive Halving instead of `Hyperband <https://jmlr.org/papers/volume
 To get the BOHB algorithm, simply import Hyperband and use it as the intensification strategy.
 
 """  # noqa (links are too long)
-
+from pprint import pprint
 
 import sklearn.model_selection
 import sklearn.datasets
@@ -110,7 +110,7 @@ automl = autosklearn.classification.AutoSklearnClassifier(
 )
 automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 predictions = automl.predict(X_test)
 # Print statistics about the auto-sklearn run such as number of
 # iterations, number of models failed with a time out.
@@ -143,7 +143,7 @@ automl = autosklearn.classification.AutoSklearnClassifier(
 automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
 # Print the final ensemble constructed by auto-sklearn.
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 automl.refit(X_train, y_train)
 predictions = automl.predict(X_test)
 # Print statistics about the auto-sklearn run such as number of
@@ -177,7 +177,7 @@ automl = autosklearn.classification.AutoSklearnClassifier(
 automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
 # Print the final ensemble constructed by auto-sklearn.
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 automl.refit(X_train, y_train)
 predictions = automl.predict(X_test)
 # Print statistics about the auto-sklearn run such as number of
@@ -208,7 +208,7 @@ automl = autosklearn.classification.AutoSklearnClassifier(
 automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
 # Print the final ensemble constructed by auto-sklearn.
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 predictions = automl.predict(X_test)
 # Print statistics about the auto-sklearn run such as number of
 # iterations, number of models failed with a time out.
@@ -245,7 +245,7 @@ automl = autosklearn.classification.AutoSklearnClassifier(
 automl.fit(X_train, y_train, dataset_name='breast_cancer')
 
 # Print the final ensemble constructed by auto-sklearn.
-print(automl.show_models())
+pprint(automl.show_models(), indent=4)
 predictions = automl.predict(X_test)
 # Print statistics about the auto-sklearn run such as number of
 # iterations, number of models failed with a time out.

--- a/examples/80_extending/example_extending_classification.py
+++ b/examples/80_extending/example_extending_classification.py
@@ -6,6 +6,7 @@ Extending Auto-Sklearn with Classification Component
 The following example demonstrates how to create a new classification
 component for using in auto-sklearn.
 """
+from pprint import pprint
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
@@ -149,4 +150,4 @@ clf.fit(X_train, y_train)
 
 y_pred = clf.predict(X_test)
 print("accuracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))
-print(clf.show_models())
+pprint(clf.show_models(), indent=4)

--- a/examples/80_extending/example_extending_data_preprocessor.py
+++ b/examples/80_extending/example_extending_data_preprocessor.py
@@ -5,6 +5,7 @@ Extending Auto-Sklearn with Data Preprocessor Component
 
 The following example demonstrates how to turn off data preprocessing step in auto-skearn.
 """
+from pprint import pprint
 
 import autosklearn.classification
 import autosklearn.pipeline.components.data_preprocessing
@@ -89,4 +90,4 @@ print(clf.sprint_statistics())
 
 y_pred = clf.predict(X_test)
 print("accuracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))
-print(clf.show_models())
+pprint(clf.show_models(), indent=4)

--- a/examples/80_extending/example_extending_preprocessor.py
+++ b/examples/80_extending/example_extending_preprocessor.py
@@ -7,6 +7,7 @@ The following example demonstrates how to create a wrapper around the linear
 discriminant analysis (LDA) algorithm from sklearn and use it as a preprocessor
 in auto-sklearn.
 """
+from pprint import pprint
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter, CategoricalHyperparameter
@@ -130,4 +131,4 @@ clf.fit(X_train, y_train)
 
 y_pred = clf.predict(X_test)
 print("accuracy: ", sklearn.metrics.accuracy_score(y_pred, y_test))
-print(clf.show_models())
+pprint(clf.show_models(), indent=4)

--- a/examples/80_extending/example_extending_regression.py
+++ b/examples/80_extending/example_extending_regression.py
@@ -6,6 +6,7 @@ Extending Auto-Sklearn with Regression Component
 The following example demonstrates how to create a new regression
 component for using in auto-sklearn.
 """
+from pprint import pprint
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter, \
@@ -137,4 +138,4 @@ reg.fit(X_train, y_train)
 # =====================================
 y_pred = reg.predict(X_test)
 print("r2 score: ", sklearn.metrics.r2_score(y_pred, y_test))
-print(reg.show_models())
+pprint(reg.show_models(), indent=4)

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -469,7 +469,8 @@ def test_leaderboard(
 @pytest.mark.parametrize('estimator', [AutoSklearnRegressor])
 @pytest.mark.parametrize('resampling_strategy', ['holdout'])
 @pytest.mark.parametrize('X', [
-    np.asarray([[1.0, 1.0, 1.0]] * 50 + [[2.0, 2.0, 2.0]] * 50)
+    np.asarray([[1.0, 1.0, 1.0]] * 25 + [[2.0, 2.0, 2.0]] * 25 +
+               [[3.0, 3.0, 3.0]] * 25 + [[4.0, 4.0, 4.0]] * 25)
 ])
 @pytest.mark.parametrize('y', [
     np.asarray([1.0] * 25 + [2.0] * 25 + [3.0] * 25 + [4.0] * 25)
@@ -522,16 +523,16 @@ def test_show_models_with_holdout(
 
     models = automl.show_models().values()
 
-    model_keys = [
+    model_keys = set([
         'model_id', 'rank', 'cost', 'ensemble_weight',
         'data_preprocessor', 'feature_preprocessor',
         'regressor', 'sklearn_regressor'
-    ]
+    ])
 
-    assert all([model_keys == list(model.keys()) for model in models]) is True
-    assert all([model['regressor'] for model in models]) is True
-    assert all([model['sklearn_regressor'] for model in models]) is True
-    assert any([None in model.values() for model in models]) is False
+    assert all([model_keys == set(model.keys()) for model in models])
+    assert all([model['regressor'] for model in models])
+    assert all([model['sklearn_regressor'] for model in models])
+    assert not any([None in model.values() for model in models])
 
 
 @pytest.mark.parametrize('estimator', [AutoSklearnClassifier])
@@ -592,28 +593,28 @@ def test_show_models_with_cv(
 
     models = automl.show_models().values()
 
-    model_keys = [
+    model_keys = set([
         'model_id', 'rank',
         'cost', 'ensemble_weight',
         'voting_model', 'estimators'
-    ]
+    ])
 
-    estimator_keys = [
+    estimator_keys = set([
         'data_preprocessor', 'balancing',
         'feature_preprocessor', 'classifier',
         'sklearn_classifier'
-    ]
+    ])
 
-    assert all([model_keys == list(model.keys()) for model in models]) is True
-    assert any([None in model.values() for model in models]) is False
-    assert all([estimator_keys == list(estimator.keys())
-                for model in models for estimator in model['estimators']]) is True
+    assert all([model_keys == set(model.keys()) for model in models])
+    assert not any([None in model.values() for model in models])
+    assert all([estimator_keys == set(estimator.keys())
+                for model in models for estimator in model['estimators']])
     assert all([estimator['classifier']
-                for model in models for estimator in model['estimators']]) is True
+                for model in models for estimator in model['estimators']])
     assert all([estimator['sklearn_classifier']
-                for model in models for estimator in model['estimators']]) is True
-    assert any([None in estimator.values()
-                for model in models for estimator in model['estimators']]) is False
+                for model in models for estimator in model['estimators']])
+    assert not any([None in estimator.values()
+                    for model in models for estimator in model['estimators']])
 
 
 @unittest.mock.patch('autosklearn.estimators.AutoSklearnEstimator.build_automl')

--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -28,6 +28,7 @@ from sklearn.base import clone
 from sklearn.base import ClassifierMixin, RegressorMixin
 from sklearn.base import is_classifier
 from smac.tae import StatusType
+from dask.distributed import Client
 
 from autosklearn.data.validation import InputValidator
 import autosklearn.pipeline.util as putil
@@ -463,6 +464,156 @@ def test_leaderboard(
                 and 'ensemble_weight' in columns
             ):
                 assert all(leaderboard['ensemble_weight'] > 0)
+
+
+@pytest.mark.parametrize('estimator', [AutoSklearnRegressor])
+@pytest.mark.parametrize('resampling_strategy', ['holdout'])
+@pytest.mark.parametrize('X', [
+    np.asarray([[1.0, 1.0, 1.0]] * 50 + [[2.0, 2.0, 2.0]] * 50)
+])
+@pytest.mark.parametrize('y', [
+    np.asarray([1.0] * 25 + [2.0] * 25 + [3.0] * 25 + [4.0] * 25)
+])
+def test_show_models_with_holdout(
+    tmp_dir: str,
+    dask_client: Client,
+    estimator: AutoSklearnEstimator,
+    resampling_strategy: str,
+    X: np.ndarray,
+    y: np.ndarray
+) -> None:
+    """
+    Parameters
+    ----------
+    tmp_dir: str
+        The temporary directory to use for this test
+
+    dask_client: dask.distributed.Client
+         The dask client to use for this test
+
+    estimator: AutoSklearnEstimator
+         The estimator to train
+
+    resampling_strategy: str
+         The resampling strategy to use
+
+    X: np.ndarray
+        The X data to use for this estimator
+
+    y: np.ndarray
+         The targets to use for this estimator
+
+    Expects
+    -------
+    * Expects all the model dictionaries to have ``model_keys``
+    * Expects all models to have an auto-sklearn wrapped model ``regressor``
+    * Expects all models to have a sklearn wrapped model ``sklearn_regressor``
+    * Expects no model to have any ``None`` value
+    """
+
+    automl = estimator(
+        time_left_for_this_task=60,
+        per_run_time_limit=5,
+        tmp_folder=tmp_dir,
+        resampling_strategy=resampling_strategy,
+        dask_client=dask_client
+    )
+    automl.fit(X, y)
+
+    models = automl.show_models().values()
+
+    model_keys = [
+        'model_id', 'rank', 'cost', 'ensemble_weight',
+        'data_preprocessor', 'feature_preprocessor',
+        'regressor', 'sklearn_regressor'
+    ]
+
+    assert all([model_keys == list(model.keys()) for model in models]) is True
+    assert all([model['regressor'] for model in models]) is True
+    assert all([model['sklearn_regressor'] for model in models]) is True
+    assert any([None in model.values() for model in models]) is False
+
+
+@pytest.mark.parametrize('estimator', [AutoSklearnClassifier])
+@pytest.mark.parametrize('resampling_strategy', ['cv'])
+@pytest.mark.parametrize('X', [
+    np.asarray([[1.0, 1.0, 1.0]] * 50 + [[2.0, 2.0, 2.0]] * 50)
+])
+@pytest.mark.parametrize('y', [
+    np.asarray([1] * 50 + [2] * 50)
+])
+def test_show_models_with_cv(
+    tmp_dir: str,
+    dask_client: Client,
+    estimator: AutoSklearnEstimator,
+    resampling_strategy: str,
+    X: np.ndarray,
+    y: np.ndarray
+) -> None:
+    """
+    Parameters
+    ----------
+    tmp_dir: str
+        The temporary directory to use for this test
+
+    dask_client: dask.distributed.Client
+         The dask client to use for this test
+
+    estimator: AutoSklearnEstimator
+         The estimator to train
+
+    resampling_strategy: str
+         The resampling strategy to use
+
+    X: np.ndarray
+        The X data to use for this estimator
+
+    y: np.ndarray
+         The targets to use for this estimator
+
+    Expects
+    -------
+    * Expects all the model dictionaries to have ``model_keys``
+    * Expects no model to have any ``None`` value
+    * Expects all the estimators in a model to have ``estimator_keys``
+    * Expects all model estimators to have an auto-sklearn wrapped model ``classifier``
+    * Expects all model estimators to have a sklearn wrapped model ``sklearn_classifier``
+    * Expects no estimator to have ``None`` value
+    """
+
+    automl = estimator(
+        time_left_for_this_task=120,
+        per_run_time_limit=5,
+        tmp_folder=tmp_dir,
+        resampling_strategy=resampling_strategy,
+        dask_client=dask_client
+    )
+    automl.fit(X, y)
+
+    models = automl.show_models().values()
+
+    model_keys = [
+        'model_id', 'rank',
+        'cost', 'ensemble_weight',
+        'voting_model', 'estimators'
+    ]
+
+    estimator_keys = [
+        'data_preprocessor', 'balancing',
+        'feature_preprocessor', 'classifier',
+        'sklearn_classifier'
+    ]
+
+    assert all([model_keys == list(model.keys()) for model in models]) is True
+    assert any([None in model.values() for model in models]) is False
+    assert all([estimator_keys == list(estimator.keys())
+                for model in models for estimator in model['estimators']]) is True
+    assert all([estimator['classifier']
+                for model in models for estimator in model['estimators']]) is True
+    assert all([estimator['sklearn_classifier']
+                for model in models for estimator in model['estimators']]) is True
+    assert any([None in estimator.values()
+                for model in models for estimator in model['estimators']]) is False
 
 
 @unittest.mock.patch('autosklearn.estimators.AutoSklearnEstimator.build_automl')


### PR DESCRIPTION
### Summary
Currently the `show_models()` function returns an `str` that has to be manually parsed with no way to access the models. I have changed it so that it returns a dictionary of models in ensemble and their information. This helps fix issue #1298 and the issues mentioned inside that thread.

### What's changed
Using `show_models()` will return a dictionary where the key would be **model_id**. Each entry is a *model* dictionary which contains the following:
- model_id
- rank
- ensemble_weight
- data preprocessor
- balancing
- feature_preprocessor
- regressor or classifier (autosklearn wrapped model)
- sklearn model

### Example
```
import sklearn.datasets
import sklearn.metrics

import autosklearn.regression
import matplotlib.pyplot as plt

X, y = sklearn.datasets.load_diabetes(return_X_y=True)

X_train, X_test, y_train, y_test = \
    sklearn.model_selection.train_test_split(X, y, random_state=1)

automl = autosklearn.regression.AutoSklearnRegressor(
    time_left_for_this_task=120,
    per_run_time_limit=30,
    tmp_folder='/tmp/autosklearn_regression_example_tmp',
)
automl.fit(X_train, y_train, dataset_name='diabetes')

ensemble_dict = automl.show_models()
print(ensemble_dict)
```
Output:
```
{
25: {'model_id': 25.0, 'rank': 1.0, 'ensemble_weight': 0.46, 'data_preprocessor': <autosklearn.pipeline.components.data_preprocessing.DataPreprocessorChoice object at 0x7ff2c06588d0>, 'feature_preprocessor': <autosklearn.pipeline.components.feature_preprocessing.FeaturePreprocessorChoice object at 0x7ff2c057bd50>, 'regressor': <autosklearn.pipeline.components.regression.RegressorChoice object at 0x7ff2c057ba90>, 'sklearn_model': SGDRegressor(alpha=0.0006517033225329654, epsilon=0.012150149892783745,
             eta0=0.016444224834275295, l1_ratio=1.7462342366289323e-09,
             loss='epsilon_insensitive', max_iter=16, penalty='elasticnet',
             power_t=0.21521743568582094, random_state=1,
             tol=0.002431731981071206, warm_start=True)}, 
6: {'model_id': 6.0, 'rank': 2.0, 'ensemble_weight': 0.32, 'data_preprocessor': <autosklearn.pipeline.components.data_preprocessing.DataPreprocessorChoice object at 0x7ff2c05b3f50>, 'feature_preprocessor': <autosklearn.pipeline.components.feature_preprocessing.FeaturePreprocessorChoice object at 0x7ff2c065c990>, 'regressor': <autosklearn.pipeline.components.regression.RegressorChoice object at 0x7ff2c057ba10>, 'sklearn_model': ARDRegression(alpha_1=0.0003701926442639788, alpha_2=2.2118001735899097e-07,
              copy_X=False, lambda_1=1.2037591637980971e-06,
              lambda_2=4.358378124977852e-09,
              threshold_lambda=1136.5286041327277, tol=0.021944240404849075)}, ....
```