### PR TITLE
change treatment of string features in metalearning

### DIFF
--- a/autosklearn/smbo.py
+++ b/autosklearn/smbo.py
@@ -96,8 +96,8 @@ def _calculate_metafeatures(
         watcher.start_task(task_name)
 
         categorical = {
-            col: True if feat_type.lower() == "categorical" else False
-            for col, feat_type in data_feat_type.items()
+            col: True if feat_type.lower() in {"categorical", "string"} else
+            False for col, feat_type in data_feat_type.items()
         }
 
         EXCLUDE_META_FEATURES = (
@@ -152,8 +152,8 @@ def _calculate_metafeatures_encoded(
         task_name = "CalculateMetafeaturesEncoded"
         watcher.start_task(task_name)
         categorical = {
-            col: True if feat_type.lower() == "categorical" else False
-            for col, feat_type in data_feat_type.items()
+            col: True if feat_type.lower() in {"categorical", "string"} else
+            False for col, feat_type in data_feat_type.items()
         }
 
         result = calculate_all_metafeatures_encoded_labels(


### PR DESCRIPTION
In file `smbo.py` string columns are marked as categorical. Previously string columns are treated as not categorical which transfers to numerical. We decided that encoded string columns are more similar to OHE as they are to numerical transformations. This change effects the metalearning part of `autosklearn` exclusively.

This is a temporary solution. For solving these problem a more general solution for treating strings in meta-learning need to be made.