### PR TITLE
Update: codecov yaml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,12 +10,12 @@ coverage:
   # https://docs.codecov.com/docs/commit-status
   status:
 
-    # We want our total main project to always remain above 87% coverage, a
+    # We want our total main project to always remain above 84% coverage, a
     # drop of 0.20% is allowed. It should fail if coverage couldn't be uploaded
     # of the CI fails otherwise
     project:
       default:
-        target: 87%
+        target: 84%
         threshold: 0.20%
         if_not_found: failure
         if_ci_failed: error


### PR DESCRIPTION
We previously had 87% code coverage so this is what I set codecov to use as the failing line. That PR also update coverage to measure branches taken of conditionals, which then lowered test coverage by 3%. This PR addresses that and sets the failing line to 84%.