### PR TITLE
fix: modify show_models() to display same ranks as leaderboard

### DIFF
--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -2184,21 +2184,20 @@ class AutoML(BaseEstimator):
 
         table = pd.DataFrame.from_dict(table_dict, orient="index")
         table.sort_values(by="cost", inplace=True)
+        table["rank"] = np.arange(1, len(table.index) + 1)
 
         # Check which resampling strategy is chosen and selecting the appropriate models
         is_cv = self._resampling_strategy == "cv"
         models = self.cv_models_ if is_cv else self.models_
 
-        rank = 1  # Initializing rank for the first model
         for (_, model_id, _), model in models.items():
             model_dict = {}  # Declaring model dictionary
 
             # Inserting model_id, rank, cost and ensemble weight
             model_dict["model_id"] = table.loc[model_id]["model_id"].astype(int)
-            model_dict["rank"] = rank
+            model_dict["rank"] = table.loc[model_id]["rank"].astype(int)
             model_dict["cost"] = table.loc[model_id]["cost"]
             model_dict["ensemble_weight"] = table.loc[model_id]["ensemble_weight"]
-            rank += 1  # Incrementing rank by 1 for the next model
 
             # The steps in the models pipeline are as follows:
             # 'data_preprocessor': DataPreprocessor,


### PR DESCRIPTION
Fixes #1594

I noticed that the show_models() function doesn't rank according to the cost, even though its documentation says so.

The issue was that there was a loop going over an array of models that was not sorted by the costs and the code assumed it to be sorted. Another array of models was sorted however, but not used to determine the rank. So I extended this sorted array with a rank column and used it to determine the rank later.

I only touched the show_models() function in automl.py