### PR TITLE
Re-organize docs to advertise new text features

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,22 +25,10 @@ the technology behind *auto-sklearn* by reading our paper published at
 `NeurIPS 2015 <https://papers.neurips.cc/paper/5872-efficient-and-robust-automated-machine-learning.pdf>`_
 .
 
-.. topic:: NEW: Auto-sklearn 2.0
+.. topic:: NEW: Text feature support
 
-    Auto-sklearn 2.0 includes latest research on automatically configuring the AutoML system itself
-    and contains a multitude of improvements which speed up the fitting the AutoML system.
-
-*auto-sklearn 2.0* works the same way as regular *auto-sklearn* and you can use it via
-
-.. code:: python
-
-    from autosklearn.experimental.askl2 import AutoSklearn2Classifier
-
-A paper describing our advances is available on `arXiv <https://arxiv.org/abs/2007.04074>`_.
-
-.. topic:: NEW: Material from tutorials and presentations
-
-    We provide slides and notebooks from talks and tutorials here: `auto-sklearn-talks <https://github.com/automl/auto-sklearn-talks>`_
+    Auto-sklearn now supports text features, check our new example:
+    :ref:`sphx_glr_examples_40_advanced_example_text_preprocessing.py`
 
 
 Example
@@ -64,7 +52,6 @@ Example
 
 This will run for one hour and should result in an accuracy above 0.98.
 
-
 Manual
 ******
 
@@ -74,6 +61,11 @@ Manual
 * :ref:`extending`
 * :ref:`faq`
 
+Additional Material
+*******************
+
+We provide slides and notebooks from talks and tutorials here:
+`auto-sklearn-talks <https://github.com/automl/auto-sklearn-talks>`_
 
 License
 *******

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -19,6 +19,25 @@ give short explanations (click the title to expand text), e.g.
 
     We provide resources for talks, tutorials and presentations on *auto-sklearn* under `auto-sklearn-talks <https://github.com/automl/auto-sklearn-talks>`_
 
+.. _askl2:
+
+Auto-sklearn 2.0
+================
+
+Auto-sklearn 2.0 includes latest research on automatically configuring the AutoML system itself
+and contains a multitude of improvements which speed up the fitting the AutoML system.
+Concretely, Auto-sklearn 2.0 automatically sets the :ref:`bestmodel`, decides whether it can use
+the efficient bandit strategy *Successive Halving* and uses meta-feature free *Portfolios* for
+efficient meta-learning.
+
+*auto-sklearn 2.0* has the same interface as regular *auto-sklearn* and you can use it via
+
+.. code:: python
+
+    from autosklearn.experimental.askl2 import AutoSklearn2Classifier
+
+A paper describing our advances is available on `arXiv <https://arxiv.org/abs/2007.04074>`_.
+
 .. _limits:
 
 Resource limits


### PR DESCRIPTION
This PR reorganizes the Docs a bit:

* Move Auto-sklearn from "new" to "manual"
* Add text features support under "new"