### PR TITLE
Fix: approx usage in pytest as illuminated with pytest/9061

### DIFF
--- a/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
+++ b/test/test_metalearning/pyMetaLearn/test_meta_features_sparse.py
@@ -226,7 +226,7 @@ def test_percentage_of_features_with_missing_values(sparse_data):
     mf = meta_features.metafeatures["PercentageOfFeaturesWithMissingValues"](
         X, y, logging.getLogger("Meta"), categorical
     )
-    assert pytest.approx(0, mf.value)
+    assert mf.value == pytest.approx(0.0)
 
 
 def test_num_symbols(sparse_data):


### PR DESCRIPTION
Upgrading pytest now correctly gives error for incorrect usage of [`pytest.approx`](https://docs.pytest.org/en/6.2.x/reference.html#pytest-approx). This was implemented in pytest [#9061](https://github.com/pytest-dev/pytest/pull/9061).