### PR TITLE
Update citation to Auto-Sklearn 1.0

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -95,7 +95,7 @@ reference to the following paper:
 
     @inproceedings{feurer-neurips15a,
         title     = {Efficient and Robust Automated Machine Learning},
-        author    = {Feurer, Matthias and Klein, Aaron and Eggensperger, Katharina  Springenberg, Jost and Blum, Manuel and Hutter, Frank},
+        author    = {Feurer, Matthias and Klein, Aaron and Eggensperger, Katharina and Springenberg, Jost and Blum, Manuel and Hutter, Frank},
         booktitle = {Advances in Neural Information Processing Systems 28 (2015)},
         pages     = {2962--2970},
         year      = {2015}


### PR DESCRIPTION
While writing my bachelor thesis, I noticed a missing conjunction `and` in the `author` field.