### PR TITLE
build(deps): Update requirements for `SMAC`, `pynisher`, `ConfigSpace`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ liac-arff
 threadpoolctl
 tqdm
 
-ConfigSpace>=0.4.21,<0.5
-pynisher>=0.6.3,<0.7
+ConfigSpace>=0.6,<0.7
+pynisher>=1.0,<1.1
 pyrfr>=0.8.1,<0.9
-smac>=1.2,<1.3
+smac==2.0.0a2


### PR DESCRIPTION
Updates our core dependancies to the latest versions.

SMAC is almost through with a redesign and so we link to it's latest `smac==2.0.a2`. This may cause issues but we will live with this until they are fixed, to prevent having to re-do efforts.