### PR TITLE
Fix: add error to be ignored during test

### DIFF
--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -533,6 +533,9 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                     continue
                 elif 'Internal work array size computation failed' in e.args[0]:
                     continue
+                # Assumed to be caused by knn with preprocessor fast_ica with whiten
+                elif 'Input contains NaN, infinity or a value too large' in e.args[0]:
+                    continue
                 else:
                     e.args += (f"config={config}",)
                     raise e


### PR DESCRIPTION
We were getting value errors which seem to correspond to `fast_ica` with `whiten`.

Examples of the test failure:
* https://github.com/automl/auto-sklearn/runs/4938696791?check_suite_focus=true
