### PR TITLE
Fix: kernal pca config error with sparse data

### DIFF
--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -5,7 +5,6 @@ import itertools
 import os
 import resource
 import tempfile
-import traceback
 import unittest
 import unittest.mock
 
@@ -519,8 +518,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
             except np.linalg.LinAlgError:
                 continue
             except ValueError as e:
-                if "Floating-point under-/overflow occurred at epoch" in \
-                        e.args[0]:
+                if "Floating-point under-/overflow occurred at epoch" in e.args[0]:
                     continue
                 elif "removed all features" in e.args[0]:
                     continue
@@ -536,8 +534,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                 elif 'Internal work array size computation failed' in e.args[0]:
                     continue
                 else:
-                    print(config)
-                    print(traceback.format_exc())
+                    e.args += (f"config={config}",)
                     raise e
 
             except RuntimeWarning as e:
@@ -554,15 +551,14 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                 elif "invalid value encountered in multiply" in e.args[0]:
                     continue
                 else:
-                    print(traceback.format_exc())
-                    print(config)
+                    e.args += (f"config={config}",)
                     raise e
+
             except UserWarning as e:
                 if "FastICA did not converge" in e.args[0]:
                     continue
                 else:
-                    print(traceback.format_exc())
-                    print(config)
+                    e.args += (f"config={config}",)
                     raise e
 
     def test_get_hyperparameter_search_space(self):
@@ -1175,6 +1171,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
             # to clean up with check in the future
             del preprocessing_components.additional_components.components['CrashPreprocessor']
             self.fail("cs={} config={} Exception={}".format(cs, config, e))
+
         cls.set_hyperparameters(config)
 
         with self.assertRaisesRegex(ValueError, "Make sure fit is called"):

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -1,9 +1,7 @@
 import copy
 import itertools
 import resource
-import sys
 import tempfile
-import traceback
 import unittest
 import unittest.mock
 
@@ -217,9 +215,9 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                      'values.' in e.args[0]:
                     continue
                 else:
-                    print(config)
-                    print(traceback.format_exc())
+                    e.args += (f"config={config}",)
                     raise e
+
             except RuntimeWarning as e:
                 if "invalid value encountered in sqrt" in e.args[0]:
                     continue
@@ -232,22 +230,21 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                 elif "invalid value encountered in multiply" in e.args[0]:
                     continue
                 else:
-                    print(config)
-                    traceback.print_tb(sys.exc_info()[2])
+                    e.args += (f"config={config}",)
                     raise e
+
             except UserWarning as e:
                 if "FastICA did not converge" in e.args[0]:
                     continue
                 else:
-                    print(config)
-                    traceback.print_tb(sys.exc_info()[2])
+                    e.args += (f"config={config}",)
                     raise e
+
             except Exception as e:
                 if "Multiple input features cannot have the same target value" in e.args[0]:
                     continue
                 else:
-                    print(config)
-                    traceback.print_tb(sys.exc_info()[2])
+                    e.args += (f"config={config}",)
                     raise e
 
     def test_default_configuration(self):

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -214,6 +214,9 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                 elif 'The condensed distance matrix must contain only finite ' \
                      'values.' in e.args[0]:
                     continue
+                elif "zero-size array to reduction operation maximum which has no " \
+                     "identity" in e.args[0]:
+                    continue
                 else:
                     e.args += (f"config={config}",)
                     raise e


### PR DESCRIPTION
Seems kernel_pca emits the error:
* `"zero-size array to reduction operation maximum which has no identity"`

This is gotten on the line `max_eig = lambdas.max()` which makes me
assume it emits a matrix with no real eigen values, not something we
can really control for.

Edit: [Looking deeper](https://github.com/scikit-learn/scikit-learn/blob/7e1e6d09b/sklearn/decomposition/_kernel_pca.py#L330), it would be good to know which solver is being used and if that would make a difference, it defaults to "auto"

Additionally, pytest seems to not be showing print statements which show the config which causes the issue, added the message to the error itself instead.

