### PR TITLE
HOTFIX: Update requirements and add upper bound for our own packages

### DIFF
--- a/autosklearn/__version__.py
+++ b/autosklearn/__version__.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.14.6"
+__version__ = "0.14.7"

--- a/autosklearn/util/dependencies.py
+++ b/autosklearn/util/dependencies.py
@@ -17,6 +17,10 @@ def verify_packages(packages: Optional[Union[str, List[str]]]) -> None:
         if not package:
             continue
 
+        # Comment line
+        if package.startswith('#'):
+            continue
+
         match = RE_PATTERN.match(package)
         if match:
             name = match.group('name')

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -9,6 +9,16 @@
 Releases
 ========
 
+Version 0.14.7
+==============
+
+* HOTFIX #1445: Update `ConfigSpace` to `0.5.0` and `smac` to `1.3`. Adds upper bounds on `automl` packages to help prevent further issues.
+
+Contributors v0.14.7
+********************
+* Eddie Bergman
+
+
 Version 0.14.6
 ==============
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ pandas>=1.0
 liac-arff
 threadpoolctl
 
-ConfigSpace>=0.4.14,<0.5
-pynisher>=0.6.3
+# Add bounds to our own packages we control to keep things stable
+ConfigSpace>=0.5,<0.6
+pynisher>=0.6.3,<0.7
 pyrfr>=0.8.1,<0.9
-smac>=0.14
+smac>=1.3,<1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ liac-arff
 threadpoolctl
 
 # Add bounds to our own packages we control to keep things stable
-ConfigSpace>=0.4.21,<0.5
+ConfigSpace>=0.5.0,<0.6
 pynisher>=0.6.3,<0.7
 pyrfr>=0.8.1,<0.9
-smac>=1.2,<1.3
+smac>=1.3.1,<1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ liac-arff
 threadpoolctl
 
 # Add bounds to our own packages we control to keep things stable
-ConfigSpace>=0.5,<0.6
+ConfigSpace>=0.4.21,<0.5
 pynisher>=0.6.3,<0.7
 pyrfr>=0.8.1,<0.9
-smac>=1.3,<1.4
+smac>=1.2,<1.3


### PR DESCRIPTION
Updates `smac` to `1.3` and `ConfigSpace` to `0.5.0` explicitly. Also adds upper bounds to our own packages as these tend to be less stable and cause issues on update.

Turns out SMAC dropped support for Python 3.7, we need to come to a decision on this.