### PR TITLE
Fix github actions `sdist.yaml` and `precommit` 

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -39,8 +39,7 @@ jobs:
       run: |
         pip install twine
         last_dist=$(ls -t dist/auto-sklearn-*.tar.gz | head -n 1)
-        twine_output=`twine check "$last_dist"`
-        if [[ "$twine_output" != "Checking $last_dist: PASSED" ]]; then echo $twine_output && exit 1;fi
+        twine check "$last_dist" --strict
 
     - name: Install dist
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
         name: isort imports test
         files: test/.*
 
-  - repo: https://github.com/ambv/black
-    rev: 22.1.0
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
       - id: black
         name: black formatter autosklearn
@@ -39,7 +39,7 @@ repos:
         additional_dependencies: ["toml"] # Needed to parse pyproject.toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.930
+    rev: v0.942
     hooks:
       - id: mypy
         name: mypy auto-sklearn


### PR DESCRIPTION
Fixes these issues by just using the `--strict` arg of `twine` which now gives an error on any issues. `precommit` needed version updates, specifically with `black`