### PR TITLE
fix(multiprocessing): Use list instead of key-view

### DIFF
--- a/autosklearn/util/parallel.py
+++ b/autosklearn/util/parallel.py
@@ -3,7 +3,16 @@ import sys
 
 
 def preload_modules(context: multiprocessing.context.BaseContext) -> None:
-    all_loaded_modules = sys.modules.keys()
+    """Attempt to preload modules when using forkserver"""
+    # NOTE: preloading and docstring
+    #
+    #   This is just a best guess at why this is used, coming from this blogpost
+    #   https://bnikolic.co.uk/blog/python/parallelism/2019/11/13/python-forkserver-preload.html
+    #   Ideally we should identify subprocesses that get run with this and try limit the
+    #   necessity to use all of these modules
+    #
+    #   @eddiebergman
+    all_loaded_modules = list(sys.modules.keys())
     preload = [
         loaded_module
         for loaded_module in all_loaded_modules


### PR DESCRIPTION
Seems [some tests](https://github.com/automl/auto-sklearn/actions/runs/3459736373/jobs/5775463044) were failing stochastically in `AutoML::fit() -> _fit_cleanup()`, many complaining that `self._logger` was `None` and calling methods like `info` and `exception` on this `None` object were failing (as expected). Scrolling further up in the stack traces, there was a seemingly unrelated failure.

```python
     all_loaded_modules = sys.modules.keys()
     preload = [
        loaded_module
        for loaded_module in all_loaded_modules
        if loaded_module.split(".")[0]
        in (
            "smac",
            "autosklearn",
            "numpy",
            "scipy",
            "pandas",
            "pynisher",
            "sklearn",
            "ConfigSpace",
        )
        and "logging" not in loaded_module
    ]
    # RuntimeError: dictionary changed size during iteration
```

My guess here is that `sys.modules` was slowly getting cleaned up by the garbage collector as cleanup was happening, causing this iteration to fail. Solution was just to wrap in a `list` as `list(sys.modules.keys())`.

Will update depending on whether this fixes the issue.