### PR TITLE
Fix: use `doc`  instead of `docs` of  for gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Documentation
-docs/build/*
-docs/examples
+doc/build/*
+doc/examples
 
 *.py[cod]
 


### PR DESCRIPTION
Fixes `.gitignore` as it was using `docs` instead of `doc` which could allow for built examples to enter commits.