### PR TITLE
Update workflow versions, add dependabot to check them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  # This will check for updates to github actions every day
+  # https://docs.github.com/en/enterprise-server@3.4/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/citation_cff.yml
+++ b/.github/workflows/citation_cff.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -26,6 +26,7 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
+      # Updating this to @v2 requires a github auth token
       - name: Push to GitHub Packages
         uses: docker/build-push-action@v1
         with:
@@ -36,6 +37,7 @@ jobs:
           tag_with_ref: true
           tags: ${{ steps.extract_branch.outputs.branch }}
 
+      # Updating this to @v2 requires a github auth token
       - name: Push to Docker Hub
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,12 +23,12 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
 

--- a/.github/workflows/generate-baselines.yml
+++ b/.github/workflows/generate-baselines.yml
@@ -1,3 +1,4 @@
+# Not currently in use
 name: Generate Baselines
 
 on:
@@ -7,10 +8,6 @@ on:
         description: 'Place holder'
         required: false
         default: 'Dummy argument'
-
-  push:
-    branches:
-      - development
 
 env:
   AUTOMLBENCHMARK_REPO: 'openml/automlbenchmark'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -20,12 +20,12 @@ jobs:
   run-all-files:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Setup Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.7
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -74,12 +74,12 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -1,3 +1,4 @@
+# Not currently in use
 name: Regression Tests
 
 on:
@@ -33,7 +34,7 @@ jobs:
       )
     steps:
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -81,7 +82,7 @@ jobs:
         #   branch: the branch name
 
       - name: Checkout Automlbenchmark
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.AUTOMLBENCHMARK_REPO }}
           ref: ${{ env.AUTOMLBENCHMARK_REF }}
@@ -141,7 +142,7 @@ jobs:
           #   value: The python version used by the installed system
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ steps.python-version.outputs.value }}
 
@@ -184,7 +185,7 @@ jobs:
           #   filename: name of the results file
 
       - name: Upload ${{matrix.task_type}} results as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.benchmark.outputs.filename }}
           path: |

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v4
         with:
           days-before-stale: 60
           days-before-close: 7


### PR DESCRIPTION
This PR simply updates the versions of what it can for all workflows.

Additionally, it adds `dependabot.yml` which seems to be a github specific bot that has some cool features, notably, we use it hear to inform us when there's a workflow out of date.

* https://docs.github.com/en/enterprise-server@3.4/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot