### PR TITLE
Create simple example and doc for naive early stopping

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -253,7 +253,7 @@ class AutoML(BaseEstimator):
         if (
             get_trials_callback is not None
             and callable(get_trials_callback)
-            and not isinstance(IncorporateRunResultCallback)
+            and not isinstance(get_trials_callback, IncorporateRunResultCallback)
         ):
             get_trials_callback = SmacRunCallback(get_trials_callback)
 

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -39,6 +39,7 @@ from sklearn.model_selection._split import (
 )
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_is_fitted
+from smac.callbacks import IncorporateRunResultCallback
 from smac.runhistory.runhistory import RunInfo, RunValue
 from smac.stats.stats import Stats
 from smac.tae import StatusType
@@ -249,7 +250,11 @@ class AutoML(BaseEstimator):
 
         # If we got something callable for `get_trials_callback`, wrap it so SMAC
         # will accept it.
-        if get_trials_callback is not None and callable(get_trials_callback):
+        if (
+            get_trials_callback is not None
+            and callable(get_trials_callback)
+            and not isinstance(IncorporateRunResultCallback)
+        ):
             get_trials_callback = SmacRunCallback(get_trials_callback)
 
         self._delete_tmp_folder_after_terminate = delete_tmp_folder_after_terminate

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -39,7 +39,6 @@ from sklearn.model_selection._split import (
 )
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_is_fitted
-from smac.callbacks import IncorporateRunResultCallback
 from smac.runhistory.runhistory import RunInfo, RunValue
 from smac.stats.stats import Stats
 from smac.tae import StatusType
@@ -104,6 +103,7 @@ from autosklearn.util.logging_ import (
 )
 from autosklearn.util.parallel import preload_modules
 from autosklearn.util.single_thread_client import SingleThreadedClient
+from autosklearn.util.smac_wrap import SMACCallback, SmacRunCallback
 from autosklearn.util.stopwatch import StopWatch
 
 import unittest.mock
@@ -218,7 +218,7 @@ class AutoML(BaseEstimator):
         logging_config: Optional[Mapping] = None,
         metrics: Sequence[Scorer] | None = None,
         scoring_functions: Optional[list[Scorer]] = None,
-        get_trials_callback: Optional[IncorporateRunResultCallback] = None,
+        get_trials_callback: SMACCallback | None = None,
         dataset_compression: bool | Mapping[str, Any] = True,
         allow_string_features: bool = True,
     ):
@@ -246,6 +246,11 @@ class AutoML(BaseEstimator):
                 dataset_compression,
                 memory_limit=memory_limit,
             )
+
+        # If we got something callable for `get_trials_callback`, wrap it so SMAC
+        # will accept it.
+        if get_trials_callback is not None and callable(get_trials_callback):
+            get_trials_callback = SmacRunCallback(get_trials_callback)
 
         self._delete_tmp_folder_after_terminate = delete_tmp_folder_after_terminate
         self._time_for_task = time_left_for_this_task

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -22,6 +22,7 @@ from autosklearn.data.validation import (
 )
 from autosklearn.metrics import Scorer
 from autosklearn.pipeline.base import BasePipeline
+from autosklearn.util.smac_wrap import SMACCallback
 
 
 class AutoSklearnEstimator(BaseEstimator):
@@ -51,7 +52,7 @@ class AutoSklearnEstimator(BaseEstimator):
         metric: Scorer | Sequence[Scorer] | None = None,
         scoring_functions: Optional[List[Scorer]] = None,
         load_models: bool = True,
-        get_trials_callback=None,
+        get_trials_callback: SMACCallback | None = None,
         dataset_compression: Union[bool, Mapping[str, Any]] = True,
         allow_string_features: bool = True,
     ):
@@ -266,10 +267,19 @@ class AutoSklearnEstimator(BaseEstimator):
             Whether to load the models after fitting Auto-sklearn.
 
         get_trials_callback: callable
-            Callback function to create an object of subclass defined in module
-            `smac.callbacks <https://automl.github.io/SMAC3/master/apidoc/smac.callbacks.html>`_.
-            This is an advanced feature. Use only if you are familiar with
-            `SMAC <https://automl.github.io/SMAC3/master/index.html>`_.
+            A callable with the following definition.
+
+            * (smac.SMBO, smac.RunInfo, smac.RunValue, time_left: float) -> bool | None
+
+            This will be called after SMAC, the underlying optimizer for autosklearn,
+            finishes training each run.
+
+            You can use this to record your own information about the optimization
+            process. You can also use this to enable a early stopping based on some
+            critera.
+
+            See the example:
+            :ref:`Early Stopping And Callbacks <sphx_glr_examples_40_advanced_example_early_stopping_and_callbacks.py>`.
 
         dataset_compression: Union[bool, Mapping[str, Any]] = True
             We compress datasets so that they fit into some predefined amount of memory.

--- a/autosklearn/util/smac_wrap.py
+++ b/autosklearn/util/smac_wrap.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Callable, Union
+
+from smac.callbacks import IncorporateRunResultCallback
+from smac.optimizer.smbo import SMBO
+from smac.runhistory.runhistory import RunInfo, RunValue
+
+SMACCallback = Callable[[SMBO, RunInfo, RunValue, float], Union[bool, None]]
+
+
+class SmacRunCallback(IncorporateRunResultCallback):
+    def __init__(self, f: SMACCallback):
+        self.f = f
+
+    def __call__(
+        self,
+        smbo: SMBO,
+        run_info: RunInfo,
+        result: RunValue,
+        time_left: float,
+    ) -> bool | None:
+        """
+        Parameters
+        ----------
+        smbo: SMBO
+            The SMAC SMBO object
+
+        run_info: RunInfo
+            Information about the run completed
+
+        result: RunValue
+            The results of the run
+
+        time_left: float
+            How much time is left for the remaining runs
+
+        Returns
+        -------
+        bool | None
+            If False is returned, the optimization loop will stop
+        """
+        return self.f(smbo, run_info, result, time_left)

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -376,3 +376,8 @@ Other
     according to its performance on the validation set. Setting the initial
     configurations found by meta-learning to zero makes *auto-sklearn* use the
     regular SMAC algorithm for suggesting new hyperparameter configurations.
+
+.. collapse:: <b>Early stopping and Callbacks</b>
+
+   By using the parameter ``get_trials_callback``, we can get access to the results
+   of runs as they occur. See this example :ref:`Early Stopping And Callbacks <sphx_glr_examples_40_advanced_example_early_stopping_and_callbacks.py>`. for more!

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -380,4 +380,4 @@ Other
 .. collapse:: <b>Early stopping and Callbacks</b>
 
    By using the parameter ``get_trials_callback``, we can get access to the results
-   of runs as they occur. See this example :ref:`Early Stopping And Callbacks <sphx_glr_examples_40_advanced_example_early_stopping_and_callbacks.py>`. for more!
+   of runs as they occur. See this example :ref:`Early Stopping And Callbacks <sphx_glr_examples_40_advanced_example_early_stopping_and_callbacks.py>` for more!

--- a/examples/40_advanced/example_early_stopping_and_callbacks.py
+++ b/examples/40_advanced/example_early_stopping_and_callbacks.py
@@ -1,0 +1,75 @@
+"""
+============================
+Early stopping and Callbacks
+============================
+
+The example below shows how we can use the ``get_trials_callback`` parameter of
+auto-sklearn to implement an early-stopping mechanism through a callback.
+
+These callbacks give access to the result of each model + hyperparameter configuration
+optimized by SMAC, the underlying optimizer for autosklearn. By checking the cost of
+a result, we can implement a simple yet effective early stopping mechanism!
+
+Do note however, this does not provide any access to the ensembles that autosklearn
+produces, only the individual models. You may wish to perform a more sophisticated
+early stopping mechanism such that there are enough good models for autosklearn to build
+and ensemble with. This is hear to provide a simple example.
+"""
+from pprint import pprint
+
+import sklearn.datasets
+import sklearn.metrics
+
+import autosklearn.classification
+
+from smac.optimizer.smbo import SMBO
+from smac.runhistory.runhistory import RunInfo, RunValue
+
+
+############################################################################
+# Build and fit a classifier
+# ==========================
+def callback(
+    smbo: SMBO,
+    run_info: RunInfo,
+    result: RunValue,
+    time_left: float,
+) -> bool:
+    """Stop early if we get a very low cost value for a single run"""
+    # You can find out the parameters in the SMAC documentation
+    # https://automl.github.io/SMAC3/main/
+    if result.cost <= 0.02:
+        print("Stopping!")
+        print(run_info)
+        print(result)
+        return False
+
+
+X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(
+    X, y, random_state=1
+)
+
+automl = autosklearn.classification.AutoSklearnClassifier(
+    time_left_for_this_task=120, per_run_time_limit=30, get_trials_callback=callback
+)
+automl.fit(X_train, y_train, dataset_name="breast_cancer")
+
+############################################################################
+# View the models found by auto-sklearn
+# =====================================
+
+print(automl.leaderboard())
+
+############################################################################
+# Print the final ensemble constructed by auto-sklearn
+# ====================================================
+
+pprint(automl.show_models(), indent=4)
+
+###########################################################################
+# Get the Score of the final ensemble
+# ===================================
+
+predictions = automl.predict(X_test)
+print("Accuracy score:", sklearn.metrics.accuracy_score(y_test, predictions))

--- a/examples/40_advanced/example_early_stopping_and_callbacks.py
+++ b/examples/40_advanced/example_early_stopping_and_callbacks.py
@@ -34,8 +34,12 @@ def callback(
     run_info: RunInfo,
     result: RunValue,
     time_left: float,
-) -> bool:
-    """Stop early if we get a very low cost value for a single run"""
+) -> bool | None:
+    """Stop early if we get a very low cost value for a single run
+
+    The return value indicates to SMAC whether to stop or not. False will
+    stop the search process while any other value will mean it continues.
+    """
     # You can find out the parameters in the SMAC documentation
     # https://automl.github.io/SMAC3/main/
     if result.cost <= 0.02:

--- a/examples/40_advanced/example_early_stopping_and_callbacks.py
+++ b/examples/40_advanced/example_early_stopping_and_callbacks.py
@@ -13,7 +13,7 @@ a result, we can implement a simple yet effective early stopping mechanism!
 Do note however, this does not provide any access to the ensembles that autosklearn
 produces, only the individual models. You may wish to perform a more sophisticated
 early stopping mechanism such that there are enough good models for autosklearn to build
-and ensemble with. This is hear to provide a simple example.
+and ensemble with. This is here to provide a simple example.
 """
 from pprint import pprint
 

--- a/examples/40_advanced/example_early_stopping_and_callbacks.py
+++ b/examples/40_advanced/example_early_stopping_and_callbacks.py
@@ -15,6 +15,8 @@ produces, only the individual models. You may wish to perform a more sophisticat
 early stopping mechanism such that there are enough good models for autosklearn to build
 and ensemble with. This is here to provide a simple example.
 """
+from __future__ import annotations
+
 from pprint import pprint
 
 import sklearn.datasets

--- a/test/test_automl/test_early_stopping.py
+++ b/test/test_automl/test_early_stopping.py
@@ -25,7 +25,7 @@ def test_early_stopping(
         run_info: RunInfo,
         result: RunValue,
         time_left: float,
-    ) -> bool:
+    ) -> bool | None:
         if int(result.additional_info["num_run"]) >= 2:
             return False
 

--- a/test/test_automl/test_early_stopping.py
+++ b/test/test_automl/test_early_stopping.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    import numpy as np
+    from smac.optimizer.smbo import SMBO
+    from smac.runhistory.runhistory import RunInfo, RunValue
+
+    from autosklearn.automl import AutoMLClassifier
+
+
+def test_early_stopping(
+    make_automl_classifier: Callable[..., AutoMLClassifier],
+    make_sklearn_dataset: Callable[..., tuple[np.ndarray, ...]],
+) -> None:
+    """
+    Expects
+    -------
+    * Should early after fitting 2 models
+    """
+
+    def callback(
+        smbo: SMBO,
+        run_info: RunInfo,
+        result: RunValue,
+        time_left: float,
+    ) -> bool:
+        if int(result.additional_info["num_run"]) >= 2:
+            return False
+
+    automl = make_automl_classifier(get_trials_callback=callback)
+
+    X_train, Y_train, X_test, Y_test = make_sklearn_dataset("iris")
+    automl.fit(X_train, Y_train)
+
+    assert len(automl.runhistory_.data) == 2


### PR DESCRIPTION
Documents the `get_trials_callback` functionality a little more and makes it more flexible by only requiring a `callable` instead of having to instantiate the `SMAC` callback object.

Should not change existing behaviour as we only wrap the call part and forward the args.

* Closes #1304 