### PR TITLE
Fix regression algorithms to give correct output dimensions

### DIFF
--- a/autosklearn/pipeline/components/regression/adaboost.py
+++ b/autosklearn/pipeline/components/regression/adaboost.py
@@ -15,7 +15,7 @@ class AdaboostRegressor(AutoSklearnRegressionAlgorithm):
         self.max_depth = max_depth
         self.estimator = None
 
-    def fit(self, X, Y):
+    def fit(self, X, y):
         import sklearn.ensemble
         import sklearn.tree
 
@@ -32,7 +32,11 @@ class AdaboostRegressor(AutoSklearnRegressionAlgorithm):
             loss=self.loss,
             random_state=self.random_state
         )
-        self.estimator.fit(X, Y)
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
+
+        self.estimator.fit(X, y)
         return self
 
     def predict(self, X):

--- a/autosklearn/pipeline/components/regression/ard_regression.py
+++ b/autosklearn/pipeline/components/regression/ard_regression.py
@@ -22,8 +22,8 @@ class ARDRegression(AutoSklearnRegressionAlgorithm):
         self.threshold_lambda = threshold_lambda
         self.fit_intercept = fit_intercept
 
-    def fit(self, X, Y):
-        import sklearn.linear_model
+    def fit(self, X, y):
+        from sklearn.linear_model import ARDRegression
 
         self.n_iter = int(self.n_iter)
         self.tol = float(self.tol)
@@ -34,20 +34,25 @@ class ARDRegression(AutoSklearnRegressionAlgorithm):
         self.threshold_lambda = float(self.threshold_lambda)
         self.fit_intercept = check_for_bool(self.fit_intercept)
 
-        self.estimator = sklearn.linear_model.\
-            ARDRegression(n_iter=self.n_iter,
-                          tol=self.tol,
-                          alpha_1=self.alpha_1,
-                          alpha_2=self.alpha_2,
-                          lambda_1=self.lambda_1,
-                          lambda_2=self.lambda_2,
-                          compute_score=False,
-                          threshold_lambda=self.threshold_lambda,
-                          fit_intercept=True,
-                          normalize=False,
-                          copy_X=False,
-                          verbose=False)
-        self.estimator.fit(X, Y)
+        self.estimator = ARDRegression(
+            n_iter=self.n_iter,
+            tol=self.tol,
+            alpha_1=self.alpha_1,
+            alpha_2=self.alpha_2,
+            lambda_1=self.lambda_1,
+            lambda_2=self.lambda_2,
+            compute_score=False,
+            threshold_lambda=self.threshold_lambda,
+            fit_intercept=True,
+            normalize=False,
+            copy_X=False,
+            verbose=False
+        )
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
+
+        self.estimator.fit(X, y)
         return self
 
     def predict(self, X):

--- a/autosklearn/pipeline/components/regression/decision_tree.py
+++ b/autosklearn/pipeline/components/regression/decision_tree.py
@@ -56,6 +56,10 @@ class DecisionTree(AutoSklearnRegressionAlgorithm):
             min_weight_fraction_leaf=self.min_weight_fraction_leaf,
             min_impurity_decrease=self.min_impurity_decrease,
             random_state=self.random_state)
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
+
         self.estimator.fit(X, y, sample_weight=sample_weight)
         return self
 

--- a/autosklearn/pipeline/components/regression/extra_trees.py
+++ b/autosklearn/pipeline/components/regression/extra_trees.py
@@ -95,7 +95,10 @@ class ExtraTreesRegressor(
             self.estimator.n_estimators = min(self.estimator.n_estimators,
                                               self.n_estimators)
 
-        self.estimator.fit(X, y,)
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
+
+        self.estimator.fit(X, y)
 
         return self
 

--- a/autosklearn/pipeline/components/regression/gaussian_process.py
+++ b/autosklearn/pipeline/components/regression/gaussian_process.py
@@ -12,7 +12,6 @@ class GaussianProcess(AutoSklearnRegressionAlgorithm):
         self.thetaU = thetaU
         self.random_state = random_state
         self.estimator = None
-        self.scaler = None
 
     def fit(self, X, y):
         import sklearn.gaussian_process
@@ -37,6 +36,9 @@ class GaussianProcess(AutoSklearnRegressionAlgorithm):
             random_state=self.random_state,
             normalize_y=True
         )
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
 
         self.estimator.fit(X, y)
 

--- a/autosklearn/pipeline/components/regression/gradient_boosting.py
+++ b/autosklearn/pipeline/components/regression/gradient_boosting.py
@@ -48,10 +48,7 @@ class GradientBoosting(
         return self.estimator.n_iter_
 
     def iterative_fit(self, X, y, n_iter=2, refit=False):
-
-        """
-        Set n_iter=2 for the same reason as for SGD
-        """
+        """ Set n_iter=2 for the same reason as for SGD """
         import sklearn.ensemble
         from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 
@@ -111,6 +108,9 @@ class GradientBoosting(
             self.estimator.max_iter += n_iter
             self.estimator.max_iter = min(self.estimator.max_iter,
                                           self.max_iter)
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
 
         self.estimator.fit(X, y)
 

--- a/autosklearn/pipeline/components/regression/k_nearest_neighbors.py
+++ b/autosklearn/pipeline/components/regression/k_nearest_neighbors.py
@@ -13,7 +13,7 @@ class KNearestNeighborsRegressor(AutoSklearnRegressionAlgorithm):
         self.p = p
         self.random_state = random_state
 
-    def fit(self, X, Y):
+    def fit(self, X, y):
         import sklearn.neighbors
 
         self.n_neighbors = int(self.n_neighbors)
@@ -24,7 +24,11 @@ class KNearestNeighborsRegressor(AutoSklearnRegressionAlgorithm):
                 n_neighbors=self.n_neighbors,
                 weights=self.weights,
                 p=self.p)
-        self.estimator.fit(X, Y)
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
+
+        self.estimator.fit(X, y)
         return self
 
     def predict(self, X):

--- a/autosklearn/pipeline/components/regression/liblinear_svr.py
+++ b/autosklearn/pipeline/components/regression/liblinear_svr.py
@@ -23,7 +23,7 @@ class LibLinear_SVR(AutoSklearnRegressionAlgorithm):
         self.random_state = random_state
         self.estimator = None
 
-    def fit(self, X, Y):
+    def fit(self, X, y):
         import sklearn.svm
 
         self.C = float(self.C)
@@ -42,7 +42,11 @@ class LibLinear_SVR(AutoSklearnRegressionAlgorithm):
                                                fit_intercept=self.fit_intercept,
                                                intercept_scaling=self.intercept_scaling,
                                                random_state=self.random_state)
-        self.estimator.fit(X, Y)
+
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
+
+        self.estimator.fit(X, y)
         return self
 
     def predict(self, X):

--- a/autosklearn/pipeline/components/regression/libsvm_svr.py
+++ b/autosklearn/pipeline/components/regression/libsvm_svr.py
@@ -6,7 +6,6 @@ from ConfigSpace.conditions import InCondition, EqualsCondition
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter, \
     UniformIntegerHyperparameter, CategoricalHyperparameter, \
     UnParametrizedHyperparameter
-
 from autosklearn.pipeline.components.base import AutoSklearnRegressionAlgorithm
 from autosklearn.pipeline.constants import DENSE, UNSIGNED_DATA, PREDICTIONS, SPARSE
 from autosklearn.util.common import check_for_bool, check_none
@@ -29,7 +28,7 @@ class LibSVM_SVR(AutoSklearnRegressionAlgorithm):
         self.random_state = random_state
         self.estimator = None
 
-    def fit(self, X, Y):
+    def fit(self, X, y):
         import sklearn.svm
 
         # Calculate the size of the kernel cache (in MB) for sklearn's LibSVM. The cache size is
@@ -88,9 +87,19 @@ class LibSVM_SVR(AutoSklearnRegressionAlgorithm):
         )
         self.scaler = sklearn.preprocessing.StandardScaler(copy=True)
 
-        self.scaler.fit(Y.reshape((-1, 1)))
-        Y_scaled = self.scaler.transform(Y.reshape((-1, 1))).ravel()
-        self.estimator.fit(X, Y_scaled)
+        # Convert y to be at least 2d for the scaler
+        # [1,1,1] -> [[1], [1], [1]]
+        if y.ndim == 1:
+            y = y.reshape((-1, 1))
+
+        y_scaled = self.scaler.fit_transform(y)
+
+        # Flatten: [[0], [0], [0]] -> [0, 0, 0]
+        if y_scaled.ndim == 2 and y_scaled.shape[1] == 1:
+            y_scaled = y_scaled.flatten()
+
+        self.estimator.fit(X, y_scaled)
+
         return self
 
     def predict(self, X):
@@ -98,8 +107,15 @@ class LibSVM_SVR(AutoSklearnRegressionAlgorithm):
             raise NotImplementedError
         if self.scaler is None:
             raise NotImplementedError
-        Y_pred = self.estimator.predict(X)
-        return self.scaler.inverse_transform(Y_pred)
+        y_pred = self.estimator.predict(X)
+
+        inverse = self.scaler.inverse_transform(y_pred)
+
+        # Flatten: [[0], [0], [0]] -> [0, 0, 0]
+        if inverse.ndim == 2 and inverse.shape[1] == 1:
+            inverse = inverse.flatten()
+
+        return inverse
 
     @staticmethod
     def get_properties(dataset_properties=None):

--- a/autosklearn/pipeline/components/regression/mlp.py
+++ b/autosklearn/pipeline/components/regression/mlp.py
@@ -137,16 +137,36 @@ class MLPRegressor(
                 # max_fun=self.max_fun
             )
             self.scaler = sklearn.preprocessing.StandardScaler(copy=True)
-            self.scaler.fit(y.reshape((-1, 1)))
+
+            # Convert y to be at least 2d for the StandardScaler
+            # [1,1,1] -> [[1], [1], [1]]
+            if y.ndim == 1:
+                y = y.reshape((-1, 1))
+
+            self.scaler.fit(y)
         else:
             new_max_iter = min(self.max_iter - self.estimator.n_iter_, n_iter)
             self.estimator.max_iter = new_max_iter
 
-        Y_scaled = self.scaler.transform(y.reshape((-1, 1))).ravel()
-        self.estimator.fit(X, Y_scaled)
-        if self.estimator.n_iter_ >= self.max_iter or \
-                self.estimator._no_improvement_count > self.n_iter_no_change:
+        # Convert y to be at least 2d for the scaler
+        # [1,1,1] -> [[1], [1], [1]]
+        if y.ndim == 1:
+            y = y.reshape((-1, 1))
+
+        y_scaled = self.scaler.transform(y)
+
+        # Flatten: [[0], [0], [0]] -> [0, 0, 0]
+        if y_scaled.ndim == 2 and y_scaled.shape[1] == 1:
+            y_scaled = y_scaled.flatten()
+
+        self.estimator.fit(X, y_scaled)
+
+        if (
+            self.estimator.n_iter_ >= self.max_iter
+            or self.estimator._no_improvement_count > self.n_iter_no_change
+        ):
             self._fully_fit = True
+
         return self
 
     def configuration_fully_fitted(self):
@@ -160,8 +180,16 @@ class MLPRegressor(
     def predict(self, X):
         if self.estimator is None:
             raise NotImplementedError
-        Y_pred = self.estimator.predict(X)
-        return self.scaler.inverse_transform(Y_pred)
+
+        y_pred = self.estimator.predict(X)
+
+        inverse = self.scaler.inverse_transform(y_pred)
+
+        # Flatten: [[0], [0], [0]] -> [0, 0, 0]
+        if inverse.ndim == 2 and inverse.shape[1] == 1:
+            inverse = inverse.flatten()
+
+        return inverse
 
     @staticmethod
     def get_properties(dataset_properties=None):

--- a/autosklearn/pipeline/components/regression/random_forest.py
+++ b/autosklearn/pipeline/components/regression/random_forest.py
@@ -85,6 +85,9 @@ class RandomForest(
             self.estimator.n_estimators = min(self.estimator.n_estimators,
                                               self.n_estimators)
 
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.flatten()
+
         self.estimator.fit(X, y)
         return self
 

--- a/autosklearn/pipeline/components/regression/sgd.py
+++ b/autosklearn/pipeline/components/regression/sgd.py
@@ -90,17 +90,36 @@ class SGD(
                                           warm_start=True)
 
             self.scaler = sklearn.preprocessing.StandardScaler(copy=True)
-            self.scaler.fit(y.reshape((-1, 1)))
-            Y_scaled = self.scaler.transform(y.reshape((-1, 1))).ravel()
-            self.estimator.fit(X, Y_scaled)
+
+            if y.ndim == 1:
+                y = y.reshape((-1, 1))
+
+            y_scaled = self.scaler.fit_transform(y)
+
+            # Flatten: [[0], [0], [0]] -> [0, 0, 0]
+            if y_scaled.ndim == 2 and y_scaled.shape[1] == 1:
+                y_scaled = y_scaled.flatten()
+
+            self.estimator.fit(X, y_scaled)
             self.n_iter_ = self.estimator.n_iter_
         else:
             self.estimator.max_iter += n_iter
             self.estimator.max_iter = min(self.estimator.max_iter, self.max_iter)
-            Y_scaled = self.scaler.transform(y.reshape((-1, 1))).ravel()
+
+            # Convert y to be at least 2d for the scaler
+            # [1,1,1] -> [[1], [1], [1]]
+            if y.ndim == 1:
+                y = y.reshape((-1, 1))
+
+            y_scaled = self.scaler.transform(y)
+
+            # Flatten: [[0], [0], [0]] -> [0, 0, 0]
+            if y_scaled.ndim == 2 and y_scaled.shape[1] == 1:
+                y_scaled = y_scaled.flatten()
+
             self.estimator._validate_params()
             self.estimator._partial_fit(
-                X, Y_scaled,
+                X, y_scaled,
                 alpha=self.estimator.alpha,
                 C=1.0,
                 loss=self.estimator.loss,

--- a/test/test_pipeline/components/regression/test_base.py
+++ b/test/test_pipeline/components/regression/test_base.py
@@ -297,7 +297,7 @@ class BaseRegressionComponentTest(unittest.TestCase):
 @pytest.mark.parametrize("X", [np.array([[1, 2, 3]] * 20)])
 @pytest.mark.parametrize("y", [np.array([1] * 20)])
 def test_fit_and_predict_with_1d_targets_as_1d(
-    regressor: RegressorChoice,
+    regressor: Type[RegressorChoice],
     X: np.ndarray,
     y: np.ndarray
 ):
@@ -333,8 +333,6 @@ def test_fit_and_predict_with_1d_targets_as_1d(
 
     predictions = model.predict(X)
 
-    print(predictions)
-    print(y)
     assert predictions.shape == y.shape
 
 
@@ -342,7 +340,7 @@ def test_fit_and_predict_with_1d_targets_as_1d(
 @pytest.mark.parametrize("X", [np.array([[1, 2, 3]] * 20)])
 @pytest.mark.parametrize("y", [np.array([[1]] * 20)])
 def test_fit_and_predict_with_1d_targets_as_2d(
-    regressor: RegressorChoice,
+    regressor: Type[ RegressorChoice ],
     X: np.ndarray,
     y: np.ndarray
 ):
@@ -390,7 +388,11 @@ def test_fit_and_predict_with_1d_targets_as_2d(
 ])
 @pytest.mark.parametrize("X", [np.array([[1, 2, 3]] * 20)])
 @pytest.mark.parametrize("y", [np.array([[1, 1, 1]] * 20)])
-def test_fit_and_predict_with_2d_targets(regressor: RegressorChoice, X: np.ndarray, y: np.ndarray):
+def test_fit_and_predict_with_2d_targets(
+    regressor: Type[RegressorChoice],
+    X: np.ndarray,
+    y: np.ndarray
+):
     """Test that all pipelines work with 2d target types
 
     Parameters

--- a/test/test_pipeline/components/regression/test_base.py
+++ b/test/test_pipeline/components/regression/test_base.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 import unittest
 
 import pytest
@@ -340,7 +342,7 @@ def test_fit_and_predict_with_1d_targets_as_1d(
 @pytest.mark.parametrize("X", [np.array([[1, 2, 3]] * 20)])
 @pytest.mark.parametrize("y", [np.array([[1]] * 20)])
 def test_fit_and_predict_with_1d_targets_as_2d(
-    regressor: Type[ RegressorChoice ],
+    regressor: Type[RegressorChoice],
     X: np.ndarray,
     y: np.ndarray
 ):

--- a/test/test_pipeline/components/regression/test_base.py
+++ b/test/test_pipeline/components/regression/test_base.py
@@ -1,12 +1,17 @@
 import unittest
 
+import pytest
+
 import numpy as np
 import sklearn.metrics
 
-from autosklearn.pipeline.util import _test_regressor, \
-    _test_regressor_iterative_fit
+from autosklearn.pipeline.util import _test_regressor, _test_regressor_iterative_fit
 from autosklearn.pipeline.constants import SPARSE
 from autosklearn.pipeline.components.regression.libsvm_svr import LibSVM_SVR
+
+from autosklearn.pipeline.components.regression import _regressors, RegressorChoice
+
+from ...ignored_warnings import regressor_warnings, ignore_warnings
 
 
 class BaseRegressionComponentTest(unittest.TestCase):
@@ -286,3 +291,136 @@ class BaseRegressionComponentTest(unittest.TestCase):
                     seed == random_state
                     for random_state in [rs_1, rs_estimator_1, rs_2, rs_estimator_2]
                 ])
+
+
+@pytest.mark.parametrize("regressor", _regressors.values())
+@pytest.mark.parametrize("X", [np.array([[1, 2, 3]] * 20)])
+@pytest.mark.parametrize("y", [np.array([1] * 20)])
+def test_fit_and_predict_with_1d_targets_as_1d(
+    regressor: RegressorChoice,
+    X: np.ndarray,
+    y: np.ndarray
+):
+    """Test that all pipelines work with 1d target types
+
+    Parameters
+    ----------
+    regressor: RegressorChoice
+        The regressor to test
+
+    X: np.ndarray
+        The features
+
+    y: np.ndarray
+        The 1d targets
+
+    Expects
+    -------
+    * Should be able to fit with 1d targets
+    * Should be able to predict with 1d targest
+    * Should have predictions with the same shape as y
+    """
+    assert len(X) == len(y)
+    assert y.ndim == 1
+
+    config_space = regressor.get_hyperparameter_search_space()
+    default_config = config_space.get_default_configuration()
+
+    model = regressor(random_state=0, **default_config)
+
+    with ignore_warnings(regressor_warnings):
+        model.fit(X, y)
+
+    predictions = model.predict(X)
+
+    print(predictions)
+    print(y)
+    assert predictions.shape == y.shape
+
+
+@pytest.mark.parametrize("regressor", _regressors.values())
+@pytest.mark.parametrize("X", [np.array([[1, 2, 3]] * 20)])
+@pytest.mark.parametrize("y", [np.array([[1]] * 20)])
+def test_fit_and_predict_with_1d_targets_as_2d(
+    regressor: RegressorChoice,
+    X: np.ndarray,
+    y: np.ndarray
+):
+    """Test that all pipelines work with 1d target types when they are wrapped as 2d
+
+    Parameters
+    ----------
+    regressor: RegressorChoice
+        The regressor to test
+
+    X: np.ndarray
+        The features
+
+    y: np.ndarray
+        The 1d targets wrapped as 2d
+
+    Expects
+    -------
+    * Should be able to fit with 1d targets wrapped in 2d
+    * Should be able to predict 1d targets wrapped in 2d
+    * Should return 1d predictions
+    * Should have predictions with the same length as the y
+    """
+    assert len(X) == len(y)
+    assert y.ndim == 2 and y.shape[1] == 1
+
+    config_space = regressor.get_hyperparameter_search_space()
+    default_config = config_space.get_default_configuration()
+
+    model = regressor(random_state=0, **default_config)
+
+    with ignore_warnings(regressor_warnings):
+        model.fit(X, y)
+
+    predictions = model.predict(X)
+
+    assert predictions.ndim == 1
+    assert len(predictions) == len(y)
+
+
+@pytest.mark.parametrize("regressor", [
+    regressor
+    for regressor in _regressors.values()
+    if regressor.get_properties()['handles_multilabel']
+])
+@pytest.mark.parametrize("X", [np.array([[1, 2, 3]] * 20)])
+@pytest.mark.parametrize("y", [np.array([[1, 1, 1]] * 20)])
+def test_fit_and_predict_with_2d_targets(regressor: RegressorChoice, X: np.ndarray, y: np.ndarray):
+    """Test that all pipelines work with 2d target types
+
+    Parameters
+    ----------
+    regressor: RegressorChoice
+        The regressor to test
+
+    X: np.ndarray
+        The features
+
+    y: np.ndarray
+        The 2d targets
+
+    Expects
+    -------
+    * Should be able to fit with 2d targets
+    * Should be able to predict with 2d targets
+    * Should have predictions with the same shape as y
+    """
+    assert len(X) == len(y)
+    assert y.ndim == 2 and y.shape[1] > 1
+
+    config_space = regressor.get_hyperparameter_search_space()
+    default_config = config_space.get_default_configuration()
+
+    model = regressor(random_state=0, **default_config)
+
+    with ignore_warnings(regressor_warnings):
+        model.fit(X, y)
+
+    predictions = model.predict(X)
+
+    assert predictions.shape == y.shape

--- a/test/test_pipeline/ignored_warnings.py
+++ b/test/test_pipeline/ignored_warnings.py
@@ -77,6 +77,7 @@ classifier_warnings = [
 
 ignored_warnings = regressor_warnings + classifier_warnings
 
+
 @contextmanager
 def ignore_warnings(to_ignore: List[Tuple[Exception, str]] = ignored_warnings) -> Iterator[None]:
     """A context manager to ignore warnings
@@ -93,4 +94,3 @@ def ignore_warnings(to_ignore: List[Tuple[Exception, str]] = ignored_warnings) -
         for category, message in to_ignore:
             warnings.filterwarnings('ignore', category=category, message=message)
         yield
-

--- a/test/test_pipeline/ignored_warnings.py
+++ b/test/test_pipeline/ignored_warnings.py
@@ -1,0 +1,96 @@
+from contextlib import contextmanager
+from typing import List, Iterator, Tuple
+
+import warnings
+from sklearn.exceptions import ConvergenceWarning
+
+
+regressor_warnings = [
+    (
+        UserWarning, (  # From QuantileTransformer
+            r"n_quantiles \(\d+\) is greater than the total number of samples \(\d+\)\."
+            r" n_quantiles is set to n_samples\."
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From GaussianProcesses
+            r"The optimal value found for dimension \d+ of parameter \w+ is close"
+            r" to the specified (upper|lower) bound .*(Increasing|Decreasing) the bound"
+            r" and calling fit again may find a better value."
+        )
+    ),
+    (
+        UserWarning, (  # From FastICA
+            r"n_components is too large: it will be set to \d+"
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From SGD
+            r"Maximum number of iteration reached before convergence\. Consider increasing"
+            r" max_iter to improve the fit\."
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From MLP
+            r"Stochastic Optimizer: Maximum iterations \(\d+\) reached and the"
+            r" optimization hasn't converged yet\."
+        )
+    ),
+]
+
+classifier_warnings = [
+    (
+        UserWarning, (  # From QuantileTransformer
+            r"n_quantiles \(\d+\) is greater than the total number of samples \(\d+\)\."
+            r" n_quantiles is set to n_samples\."
+        )
+    ),
+    (
+        UserWarning, (  # From FastICA
+            r"n_components is too large: it will be set to \d+"
+        )
+
+    ),
+    (
+        ConvergenceWarning, (  # From Liblinear
+            r"Liblinear failed to converge, increase the number of iterations\."
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From SGD
+            r"Maximum number of iteration reached before convergence\. Consider increasing"
+            r" max_iter to improve the fit\."
+        )
+    ),
+    (
+        ConvergenceWarning, (  # From MLP
+            r"Stochastic Optimizer: Maximum iterations \(\d+\) reached and the"
+            r" optimization hasn't converged yet\."
+        )
+    ),
+    (
+        UserWarning, (  # From LDA (Linear Discriminant Analysis)
+            r"Variables are collinear"
+        )
+    ),
+]
+
+ignored_warnings = regressor_warnings + classifier_warnings
+
+@contextmanager
+def ignore_warnings(to_ignore: List[Tuple[Exception, str]] = ignored_warnings) -> Iterator[None]:
+    """A context manager to ignore warnings
+
+    >>> with ignore_warnings(classifier_warnings):
+    >>>     ...
+
+    Parameters
+    ----------
+    to_ignore: List[Tuple[Exception, str]] = ignored_warnings
+        The list of warnings to ignore, defaults to all registered warnings
+    """
+    with warnings.catch_warnings():
+        for category, message in to_ignore:
+            warnings.filterwarnings('ignore', category=category, message=message)
+        yield
+

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -31,7 +31,7 @@ from autosklearn.pipeline.util import get_dataset
 from autosklearn.pipeline.constants import \
     DENSE, SPARSE, UNSIGNED_DATA, PREDICTIONS, SIGNED_DATA, INPUT
 
-from ..ignored_warnings import classifier_warnings, ignore_warnings
+from .ignored_warnings import classifier_warnings, ignore_warnings
 
 
 class DummyClassifier(AutoSklearnClassificationAlgorithm):

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -6,7 +6,6 @@ import tempfile
 import traceback
 import unittest
 import unittest.mock
-import warnings
 
 from joblib import Memory
 import numpy as np
@@ -18,7 +17,6 @@ import sklearn.model_selection
 import sklearn.ensemble
 import sklearn.svm
 from sklearn.utils.validation import check_is_fitted
-from sklearn.exceptions import ConvergenceWarning
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
@@ -33,42 +31,7 @@ from autosklearn.pipeline.util import get_dataset
 from autosklearn.pipeline.constants import \
     DENSE, SPARSE, UNSIGNED_DATA, PREDICTIONS, SIGNED_DATA, INPUT
 
-ignored_warnings = [
-    (
-        UserWarning, (  # From QuantileTransformer
-            r"n_quantiles \(\d+\) is greater than the total number of samples \(\d+\)\."
-            r" n_quantiles is set to n_samples\."
-        )
-    ),
-    (
-        UserWarning, (  # From FastICA
-            r"n_components is too large: it will be set to \d+"
-        )
-
-    ),
-    (
-        ConvergenceWarning, (  # From Liblinear
-            r"Liblinear failed to converge, increase the number of iterations\."
-        )
-    ),
-    (
-        ConvergenceWarning, (  # From SGD
-            r"Maximum number of iteration reached before convergence\. Consider increasing"
-            r" max_iter to improve the fit\."
-        )
-    ),
-    (
-        ConvergenceWarning, (  # From MLP
-            r"Stochastic Optimizer: Maximum iterations \(\d+\) reached and the"
-            r" optimization hasn't converged yet\."
-        )
-    ),
-    (
-        UserWarning, (  # From LDA (Linear Discriminant Analysis)
-            r"Variables are collinear"
-        )
-    ),
-]
+from ..ignored_warnings import classifier_warnings, ignore_warnings
 
 
 class DummyClassifier(AutoSklearnClassificationAlgorithm):
@@ -398,10 +361,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                     check_is_fitted(step)
 
             try:
-                with warnings.catch_warnings():
-                    for category, message in ignored_warnings:
-                        warnings.filterwarnings('ignore', category=category, message=message)
-
+                with ignore_warnings(classifier_warnings):
                     cls.fit(X_train, Y_train)
 
                 # After fit, all components should be tagged as fitted

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -6,7 +6,6 @@ import tempfile
 import traceback
 import unittest
 import unittest.mock
-import warnings
 
 from joblib import Memory
 import numpy as np
@@ -16,7 +15,6 @@ from sklearn.base import clone
 import sklearn.ensemble
 import sklearn.svm
 from sklearn.utils.validation import check_is_fitted
-from sklearn.exceptions import ConvergenceWarning
 
 from ConfigSpace.configuration_space import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter
@@ -30,32 +28,7 @@ import autosklearn.pipeline.components.feature_preprocessing as preprocessing_co
 from autosklearn.pipeline.util import get_dataset
 from autosklearn.pipeline.constants import SPARSE, DENSE, SIGNED_DATA, UNSIGNED_DATA, PREDICTIONS
 
-ignored_warnings = [
-    (
-        UserWarning, (  # From QuantileTransformer
-            r"n_quantiles \(\d+\) is greater than the total number of samples \(\d+\)\."
-            r" n_quantiles is set to n_samples\."
-        )
-    ),
-    (
-        ConvergenceWarning, (  # From GaussianProcesses
-            r"The optimal value found for dimension \d+ of parameter \w+ is close"
-            r" to the specified (upper|lower) bound .*(Increasing|Decreasing) the bound"
-            r" and calling fit again may find a better value."
-        )
-    ),
-    (
-        UserWarning, (  # From FastICA
-            r"n_components is too large: it will be set to \d+"
-        )
-    ),
-    (
-        ConvergenceWarning, (  # From SGD
-            r"Maximum number of iteration reached before convergence\. Consider increasing"
-            r" max_iter to improve the fit\."
-        )
-    ),
-]
+from ..ignored_warnings import regressor_warnings, ignore_warnings
 
 
 class SimpleRegressionPipelineTest(unittest.TestCase):
@@ -209,21 +182,19 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                     check_is_fitted(step)
 
             try:
-                with warnings.catch_warnings():
-                    for category, message in ignored_warnings:
-                        warnings.filterwarnings('ignore', category=category, message=message)
-
+                with ignore_warnings(regressor_warnings):
                     cls.fit(X_train, Y_train)
-                    # After fit, all components should be tagged as fitted
-                    # by sklearn. Check is fitted raises an exception if that
-                    # is not the case
-                    try:
-                        for name, step in cls.named_steps.items():
-                            check_is_fitted(step)
-                    except sklearn.exceptions.NotFittedError:
-                        self.fail("config={} raised NotFittedError unexpectedly!".format(
-                            config
-                        ))
+
+                # After fit, all components should be tagged as fitted
+                # by sklearn. Check is fitted raises an exception if that
+                # is not the case
+                try:
+                    for name, step in cls.named_steps.items():
+                        check_is_fitted(step)
+                except sklearn.exceptions.NotFittedError:
+                    self.fail("config={} raised NotFittedError unexpectedly!".format(
+                        config
+                    ))
 
                 cls.predict(X_test)
             except MemoryError:

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -28,7 +28,7 @@ import autosklearn.pipeline.components.feature_preprocessing as preprocessing_co
 from autosklearn.pipeline.util import get_dataset
 from autosklearn.pipeline.constants import SPARSE, DENSE, SIGNED_DATA, UNSIGNED_DATA, PREDICTIONS
 
-from ..ignored_warnings import regressor_warnings, ignore_warnings
+from .ignored_warnings import regressor_warnings, ignore_warnings
 
 
 class SimpleRegressionPipelineTest(unittest.TestCase):


### PR DESCRIPTION
This PR addresses issue #1297 in which some regressors gave the wrong output dimensions. This was due to the use of `StandardScaler` on the target column(s) `y`. The main source of the issue was due to the regressors not being updated one multi-output regression was considered.

Issues
* 1d arrays were converted to a 2d array, `[0,0,0] -> [[0], [0], [0]]`
* This same conversion was done on 2d arrays, `[[1,1], [1,1]] -> [[1], [1], [1], [1]]`
* The inverse transform of the standard scaler gave back a 2d array, even if the predictions were 1d. `scaler.inverse_transform([1,1,1]) -> [[1], [1], [1]]`.

Created tests for all regression algorithms (classifiers do not use standard scalers). These test the algorithms with 3 different kinds of target shapes. These tests also check that the output shape is correct, where `(n,1)` is flattened back out to `(n,)`.
* `(n,) -> (n,)`
* `(n,1) -> (n,)`
* `(n,m) -> (n,m)`

This PR also consolidates all the ignored warnings into one file and provides a context manager to be used in tests if we want to ignore warnings.