### PR TITLE
Use `isinstance` instead of `obj.__bases__` in ThirdPartyComponents

### DIFF
--- a/autosklearn/pipeline/components/base.py
+++ b/autosklearn/pipeline/components/base.py
@@ -43,7 +43,7 @@ class ThirdPartyComponents(object):
         self.components = OrderedDict()
 
     def add_component(self, obj):
-        if inspect.isclass(obj) and self.base_class in obj.__bases__:
+        if inspect.isclass(obj) and isinstance(obj, self.base_class):
             name = obj.__name__
             classifier = obj
         else:


### PR DESCRIPTION
This is a small change but will enable much easier extending of auto-sklearn algorithms, since without this change, all classes are expected to directly inherit from AutoSklearn base calsses, and do not allow additional layers of inheritance.

Closes #1604 