### PR TITLE
Replace deprecated DataFrame.append with pandas.concat in meta_base.py

### DIFF
--- a/autosklearn/metalearning/metalearning/meta_base.py
+++ b/autosklearn/metalearning/metalearning/meta_base.py
@@ -73,11 +73,7 @@ class MetaBase(object):
                 "Dataset %s already in meta-data. Removing occurence.", name.lower()
             )
             self.metafeatures.drop(name.lower(), inplace=True)
-        self.metafeatures = self.metafeatures.append(metafeatures)
-
-        runs = pd.Series([], name=name, dtype=float)
-        for metric in self.algorithm_runs.keys():
-            self.algorithm_runs[metric].append(runs)
+        self.metafeatures = pd.concat([self.metafeatures, pd.DataFrame(metafeatures).T])
 
     def get_runs(self, dataset_name, performance_measure=None):
         """Return a list of all runs for a dataset."""


### PR DESCRIPTION
[Message of deprecation from pandas docs]( https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.append.html#:~:text=Deprecated%20since%20version%201.4.0%3A%20Use%20concat()%20instead.%20For%20further%20details%20see%20Deprecated%20DataFrame.append%20and%20Series.append)
The warning I'm talking about:
![image](https://user-images.githubusercontent.com/48658337/170853810-f00d67ef-5928-4016-a3a5-1a02c38441a0.png)

Also removed a loop that wasn't doing anything. DataFrame.append doesn't operate in place so that second loop wasn't causing any side effects, and it was also just adding empty series anyway. If anyone has any insight about why that was there in the first place that would be nice.

Let me know if I need to elaborate more or write tests or anything else. It's a small change to existing code so I wasn't sure if it's necessary.