### PR TITLE
doc(smac): Update link for `get_smac_object_callback`

### DIFF
--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -276,7 +276,7 @@ class AutoSklearnEstimator(BaseEstimator):
 
         smac_scenario_args : dict, optional (None)
             Additional arguments inserted into the scenario of SMAC. See the
-            `SMAC documentation <https://automl.github.io/SMAC3/main/api/smac.scenario.scenario.html#module-smac.scenario.scenario>`_
+            `SMAC documentation <https://automl.github.io/SMAC3/main/api/smac.scenario.html#smac.scenario.Scenario>`_
             for a list of available arguments.
 
         get_smac_object_callback : callable

--- a/autosklearn/estimators.py
+++ b/autosklearn/estimators.py
@@ -281,7 +281,7 @@ class AutoSklearnEstimator(BaseEstimator):
 
         get_smac_object_callback : callable
             Callback function to create an object of class
-            `smac.optimizer.smbo.SMBO <https://automl.github.io/SMAC3/main/api/smac.optimizer.smbo.html>`_.
+            `smac.facade.AbstractFacade <https://automl.github.io/SMAC3/main/api/smac.facade.html>`_.
             The function must accept the arguments ``scenario_dict``,
             ``instances``, ``num_params``, ``runhistory``, ``seed`` and ``ta``.
             This is an advanced feature. Use only if you are familiar with

--- a/autosklearn/experimental/askl2.py
+++ b/autosklearn/experimental/askl2.py
@@ -264,7 +264,7 @@ class AutoSklearn2Classifier(AutoSklearnClassifier):
 
         smac_scenario_args : dict, optional (None)
             Additional arguments inserted into the scenario of SMAC. See the
-            `SMAC documentation <https://automl.github.io/SMAC3/main/api/smac.scenario.scenario.html#module-smac.scenario.scenario>`_
+            `SMAC documentation <https://automl.github.io/SMAC3/main/api/smac.scenario.html#smac.scenario.Scenario>`_
             for a list of available arguments.
 
         logging_config : dict, optional (None)

--- a/examples/40_advanced/example_multi_objective.py
+++ b/examples/40_advanced/example_multi_objective.py
@@ -8,7 +8,7 @@ The following example shows how to fit *auto-sklearn* to optimize for two
 competing metrics: `precision` and `recall` (read more on this tradeoff
 in the `scikit-learn docs <https://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html>`_.
 
-Auto-sklearn uses `SMAC3's implementation of ParEGO <https://automl.github.io/SMAC3/main/details/multi_objective.html>`_.
+Auto-sklearn uses `SMAC3's implementation of ParEGO <https://automl.github.io/SMAC3/main/examples/3_multi_objective/2_parego.html#parego>`_.
 Multi-objective ensembling and proper access to the full Pareto set will be added in the near
 future.
 """


### PR DESCRIPTION
Updates the link for `get_smac_object_callback` so our docs build again. Technically this is not correct because we are using an older version of SMAC right now and there's no docs to link to for that. However it shouldn't be too different and we estimate this is unlikely to be an issue until we do update SMAC.