### PR TITLE
Show progress bar while fitting to training data 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,10 +252,11 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     make doc
     ```
     *   If you're unfamiliar with sphinx, it's a documentation generator which can read comments and docstrings from within the code and generate html documentation.
-    *   If you've added documentation, we also has a command `linkcheck` for making sure all the links correctly go to some destination.
+    *   If you've added documentation, we also have a command `links` for making 
+        sure all the links correctly go to some destination.
         This helps tests for dead links or accidental typos.
     ```bash
-    make linkcheck
+    make links
     ```
     *   We also use sphinx-gallery which can take python files (such as those in the `examples` folder) and run them, creating html which shows the code and the output it generates.
     ```bash
@@ -396,7 +397,7 @@ Lastly, if the feature really is a game changer or you're very proud of it, cons
     # If you changed documentation:
     # This will generate all documentation and check links
     make doc
-    make linkcheck
+    make links
     make examples  # mainly needed if you modified some examples
 
     # ... fix any issues

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -120,6 +120,7 @@ from autosklearn.util.logging_ import (
     warnings_to,
 )
 from autosklearn.util.parallel import preload_modules
+from autosklearn.util.progress_bar import ProgressBar
 from autosklearn.util.smac_wrap import SMACCallback, SmacRunCallback
 from autosklearn.util.stopwatch import StopWatch
 
@@ -239,6 +240,7 @@ class AutoML(BaseEstimator):
         get_trials_callback: SMACCallback | None = None,
         dataset_compression: bool | Mapping[str, Any] = True,
         allow_string_features: bool = True,
+        disable_progress_bar: bool = False,
     ):
         super().__init__()
 
@@ -295,6 +297,7 @@ class AutoML(BaseEstimator):
         self.logging_config = logging_config
         self.precision = precision
         self.allow_string_features = allow_string_features
+        self.disable_progress_bar = disable_progress_bar
         self._initial_configurations_via_metalearning = (
             initial_configurations_via_metalearning
         )
@@ -597,6 +600,7 @@ class AutoML(BaseEstimator):
         -------
         self
         """
+        progress_bar = ProgressBar(total=self._time_for_task, disable=self.disable_progress_bar)
         if (X_test is not None) ^ (y_test is not None):
             raise ValueError("Must provide both X_test and y_test together")
 
@@ -961,6 +965,7 @@ class AutoML(BaseEstimator):
             self._logger.exception(e)
             raise e
         finally:
+            progress_bar.stop()
             self._fit_cleanup()
 
         self.fitted = True

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -630,7 +630,10 @@ class AutoML(BaseEstimator):
         self._logger_port = logging.handlers.DEFAULT_TCP_LOGGING_PORT
 
         progress_bar = ProgressBar(
-            total=self._time_for_task, disable=self.disable_progress_bar
+            total=self._time_for_task,
+            disable=self.disable_progress_bar,
+            desc="Fitting to the training data",
+            colour="green",
         )
         # Once we start the logging server, it starts in a new process
         # If an error occurs then we want to make sure that we exit cleanly

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -629,6 +629,9 @@ class AutoML(BaseEstimator):
         # By default try to use the TCP logging port or get a new port
         self._logger_port = logging.handlers.DEFAULT_TCP_LOGGING_PORT
 
+        progress_bar = ProgressBar(
+            total=self._time_for_task, disable=self.disable_progress_bar
+        )
         # Once we start the logging server, it starts in a new process
         # If an error occurs then we want to make sure that we exit cleanly
         # and shut it down, else it might hang
@@ -647,11 +650,6 @@ class AutoML(BaseEstimator):
                 self._backend.save_start_time(self._seed)
 
             self._stopwatch = StopWatch()
-            progress_bar = ProgressBar(
-                total=self._time_for_task,
-                disable=self.disable_progress_bar,
-                final_message="Running cleanup...",
-            )
 
             # Make sure that input is valid
             # Performs Ordinal one hot encoding to the target

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -600,7 +600,6 @@ class AutoML(BaseEstimator):
         -------
         self
         """
-        progress_bar = ProgressBar(total=self._time_for_task, disable=self.disable_progress_bar)
         if (X_test is not None) ^ (y_test is not None):
             raise ValueError("Must provide both X_test and y_test together")
 
@@ -648,6 +647,11 @@ class AutoML(BaseEstimator):
                 self._backend.save_start_time(self._seed)
 
             self._stopwatch = StopWatch()
+            progress_bar = ProgressBar(
+                total=self._time_for_task,
+                disable=self.disable_progress_bar,
+                final_message="Running cleanup...",
+            )
 
             # Make sure that input is valid
             # Performs Ordinal one hot encoding to the target

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -527,7 +527,7 @@ class AutoSklearnEstimator(BaseEstimator):
             get_trials_callback=self.get_trials_callback,
             dataset_compression=self.dataset_compression,
             allow_string_features=self.allow_string_features,
-            disable_progress_bar=self.disable_progress_bar
+            disable_progress_bar=self.disable_progress_bar,
         )
 
         return automl

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -382,6 +382,10 @@ class AutoSklearnEstimator(BaseEstimator):
             Whether autosklearn should process string features. By default the
             textpreprocessing is enabled.
 
+        disable_progress_bar: bool = False
+            Whether to disable the progress bar that is displayed in the console
+            while fitting to the training data.
+
         Attributes
         ----------
         cv_results_ : dict of numpy (masked) ndarrays

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -76,6 +76,7 @@ class AutoSklearnEstimator(BaseEstimator):
         get_trials_callback: SMACCallback | None = None,
         dataset_compression: Union[bool, Mapping[str, Any]] = True,
         allow_string_features: bool = True,
+        disable_progress_bar: bool = False,
     ):
         """
         Parameters
@@ -475,6 +476,7 @@ class AutoSklearnEstimator(BaseEstimator):
         self.get_trials_callback = get_trials_callback
         self.dataset_compression = dataset_compression
         self.allow_string_features = allow_string_features
+        self.disable_progress_bar = disable_progress_bar
 
         self.automl_ = None  # type: Optional[AutoML]
 
@@ -525,6 +527,7 @@ class AutoSklearnEstimator(BaseEstimator):
             get_trials_callback=self.get_trials_callback,
             dataset_compression=self.dataset_compression,
             allow_string_features=self.allow_string_features,
+            disable_progress_bar=self.disable_progress_bar
         )
 
         return automl

--- a/autosklearn/experimental/askl2.py
+++ b/autosklearn/experimental/askl2.py
@@ -285,6 +285,10 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
         load_models : bool, optional (True)
             Whether to load the models after fitting Auto-sklearn.
 
+        disable_progress_bar: bool = False
+            Whether to disable the progress bar that is displayed in the console
+            while fitting to the training data.
+
         Attributes
         ----------
 

--- a/autosklearn/experimental/askl2.py
+++ b/autosklearn/experimental/askl2.py
@@ -166,6 +166,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
         load_models: bool = True,
         dataset_compression: Union[bool, Mapping[str, Any]] = True,
         allow_string_features: bool = True,
+        disable_progress_bar: bool = False,
     ):
 
         """
@@ -337,6 +338,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
             scoring_functions=scoring_functions,
             load_models=load_models,
             allow_string_features=allow_string_features,
+            disable_progress_bar=disable_progress_bar,
         )
 
     def train_selectors(self, selected_metric=None):

--- a/autosklearn/util/progress_bar.py
+++ b/autosklearn/util/progress_bar.py
@@ -23,9 +23,9 @@ class ProgressBar(Thread):
         Turns on or off the progress bar. If True, this thread won't be started or
         initialized.
     kwargs : Any
-        Keyword arguments that are passed on to tqdm, refer to:
-        https://tqdm.github.io/docs/tqdm/. Note that postfix can not be specified
-        as a kwarg since it is already passed to tqdm by this class.
+        Keyword arguments that are passed into tqdm's constructor. Refer to:
+        `tqdm <https://tqdm.github.io/docs/tqdm/>`_. Note that postfix can not be
+        specified in the kwargs since it is already passed into tqdm by this class.
     """
 
     def __init__(

--- a/autosklearn/util/progress_bar.py
+++ b/autosklearn/util/progress_bar.py
@@ -1,38 +1,58 @@
 import time
-
 from threading import Thread
+
 from tqdm import trange
 
 
 class ProgressBar(Thread):
-    """A Thread that displays a tqdm progress bar in the console."""
+    """
+    A Thread that displays a tqdm progress bar in the console.
 
-    def __init__(self, total: float, update_interval: float = 1.0, disable: bool = False):
-        """
-        Parameters
-        ----------
-        total: the total amount that the progress bar should reach
-        update_interval: reduce this to update the progress bar more frequently
-        disable: flag that turns on or off the progress bar. If false, then no thread is started or created.
-        """
+    Parameters
+    ----------
+    total : float
+        The total amount that should be reached by the progress bar once it finishes
+    update_interval : float
+        Specifies how frequently the progress bar is updated (in seconds)
+    disable : bool
+        Turns on or off the progress bar. If True, this thread won't be started or initialized
+    final_message : str
+        Optional message, which is printed out on a new line once the bar is maxed out.
+    """
+
+    def __init__(
+        self,
+        total: float,
+        update_interval: float = 1.0,
+        disable: bool = False,
+        final_message: str = None,
+    ):
         self.disable = disable
         if not disable:
             super().__init__(name="_progressbar_")
             self.total = total
             self.update_interval = update_interval
+            self.final_message = final_message
             self.terminated: bool = False
             self.start()
 
-    def run(self):
+    def run(self) -> None:
+        """
+        Overrides the run method of Thread. It displays a tqdm progress bar in the console.
+
+        """
         if not self.disable:
-            for _ in trange(self.total, colour="green"):
+            for _ in trange(
+                self.total, colour="green", desc="Fitting to the training data"
+            ):
                 if not self.terminated:
                     time.sleep(self.update_interval)
-                else:
-                    pass  # max out the bar
+            print(self.final_message)
 
-    def stop(self):
+    def stop(self) -> None:
+        """
+        Terminates the thread.
+        """
         if not self.disable:
             self.terminated = True
             super().join()
-

--- a/autosklearn/util/progress_bar.py
+++ b/autosklearn/util/progress_bar.py
@@ -1,0 +1,38 @@
+import time
+
+from threading import Thread
+from tqdm import trange
+
+
+class ProgressBar(Thread):
+    """A Thread that displays a tqdm progress bar in the console."""
+
+    def __init__(self, total: float, update_interval: float = 1.0, disable: bool = False):
+        """
+        Parameters
+        ----------
+        total: the total amount that the progress bar should reach
+        update_interval: reduce this to update the progress bar more frequently
+        disable: flag that turns on or off the progress bar. If false, then no thread is started or created.
+        """
+        self.disable = disable
+        if not disable:
+            super().__init__(name="_progressbar_")
+            self.total = total
+            self.update_interval = update_interval
+            self.terminated: bool = False
+            self.start()
+
+    def run(self):
+        if not self.disable:
+            for _ in trange(self.total, colour="green"):
+                if not self.terminated:
+                    time.sleep(self.update_interval)
+                else:
+                    pass  # max out the bar
+
+    def stop(self):
+        if not self.disable:
+            self.terminated = True
+            super().join()
+

--- a/autosklearn/util/progress_bar.py
+++ b/autosklearn/util/progress_bar.py
@@ -1,53 +1,60 @@
+import datetime
 import time
 from threading import Thread
 
-from tqdm import trange
+from tqdm import trange  # type: ignore
 
 
 class ProgressBar(Thread):
     """
     A Thread that displays a tqdm progress bar in the console.
 
+    It is specialized to display information relevant to fitting to the training data
+    with auto-sklearn.
+
     Parameters
     ----------
-    total : float
+    total : int
         The total amount that should be reached by the progress bar once it finishes
     update_interval : float
         Specifies how frequently the progress bar is updated (in seconds)
     disable : bool
-        Turns on or off the progress bar. If True, this thread won't be started or initialized
-    final_message : str
-        Optional message, which is printed out on a new line once the bar is maxed out.
+        Turns on or off the progress bar. If True, this thread won't be started or
+        initialized.
     """
 
     def __init__(
         self,
-        total: float,
+        total: int,
         update_interval: float = 1.0,
         disable: bool = False,
-        final_message: str = None,
     ):
         self.disable = disable
         if not disable:
             super().__init__(name="_progressbar_")
             self.total = total
             self.update_interval = update_interval
-            self.final_message = final_message
             self.terminated: bool = False
+            # start this thread
             self.start()
 
     def run(self) -> None:
         """
-        Overrides the run method of Thread. It displays a tqdm progress bar in the console.
+        Overrides the run method of Thread. It displays a tqdm progress bar in the
+        console with useful descriptions about the task.
 
         """
         if not self.disable:
             for _ in trange(
-                self.total, colour="green", desc="Fitting to the training data"
+                self.total,
+                colour="green",
+                desc="Fitting to the training data",
+                postfix=f"The total time budget for this task is"
+                f" {datetime.timedelta(seconds=self.total)}",
             ):
                 if not self.terminated:
                     time.sleep(self.update_interval)
-            print(self.final_message)
+            print("Finishing up the task...")
 
     def stop(self) -> None:
         """

--- a/autosklearn/util/progress_bar.py
+++ b/autosklearn/util/progress_bar.py
@@ -1,13 +1,14 @@
+from typing import Any
+
 import datetime
 import time
 from threading import Thread
 
-from tqdm import trange  # type: ignore
+from tqdm import trange
 
 
 class ProgressBar(Thread):
-    """
-    A Thread that displays a tqdm progress bar in the console.
+    """A Thread that displays a tqdm progress bar in the console.
 
     It is specialized to display information relevant to fitting to the training data
     with auto-sklearn.
@@ -21,6 +22,10 @@ class ProgressBar(Thread):
     disable : bool
         Turns on or off the progress bar. If True, this thread won't be started or
         initialized.
+    kwargs : Any
+        Keyword arguments that are passed on to tqdm, refer to:
+        https://tqdm.github.io/docs/tqdm/. Note that postfix can not be specified
+        as a kwarg since it is already passed to tqdm by this class.
     """
 
     def __init__(
@@ -28,6 +33,7 @@ class ProgressBar(Thread):
         total: int,
         update_interval: float = 1.0,
         disable: bool = False,
+        **kwargs: Any,
     ):
         self.disable = disable
         if not disable:
@@ -35,31 +41,28 @@ class ProgressBar(Thread):
             self.total = total
             self.update_interval = update_interval
             self.terminated: bool = False
+            self.kwargs = kwargs
             # start this thread
             self.start()
 
     def run(self) -> None:
-        """
-        Overrides the run method of Thread. It displays a tqdm progress bar in the
-        console with useful descriptions about the task.
+        """Display a tqdm progress bar in the console.
 
+        Additionally, it shows useful information related to the task. This method
+        overrides the run method of Thread.
         """
         if not self.disable:
             for _ in trange(
                 self.total,
-                colour="green",
-                desc="Fitting to the training data",
-                postfix=f"The total time budget for this task is"
-                f" {datetime.timedelta(seconds=self.total)}",
+                postfix=f"The total time budget for this task is "
+                f"{datetime.timedelta(seconds=self.total)}",
+                **self.kwargs,
             ):
                 if not self.terminated:
                     time.sleep(self.update_interval)
-            print("Finishing up the task...")
 
     def stop(self) -> None:
-        """
-        Terminates the thread.
-        """
+        """Terminates the thread."""
         if not self.disable:
             self.terminated = True
             super().join()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,8 @@ module = [
     "setuptools.*",
     "pkg_resources.*",
     "yaml.*",
-    "psutil.*"
+    "psutil.*",
+    "tqdm.*",
 ]
 ignore_missing_imports = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,28 @@
-setuptools
+setuptools~=63.4.1
 typing_extensions
-distro
+distro~=1.8.0
 
 numpy>=1.9.0
 scipy>=1.7.0
 
-joblib
+joblib~=1.2.0
 scikit-learn>=0.24.0,<0.25.0
 
 dask>=2021.12
 distributed>=2012.12
-pyyaml
+pyyaml~=6.0
 pandas>=1.0
 liac-arff
-threadpoolctl
+threadpoolctl~=3.1.0
 
 ConfigSpace>=0.4.21,<0.5
 pynisher>=0.6.3,<0.7
 pyrfr>=0.8.1,<0.9
 smac>=1.2,<1.3
+
+pytest~=7.1.2
+filelock~=3.6.0
+psutil~=5.9.2
+openml~=0.12.2
+matplotlib~=3.6.1
+tqdm~=4.64.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,28 +1,22 @@
-setuptools~=63.4.1
+setuptools
 typing_extensions
-distro~=1.8.0
+distro
 
 numpy>=1.9.0
 scipy>=1.7.0
 
-joblib~=1.2.0
+joblib
 scikit-learn>=0.24.0,<0.25.0
 
 dask>=2021.12
 distributed>=2012.12
-pyyaml~=6.0
+pyyaml
 pandas>=1.0
 liac-arff
-threadpoolctl~=3.1.0
+threadpoolctl
+tqdm
 
 ConfigSpace>=0.4.21,<0.5
 pynisher>=0.6.3,<0.7
 pyrfr>=0.8.1,<0.9
 smac>=1.2,<1.3
-
-pytest~=7.1.2
-filelock~=3.6.0
-psutil~=5.9.2
-openml~=0.12.2
-matplotlib~=3.6.1
-tqdm~=4.64.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_reqs = {
     "test": [
         "pytest>=4.6",
         "pytest-cov",
-        "pytest-xdist",
+        "pytest-forked",
         "pytest-timeout",
         "pytest-cases>=3.6.11",
         "mypy",


### PR DESCRIPTION
Closes #1599 

**Motivation:**
Building an AutoML model and calling the fit() function does not give any indication of how much time is left from the optimization process. This may cause confusion especially for fresh users not familiar with the API.

**Solution**
A new class called ProgressBar was added under autosklearn/utils, which is an instance of Thread. By instantiating this thread, it automatically starts itself and displays a [tqdm](https://tqdm.github.io/docs/tqdm/) progress bar in the console.
ProgressBar gets instantiated at the very beginning of the AutoML fit() method and stopped in the finally block of the outermost try block. This introduced only minimal changes to the existing functions.

**Controversial**
This feature is automatically on, meaning that the console will show a progress bar by default. However, it can be turned off by setting the newly introduced disable_progress_bar parameter of AutoSklearnEstimator to True.
I believe it is more sensible to have it on by default, since the feature aims to mainly benefit new users and from my experience it greatly improves overall user experience in general.

**Potential introduced bugs**
I noticed that the fit() method doesn't _always_ stop after hitting "stop" a single time within my IDE (Pycharm). It requires the "stop" button to be clicked two times to terminate properly.
Nonetheless, I believe this is how autosklearn used to work before I introduced my feature.
This needs further investigation in the future.

**Dependency**
The only dependency required by this feature is tqdm, which is a very minimal library.

**Test**
This feature was only manually tested. So no additinal tests were written for it, because I couldn't think of a reasonable way to test it.

**Side note**
An alternative solution that I've tried was creating a context manager callback class called ProgressBar, which was an instance of IncorporateRunResultCallback. In the __call__() method of this class I updated the progress bar manually by the amount of time it took SMAC to train a sampled model. Entering a with block, my class returned an instance of itself and I passed this callback instance to [SMAC](https://github.com/automl/SMAC3)'s trials_callback parameter.
I found this alternative solution to be hard to manage and unelegant, since not only the time spent by SMAC on training estimators, but time spent in other processes has to also be accumulated.
This is why I went with the solution above instead.