### PR TITLE
Fix logging server cleanup

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -980,6 +980,10 @@ class AutoML(BaseEstimator):
                 self._load_models()
                 self._logger.info("Finished loading models...")
 
+        # The whole logic above from where we begin the logging server is capture
+        # in a try: finally: so that if something goes wrong, we at least close
+        # down the logging server, preventing it from hanging and not closing
+        # until ctrl+c is pressed
         finally:
             self._fit_cleanup()
 


### PR DESCRIPTION
Closes #1480

Tested with the code provided in the issue.

Simply wraps the point of starting the logging server to the point it's cleaned in a `try: except`

```python
try:
    logger = self._get_logging_server(...)
    ...
finally:
    self.fit_cleanup()
    # Will raise here if something was caught
```