### PR TITLE
Fix: `leaderboard` fills nans

### DIFF
--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -937,6 +937,25 @@ class AutoSklearnEstimator(BaseEstimator):
         #      tied together by ordering, might be better to store as tuple
         for i, weight in enumerate(self.automl_.ensemble_.weights_):
             (_, model_id, _) = self.automl_.ensemble_.identifiers_[i]
+
+            # We had issues where the model's in the ensembles are not in the runhistory
+            # collected. I have no clue why this is but to prevent failures, we fill
+            # the values with NaN
+            if model_id not in model_runs:
+                model_runs[model_id] = {
+                    "model_id": model_id,
+                    "seed": pd.NA,
+                    "budget": pd.NA,
+                    "duration": pd.NA,
+                    "config_id": pd.NA,
+                    "start_time": pd.NA,
+                    "end_time": pd.NA,
+                    "status": pd.NA,
+                    "cost": pd.NA,
+                    "train_loss": pd.NA,
+                    "config_origin": pd.NA,
+                }
+
             model_runs[model_id]["ensemble_weight"] = weight
 
         # Filter out non-ensemble members if needed, else fill in a default


### PR DESCRIPTION
For models that are in the ensemble but have no corresponding entry in model_runs (built from run_history), we fill in NA values to prevent crashing.

Why this occurs, I don't know but this should at least prevent total failure when we can still provide other useful information back to the user.