### PR TITLE
DOC: rename OSX -> macOS as it is the new name

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -121,7 +121,7 @@ Possible solutions:
 
 
 macOS
-~~~~~~~
+~~~~~
 
 We currently do not know if *auto-sklearn* works on macOS. There are at least two
 issues holding us back from actively supporting macOS:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -21,8 +21,8 @@ need:
 
 * SWIG (`get SWIG here <http://www.swig.org/survey.html>`_).
 
-For an explanation of missing Microsoft Windows and MAC OSX support please
-check the Section `Windows/OSX compatibility`_.
+For an explanation of missing Microsoft Windows and macOS support please
+check the Section `Windows/macOS compatibility`_.
 
 Installing auto-sklearn
 =======================
@@ -101,7 +101,7 @@ for more information about Conda forge check
 `conda-forge documentations <https://conda-forge.org/docs/>`_.
 
 
-Windows/OSX compatibility
+Windows/macOS compatibility
 =========================
 
 Windows
@@ -120,15 +120,15 @@ Possible solutions:
 * docker image
 
 
-Mac OSX
+macOS
 ~~~~~~~
 
-We currently do not know if *auto-sklearn* works on OSX. There are at least two
-issues holding us back from actively supporting OSX:
+We currently do not know if *auto-sklearn* works on macOS. There are at least two
+issues holding us back from actively supporting macOS:
 
 * The ``resource`` module cannot enforce a memory limit on a Python process
   (see `SMAC3/issues/115 <https://github.com/automl/SMAC3/issues/115>`_).
-* Not all dependencies we are using are set up to work on OSX.
+* Not all dependencies we are using are set up to work on macOS.
 
 In case you're having issues installing the `pyrfr package <https://github.com/automl/random_forest_run>`_, check out
 `this installation suggestion on github <https://github.com/automl/auto-sklearn/issues/360#issuecomment-335150470>`_.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -102,7 +102,7 @@ for more information about Conda forge check
 
 
 Windows/macOS compatibility
-=========================
+===========================
 
 Windows
 ~~~~~~~


### PR DESCRIPTION
rename OSX -> macOS as it is the new name for the operating system. e.g. see https://www.apple.com/macos