### PR TITLE
implement a new attribute `allow_string_features`

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -210,6 +210,7 @@ class AutoML(BaseEstimator):
         scoring_functions=None,
         get_trials_callback=None,
         dataset_compression: Union[bool, Mapping[str, Any]] = True,
+        allow_string_features: bool = True,
     ):
         super(AutoML, self).__init__()
         self.configuration_space = None
@@ -281,6 +282,7 @@ class AutoML(BaseEstimator):
             self._dataset_compression = validate_dataset_compression_arg(
                 dataset_compression, memory_limit=self._memory_limit
             )
+        self.allow_string_features = allow_string_features
 
         self._datamanager = None
         self._dataset_name = None
@@ -687,6 +689,7 @@ class AutoML(BaseEstimator):
             is_classification=is_classification,
             feat_type=feat_type,
             logger_port=self._logger_port,
+            allow_string_features=self.allow_string_features,
         )
         self.InputValidator.fit(X_train=X, y_train=y, X_test=X_test, y_test=y_test)
         X, y = self.InputValidator.transform(X, y)

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -306,8 +306,10 @@ class FeatureValidator(BaseEstimator):
                     feat_type[column] = "string"
                 else:
                     feat_type[column] = "categorical"
-                    warnings.warn(f"you disabled text encoding column {column} will be encoded as "
-                                  f"category")
+                    warnings.warn(
+                        f"you disabled text encoding column {column} will be encoded as "
+                        f"category"
+                    )
             # Move away from np.issubdtype as it causes
             # TypeError: data type not understood in certain pandas types
             elif not is_numeric_dtype(X[column]):
@@ -324,7 +326,8 @@ class FeatureValidator(BaseEstimator):
                         feat_type[column] = "categorical"
                         warnings.warn(
                             f"you disabled text encoding column {column} will be encoded as "
-                            f"category")
+                            f"category"
+                        )
                 elif pd.core.dtypes.common.is_datetime_or_timedelta_dtype(
                     X[column].dtype
                 ):

--- a/autosklearn/data/feature_validator.py
+++ b/autosklearn/data/feature_validator.py
@@ -45,7 +45,8 @@ class FeatureValidator(BaseEstimator):
         allow_string_features: bool = True,
     ) -> None:
         # If a dataframe was provided, we populate
-        # this attribute with a mapping from column to {numerical | categorical | string}
+        # this attribute with a mapping from column to
+        # {numerical | categorical | string}
         self.feat_type: Optional[Dict[Union[str, int], str]] = None
         if feat_type is not None:
             if isinstance(feat_type, dict):
@@ -307,8 +308,8 @@ class FeatureValidator(BaseEstimator):
                 else:
                     feat_type[column] = "categorical"
                     warnings.warn(
-                        f"you disabled text encoding column {column} will be encoded as "
-                        f"category"
+                        f"you disabled text encoding column {column} will be "
+                        f"encoded as category"
                     )
             # Move away from np.issubdtype as it causes
             # TypeError: data type not understood in certain pandas types
@@ -325,8 +326,8 @@ class FeatureValidator(BaseEstimator):
                     else:
                         feat_type[column] = "categorical"
                         warnings.warn(
-                            f"you disabled text encoding column {column} will be encoded as "
-                            f"category"
+                            f"you disabled text encoding column {column} will be"
+                            f"encoded as category"
                         )
                 elif pd.core.dtypes.common.is_datetime_or_timedelta_dtype(
                     X[column].dtype

--- a/autosklearn/data/validation.py
+++ b/autosklearn/data/validation.py
@@ -80,6 +80,7 @@ class InputValidator(BaseEstimator):
         feat_type: Optional[List[str]] = None,
         is_classification: bool = False,
         logger_port: Optional[int] = None,
+        allow_string_features: bool = True,
     ) -> None:
         self.feat_type = feat_type
         self.is_classification = is_classification
@@ -92,8 +93,11 @@ class InputValidator(BaseEstimator):
         else:
             self.logger = logging.getLogger("Validation")
 
+        self.allow_string_features = allow_string_features
         self.feature_validator = FeatureValidator(
-            feat_type=self.feat_type, logger=self.logger
+            feat_type=self.feat_type,
+            logger=self.logger,
+            allow_string_features=self.allow_string_features,
         )
         self.target_validator = TargetValidator(
             is_classification=self.is_classification, logger=self.logger

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -324,7 +324,7 @@ class AutoSklearnEstimator(BaseEstimator):
                     label is included in the sampled set.
 
         allow_string_features: bool = True
-            Allows to disable the textpreprocssing used by autosklearn. On default the
+            Whether autosklearn should process string features. By default the
             textpreprocessing is enabled.
 
         Attributes

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -51,6 +51,7 @@ class AutoSklearnEstimator(BaseEstimator):
         load_models: bool = True,
         get_trials_callback=None,
         dataset_compression: Union[bool, Mapping[str, Any]] = True,
+        allow_string_features: bool = True,
     ):
         """
         Parameters
@@ -321,6 +322,10 @@ class AutoSklearnEstimator(BaseEstimator):
                     Subsampling takes into account classification labels and stratifies
                     accordingly. We guarantee that at least one occurrence of each
                     label is included in the sampled set.
+        
+        allow_string_features: bool = True
+            Allows to disable the textpreprocssing used by autosklearn. On default the
+            textpreprocessing is enabled.  
 
         Attributes
         ----------
@@ -367,6 +372,7 @@ class AutoSklearnEstimator(BaseEstimator):
         self.load_models = load_models
         self.get_trials_callback = get_trials_callback
         self.dataset_compression = dataset_compression
+        self.allow_string_features = allow_string_features
 
         self.automl_ = None  # type: Optional[AutoML]
 
@@ -415,6 +421,7 @@ class AutoSklearnEstimator(BaseEstimator):
             scoring_functions=self.scoring_functions,
             get_trials_callback=self.get_trials_callback,
             dataset_compression=self.dataset_compression,
+            allow_string_features=self.allow_string_features,
         )
 
         return automl

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -322,10 +322,10 @@ class AutoSklearnEstimator(BaseEstimator):
                     Subsampling takes into account classification labels and stratifies
                     accordingly. We guarantee that at least one occurrence of each
                     label is included in the sampled set.
-        
+
         allow_string_features: bool = True
             Allows to disable the textpreprocssing used by autosklearn. On default the
-            textpreprocessing is enabled.  
+            textpreprocessing is enabled.
 
         Attributes
         ----------

--- a/autosklearn/experimental/askl2.py
+++ b/autosklearn/experimental/askl2.py
@@ -206,6 +206,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
         scoring_functions: Optional[List[Scorer]] = None,
         load_models: bool = True,
         dataset_compression: Union[bool, Mapping[str, Any]] = True,
+        allow_string_features: bool = True,
     ):
 
         """
@@ -363,6 +364,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
             metric=metric,
             scoring_functions=scoring_functions,
             load_models=load_models,
+            allow_string_features=allow_string_features,
         )
 
     def fit(

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -301,23 +301,28 @@ Other
     Supported formats for these training and testing pairs are: np.ndarray,
     pd.DataFrame, scipy.sparse.csr_matrix and python lists.
 
-    If your data contains categorical values (in the features or targets), autosklearn will automatically encode your
-    data using a `sklearn.preprocessing.LabelEncoder <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html>`_
-    for unidimensional data and a `sklearn.preprocessing.OrdinalEncoder <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html>`_
-    for multidimensional data.
-
-    Regarding the features, there are two methods to guide *auto-sklearn* to properly encode categorical columns:
+    Regarding the features, there are multiple things to consider:
 
     * Providing a X_train/X_test numpy array with the optional flag feat_type. For further details, you
       can check the Example :ref:`sphx_glr_examples_40_advanced_example_feature_types.py`.
     * You can provide a pandas DataFrame, with properly formatted columns. If a column has numerical
-      dtype, *auto-sklearn* will not encode it and it will be passed directly to scikit-learn. If the
-      column has a categorical/boolean class, it will be encoded. If the column is of any other type
-      (Object or Timeseries), an error will be raised. For further details on how to properly encode
-      your data, you can check the Pandas Example
-      `Working with categorical data <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_).
-      If you are working with time series, it is recommended that you follow this approach
+      dtype, *auto-sklearn* will not encode it and it will be passed directly to scikit-learn. *auto-sklearn*
+      supports both categorical or string as column type. Please ensure that you are using the correct
+      dtype for your task. By default *auto-sklearn* treats object and string columns as strings and
+      encodes the data using `sklearn.feature_extraction.text.CountVectorizer <https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html>`_
+    * If your data contains categorical values (in the features or targets), ensure that you explicitly label them as categorical.
+      data labeled as categorical is encoded by using a `sklearn.preprocessing.LabelEncoder <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html>`_
+      for unidimensional data and a `sklearn.preprocessing.OrdinalEncoder <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html>`_ for multidimensional data.
+    * For further details on how to properly encode your data, you can check the Pandas Example
+      `Working with categorical data <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_). If you are working with time series, it is recommended that you follow this approach
       `Working with time data <https://stats.stackexchange.com/questions/311494/>`_.
+    * If you prefer not using the string option at all you can disable this option. In this case
+      objects, strings and categorical columns are encoded as categorical.
+    .. code:: python
+
+        import autosklearn.classification
+        automl = autosklearn.classification.AutoSklearnClassifier(allow_string_features=False)
+        automl.fit(X_train, y_train)
 
     Regarding the targets (y_train/y_test), if the task involves a classification problem, such features will be
     automatically encoded. It is recommended to provide both y_train and y_test during fit, so that a common encoding
@@ -343,7 +348,8 @@ Other
         import autosklearn.classification
         automl = autosklearn.classification.AutoSklearnClassifier(
             ensemble_size=1,
-            initial_configurations_via_metalearning=0
+            initial_configurations_via_metalearning=0,
+            allow_string_features=False,
         )
 
     An ensemble of size one will result in always choosing the current best model

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -318,6 +318,7 @@ Other
       `Working with time data <https://stats.stackexchange.com/questions/311494/>`_.
     * If you prefer not using the string option at all you can disable this option. In this case
       objects, strings and categorical columns are encoded as categorical.
+
     .. code:: python
 
         import autosklearn.classification

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -312,7 +312,7 @@ Other
       encodes the data using `sklearn.feature_extraction.text.CountVectorizer <https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html>`_
     * If your data contains categorical values (in the features or targets), ensure that you explicitly label them as categorical.
       data labeled as categorical is encoded by using a `sklearn.preprocessing.LabelEncoder <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html>`_
-      for unidimensional data and a `sklearn.preprocessing.OrdinalEncoder <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html>`_ for multidimensional data.
+      for unidimensional data and a `sklearn.preprodcessing.OrdinalEncoder <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html>`_ for multidimensional data.
     * For further details on how to properly encode your data, you can check the Pandas Example
       `Working with categorical data <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_). If you are working with time series, it is recommended that you follow this approach
       `Working with time data <https://stats.stackexchange.com/questions/311494/>`_.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -341,7 +341,7 @@ Other
 
     In order to obtain *vanilla auto-sklearn* as used in `Efficient and Robust Automated Machine Learning
     <https://papers.nips.cc/paper/5872-efficient-and-robust-automated-machine -learning>`_
-    set ``ensemble_size=1`` and ``initial_configurations_via_metalearning=0``:
+    set ``ensemble_size=1``, ``initial_configurations_via_metalearning=0`` and ``allow_string_features=False``:
 
     .. code:: python
 

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -524,15 +524,15 @@ def test_object_columns():
     dummy_object = Dummy(1)
     lst = [1, 2, 3]
     array = np.array([1, 2, 3])
-    dummy_stirng = "dummy string"
+    dummy_string = "dummy string"
 
     df = pd.DataFrame(
         {
             "dummy_object": [dummy_object] * 4,
             "dummy_lst": [lst] * 4,
             "dummy_array": [array] * 4,
-            "dummy_string": [dummy_stirng] * 4,
-            "type_mix_column": [dummy_stirng, dummy_object, array, lst],
+            "dummy_string": [dummy_string] * 4,
+            "type_mix_column": [dummy_string, dummy_object, array, lst],
             "cat_column": ["a", "b", "a", "b"],
         }
     )
@@ -559,4 +559,30 @@ def test_object_columns():
         "cat_column": "categorical",
     }
 
+    assert feat_type == column_types
+
+def test_allow_string_feature():
+    df = pd.DataFrame({"Text": ["Hello", "how are you?"]})
+    with pytest.warns(
+        UserWarning,
+        match=r"Input Column Text has generic type object. "
+              r"Autosklearn will treat this column as string. "
+              r"Please ensure that this setting is suitable for your task.",
+    ):
+        validator = FeatureValidator(allow_string_features=False)
+        feat_type = validator.get_feat_type_from_columns(df)
+
+    column_types = {"Text": "categorical"}
+    assert feat_type == column_types
+
+    df["Text"] = df["Text"].astype("string")
+    with pytest.warns(
+        UserWarning,
+        match=r"you disabled text encoding column Text will be "
+              r"encoded as category",
+    ):
+        validator = FeatureValidator(allow_string_features=False)
+        feat_type = validator.get_feat_type_from_columns(df)
+
+    column_types = {"Text": "categorical"}
     assert feat_type == column_types

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -561,13 +561,14 @@ def test_object_columns():
 
     assert feat_type == column_types
 
+
 def test_allow_string_feature():
     df = pd.DataFrame({"Text": ["Hello", "how are you?"]})
     with pytest.warns(
         UserWarning,
         match=r"Input Column Text has generic type object. "
-              r"Autosklearn will treat this column as string. "
-              r"Please ensure that this setting is suitable for your task.",
+        r"Autosklearn will treat this column as string. "
+        r"Please ensure that this setting is suitable for your task.",
     ):
         validator = FeatureValidator(allow_string_features=False)
         feat_type = validator.get_feat_type_from_columns(df)
@@ -578,8 +579,7 @@ def test_allow_string_feature():
     df["Text"] = df["Text"].astype("string")
     with pytest.warns(
         UserWarning,
-        match=r"you disabled text encoding column Text will be "
-              r"encoded as category",
+        match=r"you disabled text encoding column Text will be " r"encoded as category",
     ):
         validator = FeatureValidator(allow_string_features=False)
         feat_type = validator.get_feat_type_from_columns(df)


### PR DESCRIPTION
implement a new attribute `allow_string_features` which en-/disables  the new text preprocessing. On default it is enabled.

Bascilly the AutoSklearnEstimator gets a new variable `allow_string_features` which is True on default. This new varialbe gets passed to the FeatureValidator (feature_validator.py). Here i use if/else statements which check if text features are allowed before assigning the string class. If text_preprocssing is disabled `string` and `object` are treated as `categorical` as it was handled priviously.