### PR TITLE
Fixed dependancies warnings introduced by `sphinx_toolbox`

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -167,7 +167,7 @@ changes:
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 linkcheck:
-	$(SPHINXBUILD) -D plot_gallery=0 -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	SPHINX_GALLERY_PLOT=False $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -60,7 +60,7 @@ html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-noexamples:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	SPHINX_GALLERY_PLOT=False $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,22 @@ import autosklearn
 if "dev" in autosklearn.__version__:
     binder_branch = "development"
 
+# Getting issues with the `-D plot_gallery=0` for sphinx gallery, this is a workaround
+# We do this by setting an evironment variable we check and modifying the python config
+# object.
+# We have this extra processing as it enters as a raw string and we need a boolean value
+gallery_env_var ="SPHINX_GALLERY_PLOT"
+
+sphinx_plot_gallery_flag = True
+if gallery_env_var in os.environ:
+    value = os.environ[gallery_env_var]
+    if value in ["False", "false", "0"]:
+        sphinx_plot_gallery_flag = False
+    elif value in ["True", "true", "1"]:
+        sphinx_plot_gallery_flag = True
+    else:
+        raise ValueError(f'Env variable {gallery_env_var} must be set to "false" or "true"')
+
 sphinx_gallery_conf = {
     # path to the examples
     'examples_dirs': '../examples',
@@ -78,6 +94,7 @@ sphinx_gallery_conf = {
     #'reference_url': {
     #    'autosklearn': None
     #},
+    'plot_gallery': sphinx_plot_gallery_flag,
     'backreferences_dir': None,
     'filename_pattern': 'example.*.py$',
     'ignore_pattern': r'custom_metrics\.py|__init__\.py',

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,12 @@ extras_reqs={
         "seaborn",
     ],
     "docs": [
-        "sphinx",
-        "sphinx-gallery<=0.10.0",
+        "sphinx<4.3",
+        "sphinx-gallery",
         "sphinx_bootstrap_theme",
         "numpydoc",
         "sphinx_toolbox",
+        "docutils==0.16"
     ],
 }
 


### PR DESCRIPTION
PR #1309 introduced the docs dependancy `sphinx_toolbox`, checking it's requirements, it relies on locked versions of `docutils` and `sphinx`.

This PR removed the warnings by locking the `docutils` version to `0.16` and `sphinx` to `<4.3`. 

It also fixes the build warning message that seems to have appeared. This is done by setting and checking environment variables in `conf.py` instead of using the `-D` option of `sphinx`
> The config value `plot_gallery` has type `str`, defaults to `bool`.

* Introduced [here ](https://github.com/automl/auto-sklearn/pull/1309/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L44)