### PR TITLE
Update dask requirement, disabled example

### DIFF
--- a/autosklearn/__version__.py
+++ b/autosklearn/__version__.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.14.2"
+__version__ = "0.14.3"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,7 +79,7 @@ sphinx_gallery_conf = {
     #},
     'backreferences_dir': None,
     'filename_pattern': 'example.*.py$',
-    'ignore_pattern': r'custom_metrics\.py|__init__\.py',
+    'ignore_pattern': r'custom_metrics\.py|__init__\.py|example_parallel_manual_spawning_python.py',
     'binder': {
          # Required keys
          'org': 'automl',

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -9,6 +9,12 @@
 Releases
 ========
 
+Version 0.14.3
+==============
+
+* HOTFIX #xxx: Updates dask to ``dask.distributed >=2012.12``.
+
+
 Version 0.14.2
 ==============
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -12,8 +12,12 @@ Releases
 Version 0.14.3
 ==============
 
-* HOTFIX #xxx: Updates dask to ``dask.distributed >=2012.12``.
+* HOTFIX #1356: Updates dask to ``dask.distributed >=2012.12``.
 
+Contributors v0.14.3
+********************
+
+* Eddie Bergman
 
 Version 0.14.2
 ==============
@@ -41,7 +45,7 @@ Version 0.14.1
 Contributors v0.14.1
 ********************
 
-* Edward Bergman
+* Eddie Bergman
 * Michael Becker
 * Katharina Eggensperger
 

--- a/examples/60_search/example_parallel_manual_spawning_cli.py
+++ b/examples/60_search/example_parallel_manual_spawning_cli.py
@@ -11,10 +11,16 @@ for parallel optimization.
 This example shows how to start the dask scheduler and spawn
 workers for *Auto-sklearn* manually from the command line. Use this example
 as a starting point to parallelize *Auto-sklearn* across multiple
-machines. If you want to start everything manually from within Python
-please see :ref:`sphx_glr_examples_60_search_example_parallel_manual_spawning_python.py`.
+machines.
+
 To run *Auto-sklearn* in parallel on a single machine check out the example
 :ref:`sphx_glr_examples_60_search_example_parallel_n_jobs.py`.
+
+If you want to start everything manually from within Python
+please see ``:ref:sphx_glr_examples_60_search_example_parallel_manual_spawning_python.py``.
+
+**NOTE:** Above example is disabled due to issue https://github.com/dask/distributed/issues/5627
+
 
 You can learn more about the dask command line interface from
 https://docs.dask.org/en/latest/setup/cli.html.

--- a/examples/60_search/example_parallel_manual_spawning_python.py
+++ b/examples/60_search/example_parallel_manual_spawning_python.py
@@ -3,6 +3,8 @@
 ===================================================
 Parallel Usage: Spawning workers from within Python
 ===================================================
+**NOTE**: Disabled due to issue https://github.com/dask/distributed/issues/5627
+
 
 *Auto-sklearn* uses
 `dask.distributed <https://distributed.dask.org/en/latest/index.html>`_

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ scipy>=1.7.0
 joblib
 scikit-learn>=0.24.0,<0.25.0
 
-dask<2021.12
+dask>=2021.12
 distributed>=2012.12
 pyyaml
 pandas>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ scipy>=1.7.0
 joblib
 scikit-learn>=0.24.0,<0.25.0
 
-dask<2021.07
-distributed>=2.2.0,<2021.07
+dask<2021.12
+distributed>=2012.12
 pyyaml
 pandas>=1.0
 liac-arff


### PR DESCRIPTION
Updates dask to `2021.12.0`. Disables example as a result.

The docs won't build properly due to `sphinx` issues encountered that are solved in development with PR #1339. Hence I will disable the `doc.yaml` command when it is merged to master.