### PR TITLE
Update scikit learn 1.2

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9']  # 3.10 once updated
+        python-version: ['3.8', '3.9', '3.10']  # 3.10 once updated
         kind: ['conda', 'source', 'dist']
 
         exclude:
@@ -60,15 +60,15 @@ jobs:
           - os: macos-latest
 
         include:
-          # Add the tag code-cov to ubuntu-3.7-source
+          # Add the tag code-cov to ubuntu-3.8-source
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: 3.8
             kind: 'source'
             code-cov: true
 
-           # Include one config with dist, ubuntu-3.7-dist
+           # Include one config with dist, ubuntu-3.8-dist
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: 3.8
             kind: 'dist'
 
     steps:

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -42,11 +42,8 @@ from sklearn.base import BaseEstimator
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import VotingClassifier, VotingRegressor
 from sklearn.metrics._classification import type_of_target
-from sklearn.model_selection._split import (
-    BaseCrossValidator,
-    BaseShuffleSplit,
-    _RepeatedSplits,
-)
+from sklearn.model_selection import BaseCrossValidator, BaseShuffleSplit
+from sklearn.model_selection._split import _RepeatedSplits
 from sklearn.pipeline import Pipeline
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_is_fitted

--- a/autosklearn/evaluation/__init__.py
+++ b/autosklearn/evaluation/__init__.py
@@ -26,11 +26,8 @@ from queue import Empty
 import numpy as np
 import pynisher
 from ConfigSpace import Configuration
-from sklearn.model_selection._split import (
-    BaseCrossValidator,
-    BaseShuffleSplit,
-    _RepeatedSplits,
-)
+from sklearn.model_selection import BaseCrossValidator, BaseShuffleSplit
+from sklearn.model_selection._split import _RepeatedSplits
 from smac.runhistory.runhistory import RunInfo, RunValue
 from smac.stats.stats import Stats
 from smac.tae import StatusType, TAEAbortException

--- a/autosklearn/evaluation/train_evaluator.py
+++ b/autosklearn/evaluation/train_evaluator.py
@@ -14,6 +14,7 @@ from ConfigSpace import Configuration
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import (
     BaseCrossValidator,
+    BaseShuffleSplit,
     KFold,
     PredefinedSplit,
     ShuffleSplit,
@@ -21,7 +22,7 @@ from sklearn.model_selection import (
     StratifiedShuffleSplit,
     train_test_split,
 )
-from sklearn.model_selection._split import BaseShuffleSplit, _RepeatedSplits
+from sklearn.model_selection._split import _RepeatedSplits
 from smac.tae import StatusType, TAEAbortException
 
 from autosklearn.automl_common.common.utils.backend import Backend

--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -382,6 +382,7 @@ class AutoSklearnChoice(object):
         # necessary to do this upon the construction of this object
         # self.set_hyperparameters(self.configuration)
         self.choice = None
+        self._fitted = False
 
     def get_components(cls):
         raise NotImplementedError()
@@ -466,11 +467,13 @@ class AutoSklearnChoice(object):
         raise NotImplementedError()
 
     def fit(self, X, y, **kwargs):
-        # Allows to use check_is_fitted on the choice object
-        self.fitted_ = True
+        self._fitted = True
         if kwargs is None:
             kwargs = {}
         return self.choice.fit(X, y, **kwargs)
+
+    def __sklearn_is_fitted__(self) -> bool:
+        return self._fitted
 
     def predict(self, X):
         return self.choice.predict(X)

--- a/autosklearn/pipeline/components/classification/__init__.py
+++ b/autosklearn/pipeline/components/classification/__init__.py
@@ -167,7 +167,7 @@ class ClassifierChoice(AutoSklearnChoice):
 
     def iterative_fit(self, X, y, n_iter=1, **fit_params):
         # Allows to use check_is_fitted on the choice object
-        self.fitted_ = True
+        self._fitted = True
         if fit_params is None:
             fit_params = {}
         return self.choice.iterative_fit(X, y, n_iter=n_iter, **fit_params)

--- a/autosklearn/pipeline/components/classification/decision_tree.py
+++ b/autosklearn/pipeline/components/classification/decision_tree.py
@@ -114,6 +114,8 @@ class DecisionTree(AutoSklearnClassificationAlgorithm):
     ):
         cs = ConfigurationSpace()
 
+        # Criterion has now `log_loss` but it is equivalent to entropy, leave it out
+        # so as to not confuse the optimizer
         criterion = CategoricalHyperparameter(
             "criterion", ["gini", "entropy"], default_value="gini"
         )

--- a/autosklearn/pipeline/components/classification/extra_trees.py
+++ b/autosklearn/pipeline/components/classification/extra_trees.py
@@ -164,6 +164,9 @@ class ExtraTreesClassifier(
     ):
         cs = ConfigurationSpace()
 
+        # There is also the `criterion` called `log_loss`, however the documation states
+        # they are equivalent. We leave one of them out so the optimizer does not need
+        # to worry about it
         criterion = CategoricalHyperparameter(
             "criterion", ["gini", "entropy"], default_value="gini"
         )

--- a/autosklearn/pipeline/components/classification/gradient_boosting.py
+++ b/autosklearn/pipeline/components/classification/gradient_boosting.py
@@ -189,7 +189,7 @@ class GradientBoostingClassifier(
         feat_type: Optional[FEAT_TYPE_TYPE] = None, dataset_properties=None
     ):
         cs = ConfigurationSpace()
-        loss = Constant("loss", "auto")
+        loss = Constant("loss", "log_loss")
         learning_rate = UniformFloatHyperparameter(
             name="learning_rate", lower=0.01, upper=1, default_value=0.1, log=True
         )

--- a/autosklearn/pipeline/components/classification/random_forest.py
+++ b/autosklearn/pipeline/components/classification/random_forest.py
@@ -78,7 +78,7 @@ class RandomForest(
             self.min_samples_leaf = int(self.min_samples_leaf)
             self.min_weight_fraction_leaf = float(self.min_weight_fraction_leaf)
 
-            if self.max_features not in ("sqrt", "log2", "auto"):
+            if self.max_features not in ("sqrt", "log2"):
                 max_features = int(X.shape[1] ** float(self.max_features))
             else:
                 max_features = self.max_features

--- a/autosklearn/pipeline/components/classification/random_forest.py
+++ b/autosklearn/pipeline/components/classification/random_forest.py
@@ -156,6 +156,9 @@ class RandomForest(
         feat_type: Optional[FEAT_TYPE_TYPE] = None, dataset_properties=None
     ):
         cs = ConfigurationSpace()
+        # There is also the `criterion` called `log_loss`, however the documation states
+        # they are equivalent. We leave one of them out so the optimizer does not need
+        # to worry about it
         criterion = CategoricalHyperparameter(
             "criterion", ["gini", "entropy"], default_value="gini"
         )

--- a/autosklearn/pipeline/components/classification/sgd.py
+++ b/autosklearn/pipeline/components/classification/sgd.py
@@ -179,8 +179,8 @@ class SGD(
 
         loss = CategoricalHyperparameter(
             "loss",
-            ["hinge", "log", "modified_huber", "squared_hinge", "perceptron"],
-            default_value="log",
+            ["hinge", "log_log", "modified_huber", "squared_hinge", "perceptron"],
+            default_value="log_log",
         )
         penalty = CategoricalHyperparameter(
             "penalty", ["l1", "l2", "elasticnet"], default_value="l2"

--- a/autosklearn/pipeline/components/feature_preprocessing/extra_trees_preproc_for_classification.py
+++ b/autosklearn/pipeline/components/feature_preprocessing/extra_trees_preproc_for_classification.py
@@ -132,6 +132,9 @@ class ExtraTreesPreprocessorClassification(AutoSklearnPreprocessingAlgorithm):
         cs = ConfigurationSpace()
 
         n_estimators = Constant("n_estimators", 100)
+        # There is also the `criterion` called `log_loss`, however the documation states
+        # they are equivalent. We leave one of them out so the optimizer does not need
+        # to worry about it
         criterion = CategoricalHyperparameter(
             "criterion", ["gini", "entropy"], default_value="gini"
         )

--- a/autosklearn/pipeline/components/feature_preprocessing/extra_trees_preproc_for_regression.py
+++ b/autosklearn/pipeline/components/feature_preprocessing/extra_trees_preproc_for_regression.py
@@ -135,7 +135,7 @@ class ExtraTreesPreprocessorRegression(AutoSklearnPreprocessingAlgorithm):
 
         n_estimators = Constant("n_estimators", 100)
         criterion = CategoricalHyperparameter(
-            "criterion", ["mse", "friedman_mse", "mae"]
+            "criterion", ["squared_error", "friedman_mse", "mae"]
         )
         max_features = UniformFloatHyperparameter(
             "max_features", 0.1, 1.0, default_value=1.0

--- a/autosklearn/pipeline/components/feature_preprocessing/kernel_pca.py
+++ b/autosklearn/pipeline/components/feature_preprocessing/kernel_pca.py
@@ -50,10 +50,10 @@ class KernelPCA(AutoSklearnPreprocessingAlgorithm):
         with warnings.catch_warnings():
             warnings.filterwarnings("error")
             self.preprocessor.fit(X)
-        # Raise an informative error message, equation is based ~line 249 in
-        # kernel_pca.py in scikit-learn
-        if len(self.preprocessor.alphas_ / self.preprocessor.lambdas_) == 0:
+
+        if self.preprocessor._n_features_out == 0:
             raise ValueError("KernelPCA removed all features!")
+
         return self
 
     def transform(self, X):

--- a/autosklearn/pipeline/components/regression/__init__.py
+++ b/autosklearn/pipeline/components/regression/__init__.py
@@ -152,7 +152,7 @@ class RegressorChoice(AutoSklearnChoice):
 
     def iterative_fit(self, X, y, n_iter=1, **fit_params):
         # Allows to use check_is_fitted on the choice object
-        self.fitted_ = True
+        self._fitted = True
         if fit_params is None:
             fit_params = {}
         return self.choice.iterative_fit(X, y, n_iter=n_iter, **fit_params)

--- a/autosklearn/pipeline/components/regression/ard_regression.py
+++ b/autosklearn/pipeline/components/regression/ard_regression.py
@@ -59,7 +59,6 @@ class ARDRegression(AutoSklearnRegressionAlgorithm):
             compute_score=False,
             threshold_lambda=self.threshold_lambda,
             fit_intercept=True,
-            normalize=False,
             copy_X=False,
             verbose=False,
         )

--- a/autosklearn/pipeline/components/regression/decision_tree.py
+++ b/autosklearn/pipeline/components/regression/decision_tree.py
@@ -105,7 +105,7 @@ class DecisionTree(AutoSklearnRegressionAlgorithm):
         cs = ConfigurationSpace()
 
         criterion = CategoricalHyperparameter(
-            "criterion", ["squared_error", "friedman_mse", "mae"]
+            "criterion", ["squared_error", "friedman_mse", "absolute_error"]
         )
         max_features = Constant("max_features", 1.0)
         max_depth_factor = UniformFloatHyperparameter(

--- a/autosklearn/pipeline/components/regression/decision_tree.py
+++ b/autosklearn/pipeline/components/regression/decision_tree.py
@@ -105,7 +105,7 @@ class DecisionTree(AutoSklearnRegressionAlgorithm):
         cs = ConfigurationSpace()
 
         criterion = CategoricalHyperparameter(
-            "criterion", ["mse", "friedman_mse", "mae"]
+            "criterion", ["squared_error", "friedman_mse", "mae"]
         )
         max_features = Constant("max_features", 1.0)
         max_depth_factor = UniformFloatHyperparameter(

--- a/autosklearn/pipeline/components/regression/extra_trees.py
+++ b/autosklearn/pipeline/components/regression/extra_trees.py
@@ -157,7 +157,7 @@ class ExtraTreesRegressor(
         cs = ConfigurationSpace()
 
         criterion = CategoricalHyperparameter(
-            "criterion", ["mse", "friedman_mse", "mae"]
+            "criterion", ["squared_error", "friedman_mse", "mae"]
         )
         max_features = UniformFloatHyperparameter(
             "max_features", 0.1, 1.0, default_value=1

--- a/autosklearn/pipeline/components/regression/extra_trees.py
+++ b/autosklearn/pipeline/components/regression/extra_trees.py
@@ -157,7 +157,7 @@ class ExtraTreesRegressor(
         cs = ConfigurationSpace()
 
         criterion = CategoricalHyperparameter(
-            "criterion", ["squared_error", "friedman_mse", "mae"]
+            "criterion", ["squared_error", "friedman_mse", "absolute_error"]
         )
         max_features = UniformFloatHyperparameter(
             "max_features", 0.1, 1.0, default_value=1

--- a/autosklearn/pipeline/components/regression/gradient_boosting.py
+++ b/autosklearn/pipeline/components/regression/gradient_boosting.py
@@ -174,7 +174,7 @@ class GradientBoosting(
     ):
         cs = ConfigurationSpace()
         loss = CategoricalHyperparameter(
-            "loss", ["squared_error"], default_value="least_squares"
+            "loss", ["squared_error"], default_value="squared_error"
         )
         learning_rate = UniformFloatHyperparameter(
             name="learning_rate", lower=0.01, upper=1, default_value=0.1, log=True

--- a/autosklearn/pipeline/components/regression/gradient_boosting.py
+++ b/autosklearn/pipeline/components/regression/gradient_boosting.py
@@ -174,7 +174,7 @@ class GradientBoosting(
     ):
         cs = ConfigurationSpace()
         loss = CategoricalHyperparameter(
-            "loss", ["least_squares"], default_value="least_squares"
+            "loss", ["squared_error"], default_value="least_squares"
         )
         learning_rate = UniformFloatHyperparameter(
             name="learning_rate", lower=0.01, upper=1, default_value=0.1, log=True

--- a/autosklearn/pipeline/components/regression/libsvm_svr.py
+++ b/autosklearn/pipeline/components/regression/libsvm_svr.py
@@ -127,6 +127,9 @@ class LibSVM_SVR(AutoSklearnRegressionAlgorithm):
             raise NotImplementedError
         y_pred = self.estimator.predict(X)
 
+        if y_pred.ndim == 1:
+            y_pred = y_pred.reshape((-1, 1))
+
         inverse = self.scaler.inverse_transform(y_pred)
 
         # Flatten: [[0], [0], [0]] -> [0, 0, 0]

--- a/autosklearn/pipeline/components/regression/mlp.py
+++ b/autosklearn/pipeline/components/regression/mlp.py
@@ -204,6 +204,9 @@ class MLPRegressor(IterativeComponent, AutoSklearnRegressionAlgorithm):
 
         y_pred = self.estimator.predict(X)
 
+        if y_pred.ndim == 1:
+            y_pred = y_pred.reshape((-1, 1))
+
         inverse = self.scaler.inverse_transform(y_pred)
 
         # Flatten: [[0], [0], [0]] -> [0, 0, 0]

--- a/autosklearn/pipeline/components/regression/random_forest.py
+++ b/autosklearn/pipeline/components/regression/random_forest.py
@@ -143,7 +143,7 @@ class RandomForest(
     ):
         cs = ConfigurationSpace()
         criterion = CategoricalHyperparameter(
-            "criterion", ["squared_error", "friedman_mse", "mae"]
+            "criterion", ["squared_error", "friedman_mse", "absolute_error"]
         )
 
         # In contrast to the random forest classifier we want to use more max_features

--- a/autosklearn/pipeline/components/regression/random_forest.py
+++ b/autosklearn/pipeline/components/regression/random_forest.py
@@ -143,7 +143,7 @@ class RandomForest(
     ):
         cs = ConfigurationSpace()
         criterion = CategoricalHyperparameter(
-            "criterion", ["mse", "friedman_mse", "mae"]
+            "criterion", ["squared_error", "friedman_mse", "mae"]
         )
 
         # In contrast to the random forest classifier we want to use more max_features

--- a/autosklearn/pipeline/components/regression/sgd.py
+++ b/autosklearn/pipeline/components/regression/sgd.py
@@ -196,12 +196,12 @@ class SGD(
         loss = CategoricalHyperparameter(
             "loss",
             [
-                "squared_loss",
+                "squared_error",
                 "huber",
                 "epsilon_insensitive",
                 "squared_epsilon_insensitive",
             ],
-            default_value="squared_loss",
+            default_value="squared_error",
         )
         penalty = CategoricalHyperparameter(
             "penalty", ["l1", "l2", "elasticnet"], default_value="l2"

--- a/autosklearn/pipeline/components/regression/sgd.py
+++ b/autosklearn/pipeline/components/regression/sgd.py
@@ -168,8 +168,19 @@ class SGD(
     def predict(self, X):
         if self.estimator is None:
             raise NotImplementedError()
-        Y_pred = self.estimator.predict(X)
-        return self.scaler.inverse_transform(Y_pred)
+
+        y_pred = self.estimator.predict(X)
+
+        if y_pred.ndim == 1:
+            y_pred = y_pred.reshape((-1, 1))
+
+        inverse = self.scaler.inverse_transform(y_pred)
+
+        # Flatten: [[0], [0], [0]] -> [0, 0, 0]
+        if inverse.ndim == 2 and inverse.shape[1] == 1:
+            inverse = inverse.flatten()
+
+        return inverse
 
     @staticmethod
     def get_properties(dataset_properties=None):

--- a/autosklearn/util/__init__.py
+++ b/autosklearn/util/__init__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 import re
 
-SUBPATTERN = r"((?P<operation%d>==|>=|>|<)(?P<version%d>(\d+)?(\.[a-zA-Z0-9]+)?(\.[a-zA-Z0-9]+)?))"  # noqa: E501
+SUBPATTERN = r"((?P<operation%d>==|>=|>|<|<=)(?P<version%d>(\d+)?(\.[a-zA-Z0-9]+)?(\.[a-zA-Z0-9]+)?))"  # noqa: E501
 RE_PATTERN = re.compile(
     r"^(?P<name>[\w\-]+)%s?(,%s)?$" % (SUBPATTERN % (1, 1), SUBPATTERN % (2, 2))
 )

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,6 +25,14 @@ the technology behind *auto-sklearn* by reading our paper published at
 `NeurIPS 2015 <https://papers.neurips.cc/paper/5872-efficient-and-robust-automated-machine-learning.pdf>`_
 .
 
+
+.. topic:: Python3.7
+   With the update to `scikit-learn 1.2 <https://github.com/automl/auto-sklearn/pull/1611>_`,
+   we are forced to drop `Python3.7` from version `0.16.0` onwards.
+   This means that that Google Colab, who only support `Python3.7` will no longer be able to
+   run the latest versions of AutoSklearn. Please use `0.15.0` if colab usage is required.
+
+
 .. topic:: NEW: Text feature support
 
     Auto-sklearn now supports text features, check our new example:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-minversion = "3.7"
+minversion = "3.8"
 addopts = "--forked"
 
 [tool.coverage.run]
@@ -21,10 +21,10 @@ exclude_lines = [
 ]
 
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']
 
 [tool.isort]
-py_version = "37"
+py_version = "38"
 profile = "black" # Play nicely with black
 src_paths = ["autosklearn", "test"]
 known_types = ["typing", "abc"] # We put these in their own section TYPES
@@ -66,7 +66,7 @@ add-ignore = [ # http://www.pydocstyle.org/en/stable/error_codes.html
 ]
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.8"
 
 show_error_codes = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy>=1.9.0
 scipy>=1.7.0
 
 joblib
-scikit-learn>=0.24.0,<0.25.0
+scikit-learn>=1.1.3,<=1.2
 
 dask>=2021.12
 distributed>=2012.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy>=1.9.0
 scipy>=1.7.0
 
 joblib
-scikit-learn>=1.1.3,<=1.2
+scikit-learn>=1.1.3,<1.2
 
 dask>=2021.12
 distributed>=2012.12

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -9,22 +9,13 @@ The working directory will be used to save all temporary and final output.
     working_directory=~/auto-sklearn-metadata/001
     mkdir -p $working_directory
 
-The task type defines whether you want update classification or regression
-metadata:
-
-    task_type=classification
-
-or
-
-    task_type=regression
-
 ## 2. Install the OpenML package and create an OpenML account
 
 Read the [OpenML python package manual](https://openml.github.io/openml-python) for this.
 
 ## 3. Create configuration commands
 
-    python3 01_create_commands.py --working-directory $working_directory --task-type $task_type
+    python3 01_create_commands.py --working-directory $working_directory
 
 This will create a file with all commands necessary to run auto-sklearn on a
 large number of datasets from OpenML. You can change the task IDs or the way

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ if os.name != "posix":
         % sys.platform
     )
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     raise ValueError(
         "Unsupported Python version %d.%d.%d found. Auto-sklearn requires Python "
-        "3.7 or higher."
+        "3.8 or higher."
         % (sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
     )
 
@@ -91,10 +91,10 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Scientific/Engineering :: Information Analysis",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     url="https://automl.github.io/auto-sklearn",
 )

--- a/test/test_pipeline/components/regression/test_gradient_boosting.py
+++ b/test/test_pipeline/components/regression/test_gradient_boosting.py
@@ -21,5 +21,5 @@ class GradientBoostingComponentTest(BaseRegressionComponentTest):
     res["default_diabetes_sparse"] = None
     res["diabetes_n_call"] = 11
 
-    sk_mod = sklearn.ensemble.GradientBoostingRegressor
+    sk_mod = sklearn.ensemble.HistGradientBoostingRegressor
     module = GradientBoosting


### PR DESCRIPTION
This PR attempts to cleanly just update scikit-learn to 1.2 which necessitates updating to Python 3.8. This means we are locked out of Colab from any newer versions as Google Colab only support python 3.7

Will be a live PR, going through the [changelogs for 1.0.2](https://scikit-learn.org/stable/whats_new/v1.0.html#version-1-0-2) and [changelogs for 1.1.3](https://scikit-learn.org/stable/whats_new/v1.1.html#version-1-1-0)

---
<details>
<summary>Supposedly relevant Changelog entries</summary>
<br>

- [x] API Change The option for using the squared error via loss and criterion parameters was made more consistent. The preferred way is by setting the value to "squared_error". Old option names are still valid, produce the same models, but are deprecated and will be removed in version 1.2. [#19310](https://github.com/scikit-learn/scikit-learn/pull/19310) by [Christian Lorentzen](https://github.com/lorentzenchr).

    For [ensemble.ExtraTreesRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html#sklearn.ensemble.ExtraTreesRegressor), criterion="mse" is deprecated, use "squared_error" instead which is now the default.

    For [ensemble.GradientBoostingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingRegressor.html#sklearn.ensemble.GradientBoostingRegressor), loss="ls" is deprecated, use "squared_error" instead which is now the default.

    For [ensemble.RandomForestRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html#sklearn.ensemble.RandomForestRegressor), criterion="mse" is deprecated, use "squared_error" instead which is now the default.

    For [ensemble.HistGradientBoostingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html#sklearn.ensemble.HistGradientBoostingRegressor), loss="least_squares" is deprecated, use "squared_error" instead which is now the default.

    For [linear_model.RANSACRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RANSACRegressor.html#sklearn.linear_model.RANSACRegressor), loss="squared_loss" is deprecated, use "squared_error" instead.

    For [linear_model.SGDRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDRegressor.html#sklearn.linear_model.SGDRegressor), loss="squared_loss" is deprecated, use "squared_error" instead which is now the default.

    For [tree.DecisionTreeRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html#sklearn.tree.DecisionTreeRegressor), criterion="mse" is deprecated, use "squared_error" instead which is now the default.

    For [tree.ExtraTreeRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.tree.ExtraTreeRegressor.html#sklearn.tree.ExtraTreeRegressor), criterion="mse" is deprecated, use "squared_error" instead which is now the default.

- [x] API Change The option for using the absolute error via loss and criterion parameters was made more consistent. The preferred way is by setting the value to "absolute_error". Old option names are still valid, produce the same models, but are deprecated and will be removed in version 1.2. [#19733](https://github.com/scikit-learn/scikit-learn/pull/19733) by [Christian Lorentzen](https://github.com/lorentzenchr).

    For [ensemble.ExtraTreesRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html#sklearn.ensemble.ExtraTreesRegressor), criterion="mae" is deprecated, use "absolute_error" instead.

    For [ensemble.GradientBoostingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingRegressor.html#sklearn.ensemble.GradientBoostingRegressor), loss="lad" is deprecated, use "absolute_error" instead.

    For [ensemble.RandomForestRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html#sklearn.ensemble.RandomForestRegressor), criterion="mae" is deprecated, use "absolute_error" instead.

    For [ensemble.HistGradientBoostingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html#sklearn.ensemble.HistGradientBoostingRegressor), loss="least_absolute_deviation" is deprecated, use "absolute_error" instead.

    For [linear_model.RANSACRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RANSACRegressor.html#sklearn.linear_model.RANSACRegressor), loss="absolute_loss" is deprecated, use "absolute_error" instead which is now the default.

    For [tree.DecisionTreeRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html#sklearn.tree.DecisionTreeRegressor), criterion="mae" is deprecated, use "absolute_error" instead.

    For [tree.ExtraTreeRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.tree.ExtraTreeRegressor.html#sklearn.tree.ExtraTreeRegressor), criterion="mae" is deprecated, use "absolute_error" instead.

- [x] API Change np.matrix usage is deprecated in 1.0 and will raise a TypeError in 1.2. [#20165](https://github.com/scikit-learn/scikit-learn/pull/20165) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] API Change [get_feature_names_out](https://scikit-learn.org/stable/glossary.html#term-get_feature_names_out) has been added to the transformer API to get the names of the output features. [get_feature_names](https://scikit-learn.org/stable/glossary.html#term-get_feature_names) has in turn been deprecated. [#18444](https://github.com/scikit-learn/scikit-learn/pull/18444) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] API Change All estimators store feature_names_in_ when fitted on pandas Dataframes. These feature names are compared to names seen in non-fit methods, e.g. transform and will raise a FutureWarning if they are not consistent. These FutureWarning s will become ValueError s in 1.2. [#18010](https://github.com/scikit-learn/scikit-learn/pull/18010) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] API Change Deprecates the following keys in cv_results_: 'mean_score', 'std_score', and 'split(k)_score' in favor of 'mean_test_score' 'std_test_score', and 'split(k)_test_score'. [#20583](https://github.com/scikit-learn/scikit-learn/pull/20583) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] API Change Deprecates [datasets.load_boston](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_boston.html#sklearn.datasets.load_boston) in 1.0 and it will be removed in 1.2. Alternative code snippets to load similar datasets are provided. Please report to the docstring of the function for details. [#20729](https://github.com/scikit-learn/scikit-learn/pull/20729) by [Guillaume Lemaitre](https://github.com/glemaitre).

- [x] API Change Rename variable names in KernelPCA to improve readability. lambdas_ and alphas_ are renamed to eigenvalues_ and eigenvectors_, respectively. lambdas_ and alphas_ are deprecated and will be removed in 1.2. [#19908](https://github.com/scikit-learn/scikit-learn/pull/19908) by [Kei Ishikawa](https://github.com/kstoneriv3). 


- [x] API Change Attribute n_features_in_ in [dummy.DummyRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyRegressor.html#sklearn.dummy.DummyRegressor) and [dummy.DummyRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyRegressor.html#sklearn.dummy.DummyRegressor) is deprecated and will be removed in 1.2. [#20960](https://github.com/scikit-learn/scikit-learn/pull/20960) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] Fix Fixed the range of the argument max_samples to be (0.0, 1.0] in [ensemble.RandomForestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html#sklearn.ensemble.RandomForestClassifier), [ensemble.RandomForestRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html#sklearn.ensemble.RandomForestRegressor), where max_samples=1.0 is interpreted as using all n_samples for bootstrapping. [#20159](https://github.com/scikit-learn/scikit-learn/pull/20159) by [@murata-yu](https://github.com/murata-yu).

- [x] API Change Removes tol=None option in [ensemble.HistGradientBoostingClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingClassifier.html#sklearn.ensemble.HistGradientBoostingClassifier) and [ensemble.HistGradientBoostingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html#sklearn.ensemble.HistGradientBoostingRegressor). Please use tol=0 for the same behavior. [#19296](https://github.com/scikit-learn/scikit-learn/pull/19296) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] Fix Raise a warning in [feature_extraction.text.CountVectorizer](https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html#sklearn.feature_extraction.text.CountVectorizer) with lowercase=True when there are vocabulary entries with uppercase characters to avoid silent misses in the resulting feature vectors. [#19401](https://github.com/scikit-learn/scikit-learn/pull/19401) by [Zito Relova](https://github.com/zitorelova)

- [x] API Change Raises an error in [feature_selection.VarianceThreshold](https://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.VarianceThreshold.html#sklearn.feature_selection.VarianceThreshold) when the variance threshold is negative. [#20207](https://github.com/scikit-learn/scikit-learn/pull/20207) by [Tomohiro Endo](https://github.com/europeanplaice)

- [x] API Change Deprecates grid_scores_ in favor of split scores in cv_results_ in [feature_selection.RFECV](https://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.RFECV.html#sklearn.feature_selection.RFECV). grid_scores_ will be removed in version 1.2. [#20161](https://github.com/scikit-learn/scikit-learn/pull/20161) by [Shuhei Kayawari](https://github.com/wowry) and [@arka204](https://github.com/arka204).

- [x] Enhancement Add max_samples parameter in [inspection.permutation_importance](https://scikit-learn.org/stable/modules/generated/sklearn.inspection.permutation_importance.html#sklearn.inspection.permutation_importance). It enables to draw a subset of the samples to compute the permutation importance. This is useful to keep the method tractable when evaluating feature importance on large datasets. [#20431](https://github.com/scikit-learn/scikit-learn/pull/20431) by [Oliver Pfaffel](https://github.com/o1iv3r).

- [x] Feature Added sample_weight parameter to [linear_model.LassoCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoCV.html#sklearn.linear_model.LassoCV) and [linear_model.ElasticNetCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNetCV.html#sklearn.linear_model.ElasticNetCV). [#16449](https://github.com/scikit-learn/scikit-learn/pull/16449) by [Christian Lorentzen](https://github.com/lorentzenchr).

- [x] Feature Added new solver lbfgs (available with solver="lbfgs") and positive argument to [linear_model.Ridge](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html#sklearn.linear_model.Ridge). When positive is set to True, forces the coefficients to be positive (only supported by lbfgs). [#20231](https://github.com/scikit-learn/scikit-learn/pull/20231) by [Toshihiro Nakae](https://github.com/tnakae).

- [x] Enhancement fit method preserves dtype for numpy.float32 in [linear_model.Lars](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lars.html#sklearn.linear_model.Lars), [linear_model.LassoLars](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoLars.html#sklearn.linear_model.LassoLars), [linear_model.LassoLars](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoLars.html#sklearn.linear_model.LassoLars), [linear_model.LarsCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LarsCV.html#sklearn.linear_model.LarsCV) and [linear_model.LassoLarsCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoLarsCV.html#sklearn.linear_model.LassoLarsCV). [#20155](https://github.com/scikit-learn/scikit-learn/pull/20155) by [Takeshi Oura](https://github.com/takoika).

- [x] API Change : The parameter normalize of [linear_model.LinearRegression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html#sklearn.linear_model.LinearRegression) is deprecated and will be removed in 1.2. Motivation for this deprecation: normalize parameter did not take any effect if fit_intercept was set to False and therefore was deemed confusing. The behavior of the deprecated LinearModel(normalize=True) can be reproduced with a [Pipeline](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html#sklearn.pipeline.Pipeline) with LinearModel (where LinearModel is [LinearRegression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html#sklearn.linear_model.LinearRegression), [Ridge](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html#sklearn.linear_model.Ridge), [RidgeClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifier.html#sklearn.linear_model.RidgeClassifier), [RidgeCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeCV.html#sklearn.linear_model.RidgeCV) or [RidgeClassifierCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifierCV.html#sklearn.linear_model.RidgeClassifierCV)) as follows: make_pipeline(StandardScaler(with_mean=False), LinearModel()). The normalize parameter in [LinearRegression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html#sklearn.linear_model.LinearRegression) was deprecated in [#17743](https://github.com/scikit-learn/scikit-learn/pull/17743) by [Maria Telenczuk](https://github.com/maikia) and [Alexandre Gramfort](https://github.com/agramfort). Same for [Ridge](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html#sklearn.linear_model.Ridge), [RidgeClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifier.html#sklearn.linear_model.RidgeClassifier), [RidgeCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeCV.html#sklearn.linear_model.RidgeCV), and [RidgeClassifierCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifierCV.html#sklearn.linear_model.RidgeClassifierCV), in: [#17772](https://github.com/scikit-learn/scikit-learn/pull/17772) by [Maria Telenczuk](https://github.com/maikia) and [Alexandre Gramfort](https://github.com/agramfort). Same for [BayesianRidge](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.BayesianRidge.html#sklearn.linear_model.BayesianRidge), [ARDRegression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ARDRegression.html#sklearn.linear_model.ARDRegression) in: [#17746](https://github.com/scikit-learn/scikit-learn/pull/17746) by [Maria Telenczuk](https://github.com/maikia). Same for [Lasso](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lasso.html#sklearn.linear_model.Lasso), [LassoCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoCV.html#sklearn.linear_model.LassoCV), [ElasticNet](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html#sklearn.linear_model.ElasticNet), [ElasticNetCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNetCV.html#sklearn.linear_model.ElasticNetCV), [MultiTaskLasso](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.MultiTaskLasso.html#sklearn.linear_model.MultiTaskLasso), [MultiTaskLassoCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.MultiTaskLassoCV.html#sklearn.linear_model.MultiTaskLassoCV), [MultiTaskElasticNet](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.MultiTaskElasticNet.html#sklearn.linear_model.MultiTaskElasticNet), [MultiTaskElasticNetCV](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.MultiTaskElasticNetCV.html#sklearn.linear_model.MultiTaskElasticNetCV), in: [#17785](https://github.com/scikit-learn/scikit-learn/pull/17785) by [Maria Telenczuk](https://github.com/maikia) and [Alexandre Gramfort](https://github.com/agramfort).

- [x] API Change Keyword validation has moved from __init__ and set_params to fit for the following estimators conforming to scikit-learn’s conventions: [SGDClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html#sklearn.linear_model.SGDClassifier), [SGDRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDRegressor.html#sklearn.linear_model.SGDRegressor), [SGDOneClassSVM](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDOneClassSVM.html#sklearn.linear_model.SGDOneClassSVM), [PassiveAggressiveClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.PassiveAggressiveClassifier.html#sklearn.linear_model.PassiveAggressiveClassifier), and [PassiveAggressiveRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.PassiveAggressiveRegressor.html#sklearn.linear_model.PassiveAggressiveRegressor). [#20683](https://github.com/scikit-learn/scikit-learn/pull/20683) by [Guillaume Lemaitre](https://github.com/glemaitre).

- [x] Enhancement The model_selection.BaseShuffleSplit base class is now public. [#20056](https://github.com/scikit-learn/scikit-learn/pull/20056) by [@pabloduque0](https://github.com/pabloduque0).

- [x] API Change The attribute sigma_ is now deprecated in [naive_bayes.GaussianNB](https://scikit-learn.org/stable/modules/generated/sklearn.naive_bayes.GaussianNB.html#sklearn.naive_bayes.GaussianNB) and will be removed in 1.2. Use var_ instead. [#18842](https://github.com/scikit-learn/scikit-learn/pull/18842) by [Hong Shao Yang](https://github.com/hongshaoyang).

- [x] Fix The [preprocessing.StandardScaler.inverse_transform](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.StandardScaler.html#sklearn.preprocessing.StandardScaler.inverse_transform) method now raises error when the input data is 1D. [#19752](https://github.com/scikit-learn/scikit-learn/pull/19752) by [Zhehao Liu](https://github.com/Max1993Liu).

- [x] Fix The fit method of [preprocessing.OrdinalEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html#sklearn.preprocessing.OrdinalEncoder) will not raise error when handle_unknown='ignore' and unknown categories are given to fit. [#19906](https://github.com/scikit-learn/scikit-learn/pull/19906) by [Zhehao Liu](https://github.com/MaxwellLZH).

- [x] API Change The n_input_features_ attribute of [preprocessing.PolynomialFeatures](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.PolynomialFeatures.html#sklearn.preprocessing.PolynomialFeatures) is deprecated in favor of n_features_in_ and will be removed in 1.2. [#20240](https://github.com/scikit-learn/scikit-learn/pull/20240) by [Jérémie du Boisberranger](https://github.com/jeremiedbb).

- [x] API Change The n_features_ attribute of [tree.DecisionTreeClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeClassifier.html#sklearn.tree.DecisionTreeClassifier), [tree.DecisionTreeRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html#sklearn.tree.DecisionTreeRegressor), [tree.ExtraTreeClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.tree.ExtraTreeClassifier.html#sklearn.tree.ExtraTreeClassifier) and [tree.ExtraTreeRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.tree.ExtraTreeRegressor.html#sklearn.tree.ExtraTreeRegressor) is deprecated in favor of n_features_in_ and will be removed in 1.2. [#20272](https://github.com/scikit-learn/scikit-learn/pull/20272) by [Jérémie du Boisberranger](https://github.com/jeremiedbb).

- [x] Enhancement [utils.validation.check_is_fitted](https://scikit-learn.org/stable/modules/generated/sklearn.utils.validation.check_is_fitted.html#sklearn.utils.validation.check_is_fitted) now uses __sklearn_is_fitted__ if available, instead of checking for attributes ending with an underscore. This also makes [pipeline.Pipeline](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html#sklearn.pipeline.Pipeline) and [preprocessing.FunctionTransformer](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html#sklearn.preprocessing.FunctionTransformer) pass check_is_fitted(estimator). [#20657](https://github.com/scikit-learn/scikit-learn/pull/20657) by [Adrin Jalali](https://github.com/adrinjalali).

- [x] Fix Support for np.matrix is deprecated in [check_array](https://scikit-learn.org/stable/modules/generated/sklearn.utils.check_array.html#sklearn.utils.check_array) in 1.0 and will raise a TypeError in 1.2. [#20165](https://github.com/scikit-learn/scikit-learn/pull/20165) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] Fix [impute.SimpleImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer) uses the dtype seen in fit for transform when the dtype is object. [#22063](https://github.com/scikit-learn/scikit-learn/pull/22063) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] Enhancement Added an extension in doc/conf.py to automatically generate the list of estimators that handle NaN values. [#23198](https://github.com/scikit-learn/scikit-learn/pull/23198) by [Lise Kleiber](https://github.com/lisekleiber), [Zhehao Liu](https://github.com/MaxwellLZH) and [Chiara Marmo](https://github.com/cmarmo).

- [x] Efficiency [cluster.KMeans](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html#sklearn.cluster.KMeans) now defaults to algorithm="lloyd" instead of algorithm="auto", which was equivalent to algorithm="elkan". Lloyd’s algorithm and Elkan’s algorithm converge to the same solution, up to numerical rounding errors, but in general Lloyd’s algorithm uses much less memory, and it is often faster.

- [x] API Change The option for using the log loss, aka binomial or multinomial deviance, via the loss parameters was made more consistent. The preferred way is by setting the value to "log_loss". Old option names are still valid and produce the same models, but are deprecated and will be removed in version 1.3.

    For [ensemble.GradientBoostingClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingClassifier.html#sklearn.ensemble.GradientBoostingClassifier), the loss parameter name “deviance” is deprecated in favor of the new name “log_loss”, which is now the default. [#23036](https://github.com/scikit-learn/scikit-learn/pull/23036) by [Christian Lorentzen](https://github.com/lorentzenchr).

    For [ensemble.HistGradientBoostingClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingClassifier.html#sklearn.ensemble.HistGradientBoostingClassifier), the loss parameter names “auto”, “binary_crossentropy” and “categorical_crossentropy” are deprecated in favor of the new name “log_loss”, which is now the default. [#23040](https://github.com/scikit-learn/scikit-learn/pull/23040) by [Christian Lorentzen](https://github.com/lorentzenchr).

    For [linear_model.SGDClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html#sklearn.linear_model.SGDClassifier), the loss parameter name “log” is deprecated in favor of the new name “log_loss”. [#23046](https://github.com/scikit-learn/scikit-learn/pull/23046) by [Christian Lorentzen](https://github.com/lorentzenchr).

- [x] Major Feature Added additional option loss="quantile" to [ensemble.HistGradientBoostingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html#sklearn.ensemble.HistGradientBoostingRegressor) for modelling quantiles. The quantile level can be specified with the new parameter quantile. [#21800](https://github.com/scikit-learn/scikit-learn/pull/21800) and [#20567](https://github.com/scikit-learn/scikit-learn/pull/20567) by [Christian Lorentzen](https://github.com/lorentzenchr).

- [x] Enhancement [ensemble.RandomForestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html#sklearn.ensemble.RandomForestClassifier) and [ensemble.ExtraTreesClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html#sklearn.ensemble.ExtraTreesClassifier) have the new criterion="log_loss", which is equivalent to criterion="entropy". [#23047](https://github.com/scikit-learn/scikit-learn/pull/23047) by [Christian Lorentzen](https://github.com/lorentzenchr).

- [x] Enhancement Adds [get_feature_names_out](https://scikit-learn.org/stable/glossary.html#term-get_feature_names_out) to [ensemble.VotingClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.VotingClassifier.html#sklearn.ensemble.VotingClassifier), [ensemble.VotingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.VotingRegressor.html#sklearn.ensemble.VotingRegressor), [ensemble.StackingClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.StackingClassifier.html#sklearn.ensemble.StackingClassifier), and [ensemble.StackingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.StackingRegressor.html#sklearn.ensemble.StackingRegressor). [#22695](https://github.com/scikit-learn/scikit-learn/pull/22695) and [#22697](https://github.com/scikit-learn/scikit-learn/pull/22697) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] API Change Changed the default of max_features to 1.0 for [ensemble.RandomForestRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html#sklearn.ensemble.RandomForestRegressor) and to "sqrt" for [ensemble.RandomForestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html#sklearn.ensemble.RandomForestClassifier). Note that these give the same fit results as before, but are much easier to understand. The old default value "auto" has been deprecated and will be removed in version 1.3. The same changes are also applied for [ensemble.ExtraTreesRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html#sklearn.ensemble.ExtraTreesRegressor) and [ensemble.ExtraTreesClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html#sklearn.ensemble.ExtraTreesClassifier). [#20803](https://github.com/scikit-learn/scikit-learn/pull/20803) by [Brian Sun](https://github.com/bsun94).

- [x] Fix predict and sample_y methods of [gaussian_process.GaussianProcessRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.gaussian_process.GaussianProcessRegressor.html#sklearn.gaussian_process.GaussianProcessRegressor) now return arrays of the correct shape in single-target and multi-target cases, and for both normalize_y=False and normalize_y=True. [#22199](https://github.com/scikit-learn/scikit-learn/pull/22199) by [Guillaume Lemaitre](https://github.com/glemaitre), [Aidar Shakerimoff](https://github.com/AidarShakerimoff) and [Tenavi Nakamura-Zimmerer](https://github.com/Tenavi).

- [x] Enhancement [impute.SimpleImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer) now warns with feature names when features which are skipped due to the lack of any observed values in the training set. [#21617](https://github.com/scikit-learn/scikit-learn/pull/21617) by [Christian Ritter](https://github.com/chritter).

- [x] Enhancement Added support for pd.NA in [impute.SimpleImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer). [#21114](https://github.com/scikit-learn/scikit-learn/pull/21114) by [Ying Xiong](https://github.com/yxiong).

- [x] Enhancement Adds [get_feature_names_out](https://scikit-learn.org/stable/glossary.html#term-get_feature_names_out) to [impute.SimpleImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer), [impute.KNNImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.KNNImputer.html#sklearn.impute.KNNImputer), [impute.IterativeImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.IterativeImputer.html#sklearn.impute.IterativeImputer), and [impute.MissingIndicator](https://scikit-learn.org/stable/modules/generated/sklearn.impute.MissingIndicator.html#sklearn.impute.MissingIndicator). [#21078](https://github.com/scikit-learn/scikit-learn/pull/21078) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] API Change The verbose parameter was deprecated for [impute.SimpleImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer). A warning will always be raised upon the removal of empty columns. [#21448](https://github.com/scikit-learn/scikit-learn/pull/21448) by [Oleh Kozynets](https://github.com/OlehKSS) and [Christian Ritter](https://github.com/chritter).

- [x] Feature [preprocessing.OneHotEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html#sklearn.preprocessing.OneHotEncoder) now supports grouping infrequent categories into a single feature. Grouping infrequent categories is enabled by specifying how to select infrequent categories with min_frequency or max_categories. [#16018](https://github.com/scikit-learn/scikit-learn/pull/16018) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] Enhancement Adds encoded_missing_value to [preprocessing.OrdinalEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html#sklearn.preprocessing.OrdinalEncoder) to configure the encoded value for missing data. [#21988](https://github.com/scikit-learn/scikit-learn/pull/21988) by [Thomas Fan](https://github.com/thomasjpfan).

- [x] Enhancement [svm.OneClassSVM](https://scikit-learn.org/stable/modules/generated/sklearn.svm.OneClassSVM.html#sklearn.svm.OneClassSVM), [svm.NuSVC](https://scikit-learn.org/stable/modules/generated/sklearn.svm.NuSVC.html#sklearn.svm.NuSVC), [svm.NuSVR](https://scikit-learn.org/stable/modules/generated/sklearn.svm.NuSVR.html#sklearn.svm.NuSVR), [svm.SVC](https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html#sklearn.svm.SVC) and [svm.SVR](https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html#sklearn.svm.SVR) now expose n_iter_, the number of iterations of the libsvm optimization routine. [#21408](https://github.com/scikit-learn/scikit-learn/pull/21408) by [Juan Martín Loyola](https://github.com/jmloyola).

- [x] Enhancement [tree.DecisionTreeClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeClassifier.html#sklearn.tree.DecisionTreeClassifier) and [tree.ExtraTreeClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.tree.ExtraTreeClassifier.html#sklearn.tree.ExtraTreeClassifier) have the new criterion="log_loss", which is equivalent to criterion="entropy". [#23047](https://github.com/scikit-learn/scikit-learn/pull/23047) by [Christian Lorentzen](https://github.com/lorentzenchr).

- [x] API Change Changed the default value of max_features to 1.0 for [tree.ExtraTreeRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.tree.ExtraTreeRegressor.html#sklearn.tree.ExtraTreeRegressor) and to "sqrt" for [tree.ExtraTreeClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.tree.ExtraTreeClassifier.html#sklearn.tree.ExtraTreeClassifier), which will not change the fit result. The original default value "auto" has been deprecated and will be removed in version 1.3. Setting max_features to "auto" is also deprecated for [tree.DecisionTreeClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeClassifier.html#sklearn.tree.DecisionTreeClassifier) and [tree.DecisionTreeRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html#sklearn.tree.DecisionTreeRegressor). [#22476](https://github.com/scikit-learn/scikit-learn/pull/22476) by [Zhehao Liu](https://github.com/MaxwellLZH).
</details>

---
- [x] API Change Deprecates [datasets.load_boston](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_boston.html#sklearn.datasets.load_boston) in 1.0 and it will be removed in 1.2. Alternative code snippets to load similar datasets are provided. Please report to the docstring of the function for details. [#20729](https://github.com/scikit-learn/scikit-learn/pull/20729) by [Guillaume Lemaitre](https://github.com/glemaitre).

Write separate issue to update this. It will break a lot of our test fixtures.

- [x] [ensemble.HistGradientBoostingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html#sklearn.ensemble.HistGradientBoostingRegressor) for modelling quantiles. The quantile level can be specified with the new parameter quantile. https://github.com/scikit-learn/scikit-learn/pull/21800 and https://github.com/scikit-learn/scikit-learn/pull/20567 by [Christian Lorentzen](https://github.com/lorentzenchr).

Write separate issue to investigate this

- [x] Feature [preprocessing.OneHotEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html#sklearn.preprocessing.OneHotEncoder) now supports grouping infrequent categories into a single feature. Grouping infrequent categories is enabled by specifying how to select infrequent categories with min_frequency or max_categories. https://github.com/scikit-learn/scikit-learn/pull/16018 by [Thomas Fan](https://github.com/thomasjpfan).

Write seperate issue to investigate this

- [x] Enhancement Adds encoded_missing_value to [preprocessing.OrdinalEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html#sklearn.preprocessing.OrdinalEncoder) to configure the encoded value for missing data. https://github.com/scikit-learn/scikit-learn/pull/21988 by [Thomas Fan](https://github.com/thomasjpfan).

Seperate issue

- [x] Enhancement [svm.OneClassSVM](https://scikit-learn.org/stable/modules/generated/sklearn.svm.OneClassSVM.html#sklearn.svm.OneClassSVM), [svm.NuSVC](https://scikit-learn.org/stable/modules/generated/sklearn.svm.NuSVC.html#sklearn.svm.NuSVC), [svm.NuSVR](https://scikit-learn.org/stable/modules/generated/sklearn.svm.NuSVR.html#sklearn.svm.NuSVR), [svm.SVC](https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html#sklearn.svm.SVC) and [svm.SVR](https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html#sklearn.svm.SVR) now expose n_iter_, the number of iterations of the libsvm optimization routine. https://github.com/scikit-learn/scikit-learn/pull/21408 by [Juan Martín Loyola](https://github.com/jmloyola).

Could be made to be iterative fit methods? Seperate issue

---

### Next steps
- [ ] Update test score fixtures
- [ ] Update meta-learning most likely
- [x] Update docs, specifically that we deprecate Python 3.7 and using newer versions of Autosklearn will no longer work in Google Colab while they are fixed to Python 3.7
