### PR TITLE
Update git ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,15 +108,23 @@ examples:
 # Publish to testpypi
 # Will echo the commands to actually publish to be run to publish to actual PyPi
 # This is done to prevent accidental publishing but provide the same conveniences
-publish: clean-build build
+publish: clean build
 	$(PIP) install twine
 	$(PYTHON) -m twine upload --repository testpypi ${DIST}/*
 	@echo
-	@echo "Test with the following line:"
-	@echo "pip install --index-url https://test.pypi.org/simple/ auto-sklearn"
+	@echo "Test with the following:"
+	@echo "* Create a new virtual environment to install the uplaoded distribution into"
+	@echo "* Run the following:"
+	@echo
+	@echo "        pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ autosklearn"
+	@echo
+	@echo "* Run this to make sure it can import correctly, plus whatever else you'd like to test:"
+	@echo
+	@echo "        python -c 'import autosklearn'"
 	@echo
 	@echo "Once you have decided it works, publish to actual pypi with"
-	@echo "python -m twine upload dist/*"
+	@echo
+	@echo "    python -m twine upload dist/*"
 
 test:
 	$(PYTEST) test

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ MYPY ?= mypy
 PRECOMMIT ?= pre-commit
 FLAKE8 ?= flake8
 
-DIR := ${CURDIR}
-DIST := ${CURDIR}/dist
-DOCDIR := ${DIR}/doc
-INDEX_HTML := file://${DOCDIR}/html/build/index.html
+DIR := "${CURDIR}"
+DIST := "${CURDIR}/dist""
+DOCDIR := "${DIR}/doc"
+INDEX_HTML := "file://${DOCDIR}/build/html/index.html"
 
 install-dev:
 	$(PIP) install -e ".[test,examples,docs]"
@@ -88,7 +88,7 @@ clean: clean-doc clean-build
 
 # Build a distribution in ./dist
 build:
-	$(PYTHON) setup.py bdist
+	$(PYTHON) setup.py sdist
 
 doc:
 	$(MAKE) -C ${DOCDIR} html-noexamples


### PR DESCRIPTION
Seems git ignore had `docs` instead of `doc`, not sure when either one changed but it's fixed now.