### PR TITLE
Load single best model as fallback

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -1553,7 +1553,13 @@ class AutoML(BaseEstimator):
         else:
             self.ensemble_ = None
 
-        # If no ensemble is loaded, try to get the best performing model
+        # If no ensemble is loaded, try to get the best performing model.
+        # This is triggered if
+        # 1. self._ensemble_size == 0 (see if-statement above)
+        # 2. if the ensemble builder crashed and no ensemble is available
+        # 3. if the ensemble cannot be built because of arguments passed
+        #    by the user (disable_evaluator_output and
+        #    resampling_strategy)
         if (
             not self.ensemble_
             and not (

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -79,7 +79,8 @@ class AutoSklearnEstimator(BaseEstimator):
         ensemble_size : int, optional (default=50)
             Number of models added to the ensemble built by *Ensemble
             selection from libraries of models*. Models are drawn with
-            replacement. If set to ``0`` no ensemble is fit.
+            replacement. If set to ``0`` no ensemble is fit and the single
+            best model is loaded.
 
         ensemble_nbest : int, optional (default=50)
             Only consider the ``ensemble_nbest`` models when building an
@@ -526,8 +527,7 @@ class AutoSklearnEstimator(BaseEstimator):
         All parameters are ``None`` by default. If no other value is given,
         the default values which were set in a call to ``fit()`` are used.
 
-        Calling this function is only necessary if ``ensemble_size==0``, for
-        example when executing *auto-sklearn* in parallel.
+        Calling this function is only necessary if ``ensemble_size==0``.
 
         Parameters
         ----------

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -527,8 +527,6 @@ class AutoSklearnEstimator(BaseEstimator):
         All parameters are ``None`` by default. If no other value is given,
         the default values which were set in a call to ``fit()`` are used.
 
-        Calling this function is only necessary if ``ensemble_size==0``.
-
         Parameters
         ----------
         y : array-like

--- a/test/test_automl/test_post_fit.py
+++ b/test/test_automl/test_post_fit.py
@@ -1,4 +1,5 @@
 from autosklearn.automl import AutoML
+from autosklearn.ensembles.singlebest_ensemble import SingleBest
 
 from pytest_cases import parametrize_with_cases
 
@@ -59,10 +60,10 @@ def test_no_ensemble(automl: AutoML) -> None:
 
     Expects
     -------
-    * The ensemble should remain None
-    * The models_ should be empty
+    * Auto-sklearn loads a single best model
+    * The models_ should be of size 1
     * The cv_models_ should remain None
     """
-    assert automl.ensemble_ is None
-    assert automl.models_ == []
+    assert isinstance(automl.ensemble_, SingleBest)
+    assert len(automl.models_) == 1
     assert automl.cv_models_ is None


### PR DESCRIPTION
in case user sets `ensemble_size=0` so that predict can always be used. Helpful for testing #1475.