### PR TITLE
fix(regressor): correctly cap the labels in predict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 repos:
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort imports autosklearn

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         files: autosklearn/.*
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
         name: flake8 autosklearn

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 repos:
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort imports autosklearn
@@ -15,7 +15,7 @@ repos:
         files: test/.*
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
       - id: black
         name: black formatter autosklearn
@@ -31,7 +31,7 @@ repos:
 
   # This is disabled as most modules fail this
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         files: DISABLED # autosklearn/.*
@@ -39,14 +39,14 @@ repos:
         additional_dependencies: ["toml"] # Needed to parse pyproject.toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.990
+    rev: v1.2.0
     hooks:
       - id: mypy
         name: mypy auto-sklearn
         files: autosklearn/.*
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         name: flake8 autosklearn

--- a/autosklearn/pipeline/regression.py
+++ b/autosklearn/pipeline/regression.py
@@ -106,6 +106,24 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
         )
 
     def predict(self, X, batch_size=None):
+        """Predict the classes using the selected model.
+
+        Predicted values are capped to approximately the maximum and minimum labels
+        seen during training.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+
+        batch_size: int or None, defaults to None
+            batch_size controls whether the pipeline will be
+            called on small chunks of the data. Useful when calling the
+            predict method on the whole array X results in a MemoryError.
+
+        Returns
+        -------
+        array, shape=(n_samples,) if n_classes == 2 else (n_samples, n_classes)
+            Returns the predicted values"""
         y = super().predict(X, batch_size=batch_size)
         if self.y_max_ > 0:
             y[y > (2 * self.y_max_)] = 2 * self.y_max_

--- a/autosklearn/pipeline/regression.py
+++ b/autosklearn/pipeline/regression.py
@@ -125,6 +125,7 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
         array, shape=(n_samples,) if n_classes == 2 else (n_samples, n_classes)
             Returns the predicted values"""
         y = super().predict(X, batch_size=batch_size)
+
         if self.y_max_ > 0:
             y[y > (2 * self.y_max_)] = 2 * self.y_max_
         elif self.y_max_ < 0:
@@ -133,6 +134,7 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
             y[y < (2 * self.y_min_)] = 2 * self.y_min_
         elif self.y_min_ > 0:
             y[y < (0.5 * self.y_min_)] = 0.5 * self.y_min_
+
         return y
 
     def _get_hyperparameter_search_space(

--- a/autosklearn/pipeline/regression.py
+++ b/autosklearn/pipeline/regression.py
@@ -107,7 +107,10 @@ class SimpleRegressionPipeline(RegressorMixin, BasePipeline):
 
     def predict(self, X, batch_size=None):
         y = super().predict(X, batch_size=batch_size)
-        y[y > (2 * self.y_max_)] = 2 * self.y_max_
+        if self.y_max_ > 0:
+            y[y > (2 * self.y_max_)] = 2 * self.y_max_
+        elif self.y_max_ < 0:
+            y[y > (0.5 * self.y_max_)] = 0.5 * self.y_max_
         if self.y_min_ < 0:
             y[y < (2 * self.y_min_)] = 2 * self.y_min_
         elif self.y_min_ > 0:


### PR DESCRIPTION
Fixes #1657 

As @ftmtas212 pointed it out in the issue above, we had a bug in our predict method of our regression pipeline.
Namely, we capped the predicted labels incorrectly, as the code did not account for cases when the maximum of the labels seen during training were negative.

This PR fixes it, by considering the same logic used for capping predicted labels from the bottom. It also adds a documentation for the function.

In the future we should consider using [TransformedTargetRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.compose.TransformedTargetRegressor.html), instead of manually manipulating the predictions.